### PR TITLE
Oppdatert node versjon i readme til 16.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Dette er en skinnet kopi av barnetrygdsøknaden (kopiert 2.8.22): https://github
 ADR-dokument: https://github.com/navikt/familie/blob/master/doc/adr/0008-KS-lager-egen-søknadsdialog-app.md
 
 ## Avhengigheter
-1. Node versjon >=16
+1. Node versjon >=16.17.0
 2. familie-ba-soknad-api (https://github.com/navikt/familie-ba-soknad-api)
 
 ## Log in på https://npm.pkg.github.com


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Fungerer ikke å kjøre opp appen med node versjon < 16.17.0. Legger inn nødvendig versjon i readme.
