### PR TITLE
lagt til opplystBarnehageplass i tekstene vi sender til backend per barn

### DIFF
--- a/src/frontend/utils/mappingTilKontrakt/barn.ts
+++ b/src/frontend/utils/mappingTilKontrakt/barn.ts
@@ -252,6 +252,7 @@ export const barnISøknadsFormat = (
                 tekster.OM_BARNET.opplystAdoptert,
                 tekster.OM_BARNET.opplystBarnOppholdUtenforNorge,
                 tekster.OM_BARNET.opplystFaarHarFaattEllerSoektYtelse,
+                tekster.OM_BARNET.opplystBarnehageplass,
                 tekster.OM_BARNET.barnetsAndreForelder,
                 tekster.OM_BARNET.omBarnetTittel,
                 tekster.OM_BARNET.bosted,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Teksten `opplystBarnehageplass` legges til i `teksterTilPdf` for barna.
