### PR TITLE
Bruk toggle for å skru av mulighet til å sende inn søknad

### DIFF
--- a/src/backend/routes/feature-toggles.ts
+++ b/src/backend/routes/feature-toggles.ts
@@ -3,7 +3,11 @@ import { ParamsDictionary } from 'express-serve-static-core';
 
 import { byggFeiletRessurs, byggSuksessRessurs, Ressurs } from '@navikt/familie-typer';
 
-import { EAllFeatureToggles } from '../../frontend/typer/feature-toggles';
+import {
+    EAllFeatureToggles,
+    EFeatureToggle,
+    ToggleKeys,
+} from '../../frontend/typer/feature-toggles';
 import { basePath } from '../environment';
 import { isEnabled } from '../utils/unleash';
 
@@ -30,7 +34,7 @@ const fetchAllFeatureTogglesHandler: RequestHandler<
 > = (_, res) => {
     res.send(
         byggSuksessRessurs({
-            // [EFeatureToggle.EXAMPLE]: isEnabled(ToggleKeys.EXAMPLE),
+            [EFeatureToggle.DISABLE_SEND_INN_KNAPP]: isEnabled(ToggleKeys.DISABLE_SEND_INN_KNAPP),
         })
     );
 };

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -28,7 +28,9 @@ function App() {
                                     <Router basename={routerBasePath}>
                                         <StegProvider>
                                             <GlobalStyle />
-                                            {process.env.NODE_ENV !== 'production' && (
+                                            {
+                                                // todo: Kommentere denne inn når vi går live
+                                                //process.env.NODE_ENV !== 'production' && (
                                                 <AlertStripe variant="warning">
                                                     {`Denne siden er under utvikling. `}
                                                     <a href="https://www.nav.no/kontantstotte">
@@ -36,7 +38,8 @@ function App() {
                                                         kontantstøtte
                                                     </a>
                                                 </AlertStripe>
-                                            )}
+                                                //)
+                                            }
                                             <AppNavigationProvider>
                                                 <AppContainer />
                                             </AppNavigationProvider>

--- a/src/frontend/components/Felleskomponenter/Steg/Navigeringspanel.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Navigeringspanel.tsx
@@ -6,6 +6,7 @@ import { Button } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { useSteg } from '../../../context/StegContext';
 import { device } from '../../../Theme';
 import { RouteEnum } from '../../../typer/routes';
@@ -55,6 +56,7 @@ const Navigeringspanel: React.FC<{
     const { hentNesteSteg } = useSteg();
     const nesteSteg = hentNesteSteg();
     const { innsendingStatus, tekster, plainTekst } = useApp();
+    const { toggles } = useFeatureToggles();
 
     const { avbrytSoeknad, tilbakeKnapp, gaaVidereKnapp, sendSoeknadKnapp } =
         tekster().FELLES.navigasjon;
@@ -85,6 +87,9 @@ const Navigeringspanel: React.FC<{
                 gridarea={'gåVidere'}
                 loading={innsendingStatus.status === RessursStatus.HENTER}
                 data-testid={'gå-videre-knapp'}
+                disabled={
+                    nesteSteg.route === RouteEnum.Kvittering && toggles.DISABLE_SEND_INN_KNAPP
+                }
             >
                 {plainTekst(
                     nesteSteg.route === RouteEnum.Kvittering ? sendSoeknadKnapp : gaaVidereKnapp

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
@@ -6,6 +6,7 @@ import { BodyShort } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import useFørsteRender from '../../../hooks/useFørsteRender';
 import { useSendInnSkjema } from '../../../hooks/useSendInnSkjema';
 import { Typografi } from '../../../typer/common';
@@ -30,6 +31,7 @@ const Dokumentasjon: React.FC = () => {
     const { søknad, settSøknad, innsendingStatus, tekster } = useApp();
     const { sendInnSkjema } = useSendInnSkjema();
     const [slettaVedlegg, settSlettaVedlegg] = useState<IVedlegg[]>([]);
+    const { toggles } = useFeatureToggles();
 
     const { dokumentasjonInfo, dokumentasjonTittel, forLangTidDokumentasjon, nudgeDokumentasjon } =
         tekster().DOKUMENTASJON;
@@ -71,10 +73,14 @@ const Dokumentasjon: React.FC = () => {
     return (
         <Steg
             tittel={<TekstBlock block={dokumentasjonTittel} typografi={Typografi.StegHeadingH1} />}
-            gåVidereCallback={async () => {
-                const [success, _] = await sendInnSkjema();
-                return success;
-            }}
+            gåVidereCallback={
+                !toggles.DISABLE_SEND_INN_KNAPP
+                    ? async () => {
+                          const [success, _] = await sendInnSkjema();
+                          return success;
+                      }
+                    : undefined
+            }
         >
             {slettaVedlegg.length > 0 && (
                 <KomponentGruppe>
@@ -112,6 +118,15 @@ const Dokumentasjon: React.FC = () => {
                     />
                 ))}
             {innsendingStatus.status === RessursStatus.FEILET && <Feilside />}
+            {toggles.DISABLE_SEND_INN_KNAPP && (
+                <div>
+                    <AlertStripe variant="error">
+                        <BodyShort>
+                            Denne siden er under utvikling og du kan derfor ikke sende inn en søknad
+                        </BodyShort>
+                    </AlertStripe>
+                </div>
+            )}
         </Steg>
     );
 };

--- a/src/frontend/context/FeatureToggleContext.ts
+++ b/src/frontend/context/FeatureToggleContext.ts
@@ -6,7 +6,7 @@ import { Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import useFørsteRender from '../hooks/useFørsteRender';
 import { basePath } from '../Miljø';
-import { EAllFeatureToggles } from '../typer/feature-toggles';
+import { EAllFeatureToggles, EFeatureToggle } from '../typer/feature-toggles';
 import { useLastRessurserContext } from './LastRessurserContext';
 
 const [FeatureTogglesProvider, useFeatureToggles] = createUseContext(() => {
@@ -15,7 +15,7 @@ const [FeatureTogglesProvider, useFeatureToggles] = createUseContext(() => {
      * Husk å legge til nye toggles i funksjon konfigurerAllFeatureTogglesEndpoint (feature-toggles.ts)
      */
     const [toggles, setToggles] = useState<EAllFeatureToggles>({
-        //[EFeatureToggle.EXAMPLE]: false,
+        [EFeatureToggle.DISABLE_SEND_INN_KNAPP]: false,
     });
 
     useFørsteRender(async () => {

--- a/src/frontend/typer/feature-toggles.ts
+++ b/src/frontend/typer/feature-toggles.ts
@@ -2,7 +2,9 @@ export enum EToggle {
     KONTANTSTOTTE = 'familie-ks-soknad.disable-soknad',
 }
 
-export enum EFeatureToggle {}
+export enum EFeatureToggle {
+    DISABLE_SEND_INN_KNAPP = 'DISABLE_SEND_INN_KNAPP',
+}
 /**
  * true -> fullt EØS skjema
  * false -> eøs dekkes ved opplasting av utfylt pdf
@@ -10,7 +12,7 @@ export enum EFeatureToggle {}
 //EXAMPLE = 'EXAMPLE',
 
 export const ToggleKeys: Record<EFeatureToggle, string> = {
-    // [EFeatureToggle.EXAMPLE]: 'familie-ks-soknad.example',
+    [EFeatureToggle.DISABLE_SEND_INN_KNAPP]: 'familie-ks-soknad.disable-send-inn-knapp',
 };
 
 export type EAllFeatureToggles = Record<EFeatureToggle, boolean>;

--- a/src/frontend/utils/testing.tsx
+++ b/src/frontend/utils/testing.tsx
@@ -27,6 +27,7 @@ import * as routesContext from '../context/RoutesContext';
 import { getRoutes, RoutesProvider } from '../context/RoutesContext';
 import { SanityProvider } from '../context/SanityContext';
 import { StegProvider } from '../context/StegContext';
+import { EFeatureToggle } from '../typer/feature-toggles';
 import { ESivilstand } from '../typer/kontrakt/generelle';
 import { IKvittering } from '../typer/kvittering';
 import { ISøker, ISøkerRespons } from '../typer/person';
@@ -154,7 +155,7 @@ export const mockFeatureToggle = () => {
         .spyOn(featureToggleContext, 'useFeatureToggles')
         .mockImplementation(
             jest.fn().mockReturnValue({
-                // toggles: { [EFeatureToggle.EXAMPLE]: false },
+                toggles: { [EFeatureToggle.DISABLE_SEND_INN_KNAPP]: false },
             })
         );
     return { useFeatureToggle };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Legger til en toggle som gjør at vi kan skru av mulighet til å sende inn søknad. Dette for å unngå at folk sender inn søknader i prod før vi er klare.

  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
<img width="634" alt="Screenshot 2022-12-01 at 13 36 20" src="https://user-images.githubusercontent.com/8656966/205056156-a269dcff-f82f-423d-a918-7f1f4b79cc5c.png">

