### PR TITLE
Sørger for at alle oppsummeringstitler har stor forbokstav

### DIFF
--- a/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummeringsbolk.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummeringsbolk.tsx
@@ -12,6 +12,7 @@ import { LocaleRecordBlock, LocaleRecordString } from '../../../typer/common';
 import { FlettefeltVerdier } from '../../../typer/kontrakt/generelle';
 import { ISteg, RouteEnum } from '../../../typer/routes';
 import { SkjemaFeltTyper } from '../../../typer/skjema';
+import { uppercaseFørsteBokstav } from '../../../utils/visning';
 import { AppLenke } from '../../Felleskomponenter/AppLenke/AppLenke';
 import { SkjemaFeiloppsummering } from '../../Felleskomponenter/SkjemaFeiloppsummering/SkjemaFeiloppsummering';
 
@@ -75,7 +76,7 @@ const Oppsummeringsbolk: React.FC<Props> = ({
         <Accordion>
             <Accordion.Item defaultOpen={true}>
                 <Accordion.Header type="button">
-                    {`${stegnummer}. ${plainTekst(tittel, flettefelter)}`}
+                    {`${stegnummer}. ${uppercaseFørsteBokstav(plainTekst(tittel, flettefelter))}`}
                 </Accordion.Header>
                 <StyledAccordionContent>
                     {children}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Noen av titlene på oppsummeringssteget hadde ikke stor forbokstav. Bruker nå `uppercaseFørsteBokstav` på `Header` i `Oppsummeringsbolk` slik at alle titler får stor forbokstav.