### PR TITLE
Fjern oppfølgning om institusjon på Om Barnet

### DIFF
--- a/src/frontend/components/SøknadsSteg/OmBarnaDine/utils.ts
+++ b/src/frontend/components/SøknadsSteg/OmBarnaDine/utils.ts
@@ -187,54 +187,6 @@ export const genererOppdaterteBarn = (
                 ...barn[barnDataKeySpørsmål.andreForelderErDød],
                 svar: andreForelderErDød,
             },
-            [barnDataKeySpørsmål.institusjonIUtland]: {
-                ...barn[barnDataKeySpørsmål.institusjonIUtland],
-                svar: genererSvarForOppfølgningspørsmålBarn(
-                    oppholderSegIInstitusjon,
-                    barn[barnDataKeySpørsmål.institusjonIUtland],
-                    ESvar.NEI
-                ),
-            },
-            [barnDataKeySpørsmål.institusjonsnavn]: {
-                ...barn[barnDataKeySpørsmål.institusjonsnavn],
-                svar: genererSvarForOppfølgningspørsmålBarn(
-                    oppholderSegIInstitusjon,
-                    barn[barnDataKeySpørsmål.institusjonsnavn],
-                    ''
-                ),
-            },
-            [barnDataKeySpørsmål.institusjonsadresse]: {
-                ...barn[barnDataKeySpørsmål.institusjonsadresse],
-                svar: genererSvarForOppfølgningspørsmålBarn(
-                    oppholderSegIInstitusjon,
-                    barn[barnDataKeySpørsmål.institusjonsadresse],
-                    ''
-                ),
-            },
-            [barnDataKeySpørsmål.institusjonspostnummer]: {
-                ...barn[barnDataKeySpørsmål.institusjonspostnummer],
-                svar: genererSvarForOppfølgningspørsmålBarn(
-                    oppholderSegIInstitusjon,
-                    barn[barnDataKeySpørsmål.institusjonspostnummer],
-                    ''
-                ),
-            },
-            [barnDataKeySpørsmål.institusjonOppholdStartdato]: {
-                ...barn[barnDataKeySpørsmål.institusjonOppholdStartdato],
-                svar: genererSvarForOppfølgningspørsmålBarn(
-                    oppholderSegIInstitusjon,
-                    barn[barnDataKeySpørsmål.institusjonOppholdStartdato],
-                    ''
-                ),
-            },
-            [barnDataKeySpørsmål.institusjonOppholdSluttdato]: {
-                ...barn[barnDataKeySpørsmål.institusjonOppholdSluttdato],
-                svar: genererSvarForOppfølgningspørsmålBarn(
-                    oppholderSegIInstitusjon,
-                    barn[barnDataKeySpørsmål.institusjonOppholdSluttdato],
-                    ''
-                ),
-            },
             [barnDataKeySpørsmål.utbetaltForeldrepengerEllerEngangsstønad]: {
                 ...barn[barnDataKeySpørsmål.utbetaltForeldrepengerEllerEngangsstønad],
                 svar: genererSvarForOppfølgningspørsmålBarn(

--- a/src/frontend/components/SøknadsSteg/OmBarnet/Oppfølgningsspørsmål.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/Oppfølgningsspørsmål.tsx
@@ -11,17 +11,13 @@ import {
 } from '../../../typer/perioder';
 import { PersonType } from '../../../typer/personType';
 import { IOmBarnetUtvidetFeltTyper } from '../../../typer/skjema';
-import { dagensDato, erSammeDatoSomDagensDato, morgendagensDato } from '../../../utils/dato';
 import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import { BarnehageplassPeriode } from '../../Felleskomponenter/Barnehagemodal/BarnehageplassPeriode';
-import Datovelger from '../../Felleskomponenter/Datovelger/Datovelger';
 import { LandDropdown } from '../../Felleskomponenter/Dropdowns/LandDropdown';
 import Informasjonsbolk from '../../Felleskomponenter/Informasjonsbolk/Informasjonsbolk';
 import JaNeiSpm from '../../Felleskomponenter/JaNeiSpm/JaNeiSpm';
 import KomponentGruppe from '../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
 import { KontantstøttePeriode } from '../../Felleskomponenter/KontantstøttePeriode/KontantstøttePeriode';
-import { SkjemaCheckbox } from '../../Felleskomponenter/SkjemaCheckbox/SkjemaCheckbox';
-import { SkjemaFeltInput } from '../../Felleskomponenter/SkjemaFeltInput/SkjemaFeltInput';
 import SkjemaFieldset from '../../Felleskomponenter/SkjemaFieldset';
 import SpråkTekst from '../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import { Utenlandsperiode } from '../../Felleskomponenter/UtenlandsoppholdModal/Utenlandsperiode';
@@ -64,85 +60,6 @@ const Oppfølgningsspørsmål: React.FC<{
                 </KomponentGruppe>
             )}
 
-            {barn[barnDataKeySpørsmål.oppholderSegIInstitusjon].svar === ESvar.JA && (
-                <SkjemaFieldset tittelId={'ombarnet.institusjon'} språkValues={{ navn: barn.navn }}>
-                    <SkjemaCheckbox
-                        labelSpråkTekstId={
-                            omBarnetSpørsmålSpråkId[OmBarnetSpørsmålsId.institusjonIUtland]
-                        }
-                        felt={skjema.felter.institusjonIUtlandCheckbox}
-                    />
-                    <SkjemaFeltInput
-                        felt={skjema.felter.institusjonsnavn}
-                        visFeilmeldinger={skjema.visFeilmeldinger}
-                        labelSpråkTekstId={
-                            omBarnetSpørsmålSpråkId[OmBarnetSpørsmålsId.institusjonsnavn]
-                        }
-                    />
-                    <SkjemaFeltInput
-                        felt={skjema.felter.institusjonsadresse}
-                        visFeilmeldinger={skjema.visFeilmeldinger}
-                        labelSpråkTekstId={
-                            omBarnetSpørsmålSpråkId[OmBarnetSpørsmålsId.institusjonsadresse]
-                        }
-                    />
-                    <SkjemaFeltInput
-                        felt={skjema.felter.institusjonspostnummer}
-                        visFeilmeldinger={skjema.visFeilmeldinger}
-                        labelSpråkTekstId={
-                            omBarnetSpørsmålSpråkId[OmBarnetSpørsmålsId.institusjonspostnummer]
-                        }
-                        bredde={'S'}
-                    />
-                    <Datovelger
-                        felt={skjema.felter.institusjonOppholdStartdato}
-                        skjema={skjema}
-                        avgrensMaxDato={dagensDato()}
-                        label={
-                            <SpråkTekst
-                                id={
-                                    omBarnetSpørsmålSpråkId[
-                                        OmBarnetSpørsmålsId.institusjonOppholdStartdato
-                                    ]
-                                }
-                            />
-                        }
-                    />
-                    <>
-                        <Datovelger
-                            felt={skjema.felter.institusjonOppholdSluttdato}
-                            avgrensMinDato={
-                                erSammeDatoSomDagensDato(
-                                    skjema.felter.institusjonOppholdStartdato.verdi
-                                )
-                                    ? morgendagensDato()
-                                    : dagensDato()
-                            }
-                            skjema={skjema}
-                            label={
-                                <SpråkTekst
-                                    id={
-                                        omBarnetSpørsmålSpråkId[
-                                            OmBarnetSpørsmålsId.institusjonOppholdSluttdato
-                                        ]
-                                    }
-                                />
-                            }
-                            disabled={
-                                skjema.felter.institusjonOppholdSluttVetIkke.verdi === ESvar.JA
-                            }
-                        />
-                        <SkjemaCheckbox
-                            labelSpråkTekstId={
-                                omBarnetSpørsmålSpråkId[
-                                    OmBarnetSpørsmålsId.institusjonOppholdVetIkke
-                                ]
-                            }
-                            felt={skjema.felter.institusjonOppholdSluttVetIkke}
-                        />
-                    </>
-                </SkjemaFieldset>
-            )}
             {skjema.felter.utbetaltForeldrepengerEllerEngangsstønad.erSynlig && (
                 <KomponentGruppe>
                     <Informasjonsbolk

--- a/src/frontend/components/SøknadsSteg/OmBarnet/spørsmål.ts
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/spørsmål.ts
@@ -1,11 +1,4 @@
 export enum OmBarnetSpørsmålsId {
-    institusjonIUtland = 'institusjonIUtland',
-    institusjonsnavn = 'institusjonsnavn',
-    institusjonsadresse = 'institusjonsadresse',
-    institusjonspostnummer = 'institusjonspostnummer',
-    institusjonOppholdStartdato = 'institusjon-opphold-startdato',
-    institusjonOppholdSluttdato = 'institusjon-opphold-sluttdato',
-    institusjonOppholdVetIkke = 'institusjon-opphold-ukjent-sluttdato',
     utbetaltForeldrepengerEllerEngangsstønad = 'utbetalt-foreldrepenger-eller-engangsstønad',
     planleggerÅBoINorge12Mnd = 'barn-planlegger-å-bo-sammenhengende-i-norge-12mnd',
     pågåendeSøknadFraAnnetEøsLand = 'pågående-søknad-fra-annet-eøsland',
@@ -30,13 +23,6 @@ export enum OmBarnetSpørsmålsId {
 }
 
 export const omBarnetSpørsmålSpråkId: Record<OmBarnetSpørsmålsId, string> = {
-    [OmBarnetSpørsmålsId.institusjonIUtland]: 'ombarnet.institusjon.i-utlandet',
-    [OmBarnetSpørsmålsId.institusjonsnavn]: 'ombarnet.institusjon.navn.spm',
-    [OmBarnetSpørsmålsId.institusjonsadresse]: 'ombarnet.institusjon.adresse.spm',
-    [OmBarnetSpørsmålsId.institusjonspostnummer]: 'ombarnet.institusjon.postnummer.spm',
-    [OmBarnetSpørsmålsId.institusjonOppholdStartdato]: 'ombarnet.institusjon.startdato.spm',
-    [OmBarnetSpørsmålsId.institusjonOppholdSluttdato]: 'ombarnet.institusjon.sluttdato.spm',
-    [OmBarnetSpørsmålsId.institusjonOppholdVetIkke]: 'ombarnet.institusjon.ukjent-sluttdato.spm',
     [OmBarnetSpørsmålsId.utbetaltForeldrepengerEllerEngangsstønad]:
         'todo.ombarnet.utbetalt.foreldrepenger.engangsstønad',
     [OmBarnetSpørsmålsId.planleggerÅBoINorge12Mnd]: 'ombarnet.oppholdtsammenhengende.spm',

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/OmBarnetOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/OmBarnetOppsummering.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { useIntl } from 'react-intl';
-
 import { ESvar } from '@navikt/familie-form-elements';
 import { useSprakContext } from '@navikt/familie-sprakvelger';
 
@@ -12,7 +10,6 @@ import {
     IBarnMedISøknad,
 } from '../../../../../typer/barn';
 import { PersonType } from '../../../../../typer/personType';
-import { formaterDato, formaterDatoMedUkjent } from '../../../../../utils/dato';
 import { landkodeTilSpråk } from '../../../../../utils/språk';
 import { BarnehageplassPeriodeOppsummering } from '../../../../Felleskomponenter/Barnehagemodal/barnehageplassPeriodeOppsummering';
 import { KontantstøttePeriodeOppsummering } from '../../../../Felleskomponenter/KontantstøttePeriode/KontantstøttePeriodeOppsummering';
@@ -33,8 +30,6 @@ interface Props {
 }
 
 const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, nummer, barn, index }) => {
-    const intl = useIntl();
-    const { formatMessage } = intl;
     const { hentStegObjektForBarn } = useSteg();
     const [valgtLocale] = useSprakContext();
     const omBarnetHook = useOmBarnet(barn.id);
@@ -53,105 +48,7 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, nummer, barn, 
                     tittel={<SpråkTekst id={'ombarnet.fosterbarn'} values={{ navn: barn.navn }} />}
                 />
             )}
-            {barn[barnDataKeySpørsmål.oppholderSegIInstitusjon].svar === ESvar.JA && (
-                <StyledOppsummeringsFeltGruppe>
-                    <OppsummeringFelt
-                        tittel={
-                            <SpråkTekst id={'ombarnet.institusjon'} values={{ navn: barn.navn }} />
-                        }
-                    />
 
-                    {barn[barnDataKeySpørsmål.institusjonIUtland].svar === ESvar.JA ? (
-                        <OppsummeringFelt
-                            tittel={
-                                <SpråkTekst
-                                    id={
-                                        omBarnetSpørsmålSpråkId[
-                                            OmBarnetSpørsmålsId.institusjonIUtland
-                                        ]
-                                    }
-                                />
-                            }
-                        />
-                    ) : (
-                        <>
-                            <OppsummeringFelt
-                                tittel={
-                                    <SpråkTekst
-                                        id={
-                                            omBarnetSpørsmålSpråkId[
-                                                OmBarnetSpørsmålsId.institusjonsnavn
-                                            ]
-                                        }
-                                    />
-                                }
-                                søknadsvar={barn[barnDataKeySpørsmål.institusjonsnavn].svar}
-                            />
-
-                            <OppsummeringFelt
-                                tittel={
-                                    <SpråkTekst
-                                        id={
-                                            omBarnetSpørsmålSpråkId[
-                                                OmBarnetSpørsmålsId.institusjonsadresse
-                                            ]
-                                        }
-                                    />
-                                }
-                                søknadsvar={barn[barnDataKeySpørsmål.institusjonsadresse].svar}
-                            />
-
-                            <OppsummeringFelt
-                                tittel={
-                                    <SpråkTekst
-                                        id={
-                                            omBarnetSpørsmålSpråkId[
-                                                OmBarnetSpørsmålsId.institusjonspostnummer
-                                            ]
-                                        }
-                                    />
-                                }
-                                søknadsvar={barn[barnDataKeySpørsmål.institusjonspostnummer].svar}
-                            />
-                        </>
-                    )}
-
-                    <OppsummeringFelt
-                        tittel={
-                            <SpråkTekst
-                                id={
-                                    omBarnetSpørsmålSpråkId[
-                                        OmBarnetSpørsmålsId.institusjonOppholdStartdato
-                                    ]
-                                }
-                            />
-                        }
-                        søknadsvar={formaterDato(
-                            barn[barnDataKeySpørsmål.institusjonOppholdStartdato].svar
-                        )}
-                    />
-
-                    <OppsummeringFelt
-                        tittel={
-                            <SpråkTekst
-                                id={
-                                    omBarnetSpørsmålSpråkId[
-                                        OmBarnetSpørsmålsId.institusjonOppholdSluttdato
-                                    ]
-                                }
-                            />
-                        }
-                        søknadsvar={formaterDatoMedUkjent(
-                            barn[barnDataKeySpørsmål.institusjonOppholdSluttdato].svar,
-                            formatMessage({
-                                id: omBarnetSpørsmålSpråkId[
-                                    OmBarnetSpørsmålsId.institusjonOppholdVetIkke
-                                ],
-                            })
-                        )}
-                    />
-                </StyledOppsummeringsFeltGruppe>
-            )}
             {barn[barnDataKeySpørsmål.utbetaltForeldrepengerEllerEngangsstønad].svar && (
                 <StyledOppsummeringsFeltGruppe>
                     <OppsummeringFelt

--- a/src/frontend/typer/barn.ts
+++ b/src/frontend/typer/barn.ts
@@ -1,6 +1,6 @@
 import { Alpha3Code } from 'i18n-iso-countries';
 
-import { ESvar, ISODateString } from '@navikt/familie-form-elements';
+import { ESvar } from '@navikt/familie-form-elements';
 
 import { AlternativtSvarForInput, BarnetsId, DatoMedUkjent } from './common';
 import { Slektsforhold } from './kontrakt/generelle';
@@ -48,12 +48,6 @@ export enum barnDataKeySpørsmål {
     harBarnehageplass = 'harBarnehageplass',
     andreForelderErDød = 'andreForelderErDød',
     oppholderSegIInstitusjon = 'oppholderSegIInstitusjon',
-    institusjonIUtland = 'institusjonIUtland',
-    institusjonsnavn = 'institusjonsnavn',
-    institusjonsadresse = 'institusjonsadresse',
-    institusjonspostnummer = 'institusjonspostnummer',
-    institusjonOppholdStartdato = 'institusjonOppholdStartdato',
-    institusjonOppholdSluttdato = 'institusjonOppholdSluttdato',
     utbetaltForeldrepengerEllerEngangsstønad = 'utbetaltForeldrepengerEllerEngangsstønad',
     boddMindreEnn12MndINorge = 'boddMindreEnn12MndINorge',
     planleggerÅBoINorge12Mnd = 'planleggerÅBoINorge12Mnd',
@@ -114,12 +108,6 @@ export interface IBarnMedISøknad extends IBarn {
     [barnDataKeySpørsmål.harBarnehageplass]: ISøknadSpørsmål<ESvar | null>;
     [barnDataKeySpørsmål.andreForelderErDød]: ISøknadSpørsmål<ESvar | null>;
     [barnDataKeySpørsmål.oppholderSegIInstitusjon]: ISøknadSpørsmål<ESvar | null>;
-    [barnDataKeySpørsmål.institusjonIUtland]: ISøknadSpørsmål<ESvar>;
-    [barnDataKeySpørsmål.institusjonsnavn]: ISøknadSpørsmål<string>;
-    [barnDataKeySpørsmål.institusjonsadresse]: ISøknadSpørsmål<string>;
-    [barnDataKeySpørsmål.institusjonspostnummer]: ISøknadSpørsmål<string>;
-    [barnDataKeySpørsmål.institusjonOppholdStartdato]: ISøknadSpørsmål<ISODateString>;
-    [barnDataKeySpørsmål.institusjonOppholdSluttdato]: ISøknadSpørsmål<DatoMedUkjent>;
     [barnDataKeySpørsmål.utbetaltForeldrepengerEllerEngangsstønad]: ISøknadSpørsmål<ESvar | null>;
     [barnDataKeySpørsmål.boddMindreEnn12MndINorge]: ISøknadSpørsmål<ESvar | null>;
     [barnDataKeySpørsmål.planleggerÅBoINorge12Mnd]: ISøknadSpørsmål<ESvar | null>;

--- a/src/frontend/typer/skjema.ts
+++ b/src/frontend/typer/skjema.ts
@@ -45,13 +45,6 @@ export interface IOmBarnaDineFeltTyper {
 }
 
 export interface IOmBarnetUtvidetFeltTyper {
-    institusjonIUtlandCheckbox: ESvar;
-    institusjonsnavn: string;
-    institusjonsadresse: string;
-    institusjonspostnummer: string;
-    institusjonOppholdStartdato: ISODateString;
-    institusjonOppholdSluttdato: DatoMedUkjent;
-    institusjonOppholdSluttVetIkke: ESvar;
     utbetaltForeldrepengerEllerEngangsstønad: ESvar | null;
     planleggerÅBoINorge12Mnd: ESvar | null;
     pågåendeSøknadFraAnnetEøsLand: ESvar | null;

--- a/src/frontend/utils/barn.test.ts
+++ b/src/frontend/utils/barn.test.ts
@@ -9,7 +9,6 @@ import {
     genererSvarForSpørsmålBarn,
 } from '../components/SøknadsSteg/OmBarnaDine/utils';
 import { IBarnMedISøknad } from '../typer/barn';
-import { AlternativtSvarForInput } from '../typer/common';
 import { IOmBarnaDineFeltTyper } from '../typer/skjema';
 import { ISøknad } from '../typer/søknad';
 
@@ -37,11 +36,6 @@ describe('genererOppdaterteBarn', () => {
                 idNummer: [],
                 utenlandsperioder: [],
                 eøsKontantstøttePerioder: [],
-                institusjonsnavn: { svar: 'Narvesen' },
-                institusjonsadresse: { svar: 'Narvesen' },
-                institusjonspostnummer: { svar: '2020' },
-                institusjonOppholdStartdato: { svar: '2020-09-08' },
-                institusjonOppholdSluttdato: { svar: AlternativtSvarForInput.UKJENT },
                 planleggerÅBoINorge12Mnd: { svar: ESvar.JA },
             },
         ],
@@ -86,11 +80,6 @@ describe('genererOppdaterteBarn', () => {
                 oppholderSegIInstitusjon: objectContaining({ svar: 'NEI' }),
                 boddMindreEnn12MndINorge: objectContaining({ svar: 'NEI' }),
                 kontantstøtteFraAnnetEøsland: objectContaining({ svar: 'JA' }),
-                institusjonsnavn: objectContaining({ svar: '' }),
-                institusjonsadresse: objectContaining({ svar: '' }),
-                institusjonspostnummer: objectContaining({ svar: '' }),
-                institusjonOppholdStartdato: objectContaining({ svar: '' }),
-                institusjonOppholdSluttdato: objectContaining({ svar: '' }),
                 planleggerÅBoINorge12Mnd: objectContaining({ svar: null }),
             }),
         ]);

--- a/src/frontend/utils/barn.ts
+++ b/src/frontend/utils/barn.ts
@@ -170,30 +170,6 @@ export const genererInitialBarnMedISøknad = (barn: IBarn): IBarnMedISøknad => 
             id: OmBarnaDineSpørsmålId.hvemOppholderSegIInstitusjon,
             svar: null,
         },
-        [barnDataKeySpørsmål.institusjonIUtland]: {
-            id: OmBarnetSpørsmålsId.institusjonIUtland,
-            svar: ESvar.NEI,
-        },
-        [barnDataKeySpørsmål.institusjonsnavn]: {
-            id: OmBarnetSpørsmålsId.institusjonsnavn,
-            svar: '',
-        },
-        [barnDataKeySpørsmål.institusjonsadresse]: {
-            id: OmBarnetSpørsmålsId.institusjonsadresse,
-            svar: '',
-        },
-        [barnDataKeySpørsmål.institusjonspostnummer]: {
-            id: OmBarnetSpørsmålsId.institusjonspostnummer,
-            svar: '',
-        },
-        [barnDataKeySpørsmål.institusjonOppholdStartdato]: {
-            id: OmBarnetSpørsmålsId.institusjonOppholdStartdato,
-            svar: '',
-        },
-        [barnDataKeySpørsmål.institusjonOppholdSluttdato]: {
-            id: OmBarnetSpørsmålsId.institusjonOppholdSluttdato,
-            svar: '',
-        },
         [barnDataKeySpørsmål.utbetaltForeldrepengerEllerEngangsstønad]: {
             id: OmBarnetSpørsmålsId.utbetaltForeldrepengerEllerEngangsstønad,
             svar: null,

--- a/src/frontend/utils/mappingTilKontrakt/barn.ts
+++ b/src/frontend/utils/mappingTilKontrakt/barn.ts
@@ -4,10 +4,6 @@ import {
     EøsBarnSpørsmålId,
     eøsBarnSpørsmålSpråkId,
 } from '../../components/SøknadsSteg/EøsSteg/Barn/spørsmål';
-import {
-    OmBarnetSpørsmålsId,
-    omBarnetSpørsmålSpråkId,
-} from '../../components/SøknadsSteg/OmBarnet/spørsmål';
 import { barnDataKeySpørsmål, IBarnMedISøknad } from '../../typer/barn';
 import { ERegistrertBostedType, TilRestLocaleRecord } from '../../typer/kontrakt/generelle';
 import { ISøknadIKontraktBarn } from '../../typer/kontrakt/v1';
@@ -49,7 +45,6 @@ export const barnISøknadsFormat = (
         adressebeskyttelse,
         andreForelder,
         omsorgsperson,
-        institusjonOppholdSluttdato,
         utenlandsperioder,
         // Nye felter under utvikling av EØS full
         eøsKontantstøttePerioder,
@@ -142,14 +137,6 @@ export const barnISøknadsFormat = (
                 navn: navn,
                 barn: navn,
             }),
-            [barnDataKeySpørsmål.institusjonOppholdSluttdato]: søknadsfeltBarn(
-                språktekstIdFraSpørsmålId(OmBarnetSpørsmålsId.institusjonOppholdSluttdato),
-                sammeVerdiAlleSpråkEllerUkjentSpråktekst(
-                    institusjonOppholdSluttdato.svar,
-                    omBarnetSpørsmålSpråkId['institusjon-opphold-ukjent-sluttdato']
-                ),
-                barn
-            ),
             [barnDataKeySpørsmål.adresse]: søknadsfeltBarn(
                 språktekstIdFraSpørsmålId(EøsBarnSpørsmålId.barnetsAdresse),
                 sammeVerdiAlleSpråkEllerUkjentSpråktekst(


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Siden man ikke har rett til kontantstøtte dersom barnet er i institusjon kan vi fjerne all oppfølgningsinfo om barnet er i institusjon. I stedet viser man en alert på Om Barna siden, om at de ikke har rett på kontantstøtte. 

Alerten er en egen oppgave

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
