### PR TITLE
Fix/use eøs for barn sanity og bugs

### DIFF
--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/arbeidsperiodeSpråkUtils.ts
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/arbeidsperiodeSpråkUtils.ts
@@ -2,11 +2,6 @@ import { PersonType } from '../../../typer/personType';
 import { ISanitySpørsmålDokument } from '../../../typer/sanity/sanity';
 import { ITekstinnhold } from '../../../typer/sanity/tekstInnhold';
 
-export const arbeidsperiodeFeilmelding = (gjelderUtlandet: boolean): string =>
-    gjelderUtlandet
-        ? 'felles.flerearbeidsperioderutland.feilmelding'
-        : 'felles.flerearbeidsperiodernorge.feilmelding';
-
 export const arbeidsperiodeSpørsmålDokument = (
     gjelderUtlandet: boolean,
     personType: PersonType,

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/språkUtils.ts
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/språkUtils.ts
@@ -41,11 +41,6 @@ export const mottarPensjonNåFeilmelding = ({
     }
 };
 
-export const pensjonsperiodeFeilmelding = (gjelderUtlandet: boolean): string =>
-    gjelderUtlandet
-        ? 'felles.modal.leggtilpensjonutland.feilmelding'
-        : 'felles.modal.leggtilpensjonnorge.feilmelding';
-
 export const pensjonSpørsmålDokument = (
     gjelderUtlandet: boolean,
     personType: PersonType,

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { Heading } from '@navikt/ds-react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../../context/AppContext';
@@ -7,6 +8,7 @@ import { barnDataKeySpørsmål, IBarnMedISøknad } from '../../../../typer/barn'
 import { BarnetsId, Typografi } from '../../../../typer/common';
 import { PersonType } from '../../../../typer/personType';
 import { skalSkjuleAndreForelderFelt } from '../../../../utils/barn';
+import { uppercaseFørsteBokstav } from '../../../../utils/visning';
 import { Arbeidsperiode } from '../../../Felleskomponenter/Arbeidsperiode/Arbeidsperiode';
 import { LandDropdown } from '../../../Felleskomponenter/Dropdowns/LandDropdown';
 import SlektsforholdDropdown from '../../../Felleskomponenter/Dropdowns/SlektsforholdDropdown';
@@ -86,11 +88,9 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
     return (
         <Steg
             tittel={
-                <TekstBlock
-                    block={eoesForBarnTittel}
-                    flettefelter={{ barnetsNavn }}
-                    typografi={Typografi.StegHeadingH1}
-                />
+                <Heading level={'1'} size={'xsmall'}>
+                    {uppercaseFørsteBokstav(plainTekst(eoesForBarnTittel, { barnetsNavn }))}
+                </Heading>
             }
             skjema={{
                 validerFelterOgVisFeilmelding,

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { Heading } from '@navikt/ds-react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../../context/AppContext';
@@ -197,9 +196,11 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
             {!skalSkjuleAndreForelderFelt(barn) && (
                 <SkjemaFieldset
                     tittel={
-                        <Heading level={'2'} size={'xsmall'} spacing>
-                            {plainTekst(subtittelAndreForelder, { barnetsNavn: barnetsNavn })}
-                        </Heading>
+                        <TekstBlock
+                            block={subtittelAndreForelder}
+                            flettefelter={{ barnetsNavn }}
+                            typografi={Typografi.HeadingH2}
+                        />
                     }
                 >
                     {!barnMedSammeForelder ? (

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/Omsorgsperson.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/Omsorgsperson.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { Heading } from '@navikt/ds-react';
 import { ESvar } from '@navikt/familie-form-elements';
 import { ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../../context/AppContext';
 import { IBarnMedISøknad } from '../../../../typer/barn';
+import { Typografi } from '../../../../typer/common';
 import {
     IArbeidsperiode,
     IEøsKontantstøttePeriode,
@@ -67,9 +67,11 @@ const Omsorgsperson: React.FC<OmsorgspersonProps> = ({ skjema, barn, periodeFunk
     return (
         <SkjemaFieldset
             tittel={
-                <Heading size={'xsmall'} level={'2'} spacing>
-                    {plainTekst(eøsForBarnTekster.oppgittIkkeBorFastSammenMedDeg, flettefelter)}
-                </Heading>
+                <TekstBlock
+                    block={eøsForBarnTekster.oppgittIkkeBorFastSammenMedDeg}
+                    flettefelter={flettefelter}
+                    typografi={Typografi.HeadingH2}
+                />
             }
         >
             <SkjemaFeltInput

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/innholdTyper.ts
@@ -9,10 +9,10 @@ export interface IEøsForBarnTekstinnhold {
     borMedAndreForelder: ISanitySpørsmålDokument;
     borMedOmsorgsperson: ISanitySpørsmålDokument;
     hvorBorBarnet: ISanitySpørsmålDokument;
-    oppgittIkkeBorFastSammenMedDeg: LocaleRecordString;
+    oppgittIkkeBorFastSammenMedDeg: LocaleRecordBlock;
 
     /* Andre forelder */
-    subtittelAndreForelder: LocaleRecordString;
+    subtittelAndreForelder: LocaleRecordBlock;
     arbeidNorgeAndreForelder: ISanitySpørsmålDokument;
     arbeidNorgeAndreForelderGjenlevende: ISanitySpørsmålDokument;
     pensjonNorgeAndreForelder: ISanitySpørsmålDokument;

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/useEøsForBarn.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 
 import { Alpha3Code } from 'i18n-iso-countries';
 
@@ -32,9 +32,6 @@ import { skalSkjuleAndreForelderFelt, skalViseBorMedOmsorgsperson } from '../../
 import { trimWhiteSpace } from '../../../../utils/hjelpefunksjoner';
 import { formaterVerdiForCheckbox } from '../../../../utils/input';
 import { svarForSpørsmålMedUkjent } from '../../../../utils/spørsmål';
-import { arbeidsperiodeFeilmelding } from '../../../Felleskomponenter/Arbeidsperiode/arbeidsperiodeSpråkUtils';
-import { pensjonsperiodeFeilmelding } from '../../../Felleskomponenter/Pensjonsmodal/språkUtils';
-import SpråkTekst from '../../../Felleskomponenter/SpråkTekst/SpråkTekst';
 import { idNummerKeyPrefix } from '../idnummerUtils';
 import { EøsBarnSpørsmålId } from './spørsmål';
 
@@ -115,12 +112,7 @@ export const useEøsForBarn = (
                 ? ok(felt)
                 : feil(
                       felt,
-                      <SpråkTekst
-                          id={'felles.relasjon.format.feilmelding'}
-                          values={{
-                              barn: gjeldendeBarn.navn,
-                          }}
-                      />
+                      plainTekst(tekster().FELLES.formateringsfeilmeldinger.ugyldigRelasjon)
                   );
         },
         nullstillVedAvhengighetEndring: false,
@@ -162,12 +154,7 @@ export const useEøsForBarn = (
                 ? ok(felt)
                 : feil(
                       felt,
-                      <SpråkTekst
-                          id={'felles.relasjon.format.feilmelding'}
-                          values={{
-                              barn: gjeldendeBarn.navn,
-                          }}
-                      />
+                      plainTekst(tekster().FELLES.formateringsfeilmeldinger.ugyldigRelasjon)
                   );
         },
         nullstillVedAvhengighetEndring: false,
@@ -198,12 +185,7 @@ export const useEøsForBarn = (
                 ? ok(felt)
                 : feil(
                       felt,
-                      <SpråkTekst
-                          id={'felles.relasjon.format.feilmelding'}
-                          values={{
-                              barn: gjeldendeBarn.navn,
-                          }}
-                      />
+                      plainTekst(tekster().FELLES.formateringsfeilmeldinger.ugyldigRelasjon)
                   );
         },
         nullstillVedAvhengighetEndring: false,
@@ -227,12 +209,7 @@ export const useEøsForBarn = (
                 ? ok(felt)
                 : feil(
                       felt,
-                      <SpråkTekst
-                          id={'felles.idnummer-feilformat.feilmelding'}
-                          values={{
-                              barn: gjeldendeBarn.navn,
-                          }}
-                      />
+                      plainTekst(tekster().FELLES.formateringsfeilmeldinger.ugyldigIDnummer)
                   );
         },
         nullstillVedAvhengighetEndring: false,
@@ -264,7 +241,13 @@ export const useEøsForBarn = (
             return avhengigheter?.omsorgspersonArbeidUtland.verdi === ESvar.NEI ||
                 (avhengigheter?.omsorgspersonArbeidUtland.verdi === ESvar.JA && felt.verdi.length)
                 ? ok(felt)
-                : feil(felt, <SpråkTekst id={arbeidsperiodeFeilmelding(true)} />);
+                : feil(
+                      felt,
+                      plainTekst(
+                          tekster().FELLES.modaler.arbeidsperiode.omsorgsperson.leggTilFeilmelding,
+                          { gjelderUtland: true }
+                      )
+                  );
         }
     );
 
@@ -286,7 +269,13 @@ export const useEøsForBarn = (
             return avhengigheter?.omsorgspersonArbeidNorge.verdi === ESvar.NEI ||
                 (avhengigheter?.omsorgspersonArbeidNorge.verdi === ESvar.JA && felt.verdi.length)
                 ? ok(felt)
-                : feil(felt, <SpråkTekst id={arbeidsperiodeFeilmelding(false)} />);
+                : feil(
+                      felt,
+                      plainTekst(
+                          tekster().FELLES.modaler.arbeidsperiode.omsorgsperson.leggTilFeilmelding,
+                          { gjelderUtland: false }
+                      )
+                  );
         }
     );
 
@@ -308,7 +297,13 @@ export const useEøsForBarn = (
             return avhengigheter?.omsorgspersonPensjonUtland.verdi === ESvar.NEI ||
                 (avhengigheter?.omsorgspersonPensjonUtland.verdi === ESvar.JA && felt.verdi.length)
                 ? ok(felt)
-                : feil(felt, <SpråkTekst id={pensjonsperiodeFeilmelding(false)} />);
+                : feil(
+                      felt,
+                      plainTekst(
+                          tekster().FELLES.modaler.pensjonsperiode.omsorgsperson.leggTilFeilmelding,
+                          { gjelderUtland: true }
+                      )
+                  );
         }
     );
 
@@ -330,7 +325,13 @@ export const useEøsForBarn = (
             return avhengigheter?.omsorgspersonPensjonNorge.verdi === ESvar.NEI ||
                 (avhengigheter?.omsorgspersonPensjonNorge.verdi === ESvar.JA && felt.verdi.length)
                 ? ok(felt)
-                : feil(felt, <SpråkTekst id={pensjonsperiodeFeilmelding(false)} />);
+                : feil(
+                      felt,
+                      plainTekst(
+                          tekster().FELLES.modaler.pensjonsperiode.omsorgsperson.leggTilFeilmelding,
+                          { gjelderUtland: false }
+                      )
+                  );
         }
     );
 
@@ -353,7 +354,13 @@ export const useEøsForBarn = (
                 (avhengigheter?.omsorgspersonAndreUtbetalinger.verdi === ESvar.JA &&
                     felt.verdi.length)
                 ? ok(felt)
-                : feil(felt, <SpråkTekst id={'felles.flereytelser.feilmelding'} />);
+                : feil(
+                      felt,
+                      plainTekst(
+                          tekster().FELLES.modaler.andreUtbetalinger.omsorgsperson
+                              .leggTilFeilmelding
+                      )
+                  );
         }
     );
     const omsorgspersonPågåendeSøknadFraAnnetEøsLand = useJaNeiSpmFelt({
@@ -388,7 +395,12 @@ export const useEøsForBarn = (
                 (avhengigheter?.omsorgspersonKontantstøtteFraEøs.verdi === ESvar.JA &&
                     felt.verdi.length)
                 ? ok(felt)
-                : feil(felt, <SpråkTekst id={'ombarnet.trygdandreperioder.feilmelding'} />);
+                : feil(
+                      felt,
+                      plainTekst(
+                          tekster().FELLES.modaler.eøsYtelse.omsorgsperson.leggTilFeilmelding
+                      )
+                  );
         }
     );
 
@@ -450,7 +462,13 @@ export const useEøsForBarn = (
             return avhengigheter?.andreForelderArbeidNorge.verdi === ESvar.NEI ||
                 (avhengigheter?.andreForelderArbeidNorge.verdi === ESvar.JA && felt.verdi.length)
                 ? ok(felt)
-                : feil(felt, <SpråkTekst id={arbeidsperiodeFeilmelding(false)} />);
+                : feil(
+                      felt,
+                      plainTekst(
+                          tekster().FELLES.modaler.arbeidsperiode.andreForelder.leggTilFeilmelding,
+                          { gjelderUtland: false }
+                      )
+                  );
         }
     );
 
@@ -474,7 +492,13 @@ export const useEøsForBarn = (
             return avhengigheter?.andreForelderPensjonNorge.verdi === ESvar.NEI ||
                 (avhengigheter?.andreForelderPensjonNorge.verdi === ESvar.JA && felt.verdi.length)
                 ? ok(felt)
-                : feil(felt, <SpråkTekst id={pensjonsperiodeFeilmelding(false)} />);
+                : feil(
+                      felt,
+                      plainTekst(
+                          tekster().FELLES.modaler.pensjonsperiode.andreForelder.leggTilFeilmelding,
+                          { gjelderUtland: false }
+                      )
+                  );
         }
     );
 
@@ -499,7 +523,13 @@ export const useEøsForBarn = (
                 (avhengigheter?.andreForelderAndreUtbetalinger.verdi === ESvar.JA &&
                     felt.verdi.length)
                 ? ok(felt)
-                : feil(felt, <SpråkTekst id={'felles.flereytelser.feilmelding'} />);
+                : feil(
+                      felt,
+                      plainTekst(
+                          tekster().FELLES.modaler.andreUtbetalinger.andreForelder
+                              .leggTilFeilmelding
+                      )
+                  );
         }
     );
 
@@ -539,7 +569,12 @@ export const useEøsForBarn = (
                 (avhengigheter?.andreForelderKontantstøtteFraEøs.verdi === ESvar.JA &&
                     felt.verdi.length)
                 ? ok(felt)
-                : feil(felt, <SpråkTekst id={'ombarnet.trygdandreperioder.feilmelding'} />);
+                : feil(
+                      felt,
+                      plainTekst(
+                          tekster().FELLES.modaler.eøsYtelse.andreForelder.leggTilFeilmelding
+                      )
+                  );
         }
     );
 

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Søker/EøsForSøker.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Søker/EøsForSøker.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
+import { Heading } from '@navikt/ds-react';
+
 import { useApp } from '../../../../context/AppContext';
-import { Typografi } from '../../../../typer/common';
 import { PersonType } from '../../../../typer/personType';
+import { uppercaseFørsteBokstav } from '../../../../utils/visning';
 import { Arbeidsperiode } from '../../../Felleskomponenter/Arbeidsperiode/Arbeidsperiode';
 import KomponentGruppe from '../../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
 import { Pensjonsperiode } from '../../../Felleskomponenter/Pensjonsmodal/Pensjonsperiode';
@@ -33,7 +35,11 @@ const EøsForSøker: React.FC = () => {
 
     return (
         <Steg
-            tittel={<TekstBlock block={eoesForSoekerTittel} typografi={Typografi.StegHeadingH1} />}
+            tittel={
+                <Heading level={'1'} size={'xsmall'}>
+                    {uppercaseFørsteBokstav(plainTekst(eoesForSoekerTittel))}
+                </Heading>
+            }
             skjema={{
                 validerFelterOgVisFeilmelding,
                 valideringErOk,

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Søker/useEøsForSøker.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Søker/useEøsForSøker.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 
 import { Alpha3Code } from 'i18n-iso-countries';
 
@@ -17,8 +17,6 @@ import { ESanitySteg } from '../../../../typer/sanity/sanity';
 import { IEøsForSøkerFeltTyper } from '../../../../typer/skjema';
 import { valideringAdresse } from '../../../../utils/adresse';
 import { trimWhiteSpace } from '../../../../utils/hjelpefunksjoner';
-import SpråkTekst from '../../../Felleskomponenter/SpråkTekst/SpråkTekst';
-import TekstBlock from '../../../Felleskomponenter/TekstBlock';
 import { idNummerKeyPrefix } from '../idnummerUtils';
 import { EøsSøkerSpørsmålId } from './spørsmål';
 
@@ -37,7 +35,7 @@ export const useEøsForSøker = (): {
     settIdNummerFelter: Dispatch<SetStateAction<Felt<string>[]>>;
     idNummerFelter: Felt<string>[];
 } => {
-    const { søknad, settSøknad, tekster } = useApp();
+    const { søknad, settSøknad, tekster, plainTekst } = useApp();
     const { arbeidNorge, hvorBor, pensjonNorge, utbetalinger } = tekster().EØS_FOR_SØKER;
 
     const teksterForArbeidsperiode: IArbeidsperiodeTekstinnhold =
@@ -76,10 +74,9 @@ export const useEøsForSøker = (): {
                 ? ok(felt)
                 : feil(
                       felt,
-                      <TekstBlock
-                          block={teksterForArbeidsperiode.leggTilFeilmelding}
-                          flettefelter={{ gjelderUtland: false }}
-                      />
+                      plainTekst(teksterForArbeidsperiode.leggTilFeilmelding, {
+                          gjelderUtland: false,
+                      })
                   );
         }
     );
@@ -101,7 +98,7 @@ export const useEøsForSøker = (): {
             return avhengigheter?.pensjonNorgeFelt.verdi === ESvar.NEI ||
                 (avhengigheter?.pensjonNorgeFelt.verdi === ESvar.JA && felt.verdi.length)
                 ? ok(felt)
-                : feil(felt, <TekstBlock block={pensjonNorge.feilmelding} />);
+                : feil(felt, plainTekst(pensjonNorge.feilmelding));
         }
     );
 
@@ -121,7 +118,12 @@ export const useEøsForSøker = (): {
             return avhengigheter?.andreUtbetalinger.verdi === ESvar.NEI ||
                 (avhengigheter?.andreUtbetalinger.verdi === ESvar.JA && felt.verdi.length)
                 ? ok(felt)
-                : feil(felt, <SpråkTekst id={'felles.flereytelser.feilmelding'} />);
+                : feil(
+                      felt,
+                      plainTekst(
+                          tekster().FELLES.modaler.andreUtbetalinger.søker.leggTilFeilmelding
+                      )
+                  );
         }
     );
 

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -132,4 +132,5 @@ export interface IFormateringsfeilmeldingerTekstinnhold {
     ugyldigIDnummer: LocaleRecordString;
     ugyldigBeloep: LocaleRecordString;
     ugyldigFoedselsnummer: LocaleRecordString;
+    ugyldigRelasjon: LocaleRecordString;
 }

--- a/src/frontend/utils/adresse.tsx
+++ b/src/frontend/utils/adresse.tsx
@@ -8,7 +8,7 @@ import SpråkTekst from '../components/Felleskomponenter/SpråkTekst/SpråkTekst
 import { IAdresse } from '../typer/kontrakt/generelle';
 import { ISøker } from '../typer/person';
 import { trimWhiteSpace } from './hjelpefunksjoner';
-import { uppercaseFørsteBokstav } from './visning';
+import { uppercaseKunFørsteBokstav } from './visning';
 
 export const erNorskPostnummer = (verdi: string) =>
     !!(verdi?.length === 4 && Number.parseInt(verdi));
@@ -19,7 +19,7 @@ export const hentAdressefelterSortert = (adresse: IAdresse): string[] => {
             adresse.bruksenhetsnummer ?? ''
         }`,
         `${adresse.postnummer ?? ''} ${
-            adresse.poststed ? uppercaseFørsteBokstav(adresse.poststed) : ''
+            adresse.poststed ? uppercaseKunFørsteBokstav(adresse.poststed) : ''
         }`,
     ]
         .map(linje => linje.replace(/\s{2+}/, ' ').trim())

--- a/src/frontend/utils/visning.ts
+++ b/src/frontend/utils/visning.ts
@@ -2,7 +2,12 @@ export const formaterFnr = (fødselsnummer: string) => {
     return fødselsnummer.substring(0, 6) + ' ' + fødselsnummer.substring(6, 11);
 };
 
-export const uppercaseFørsteBokstav = text => {
+export const uppercaseKunFørsteBokstav = text => {
     if (typeof text !== 'string') return '';
     return text.charAt(0).toUpperCase() + text.toLowerCase().slice(1);
+};
+
+export const uppercaseFørsteBokstav = text => {
+    if (typeof text !== 'string') return '';
+    return text.charAt(0).toUpperCase() + text.slice(1);
 };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Fikser:
- Feilmeldinger på Eøs for barn og søker steget
- Overskrift på eøs-steg
- Subtitler på eøs-steg
- Fikset manglende knappetekst i sanity

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
FØR:
![Screenshot 2022-11-25 at 10 15 29](https://user-images.githubusercontent.com/8656966/203946589-09bef7eb-d5cb-43ce-96ed-ef90b046a102.png)

NÅ:
![Screenshot 2022-11-25 at 10 27 33](https://user-images.githubusercontent.com/8656966/203946682-230c0e32-66cb-4f5f-a663-765981faf443.png)


Før:
![Screenshot 2022-11-25 at 09 40 17](https://user-images.githubusercontent.com/8656966/203946742-13f7e379-a939-40a2-b36f-98c1e32c0ed8.png)

Nå:
![Screenshot 2022-11-25 at 10 15 07](https://user-images.githubusercontent.com/8656966/203946769-ba6de05c-1a24-4699-9358-a5bd8c04881a.png)

Før:
![Screenshot 2022-11-23 at 12 05 06](https://user-images.githubusercontent.com/8656966/203946814-f90a9b21-61c5-45a9-a418-3472622fa426.png)

Nå:
![Screenshot 2022-11-25 at 10 15 25](https://user-images.githubusercontent.com/8656966/203946857-d81c0c6f-194c-46c2-8a97-0156c5628196.png)
