### PR TITLE
Wrap href i encodeURI

### DIFF
--- a/src/frontend/components/Felleskomponenter/TekstBlock.tsx
+++ b/src/frontend/components/Felleskomponenter/TekstBlock.tsx
@@ -42,7 +42,7 @@ const TekstBlock: React.FC<{ block: LocaleRecordBlock | undefined; barnetsNavn?:
                             <a
                                 target={props.value.blank ? '_blank' : '_self'}
                                 rel={'noopener noreferrer'}
-                                href={props.value.href}
+                                href={encodeURI(props.value.href)}
                             >
                                 {props.text}
                             </a>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/077068028bffba85055cca2d?card=Tea-9710

Wrapper href i `encodeURI()` slik at den blir safe. 

Eksempel 
![image](https://user-images.githubusercontent.com/17828446/192262876-3d5815e5-1efd-418a-87df-090bab7e048a.png)

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
