### PR TITLE
Workaround på at PortableText ikke støtter linebreaks

### DIFF
--- a/src/frontend/components/Felleskomponenter/TekstBlock.tsx
+++ b/src/frontend/components/Felleskomponenter/TekstBlock.tsx
@@ -24,6 +24,7 @@ const StyledLabel = styled(Label)`
 
 interface Props {
     typografi?: Typografi;
+    style?: React.CSSProperties;
 }
 
 const StyledBodyLong = styled(BodyLong)`
@@ -32,46 +33,50 @@ const StyledBodyLong = styled(BodyLong)`
     }
 `;
 
-export const TypografiWrapper: React.FC<Props> = ({ children, typografi }) => {
+export const TypografiWrapper: React.FC<Props> = ({ typografi, style, children }) => {
     switch (typografi) {
         case Typografi.StegHeadingH1:
             return (
-                <Heading level={'1'} size={'xsmall'}>
+                <Heading level={'1'} size={'xsmall'} style={style}>
                     {children}
                 </Heading>
             );
         case Typografi.ModalHeadingH1:
             return (
-                <Heading level={'1'} size={'large'}>
+                <Heading level={'1'} size={'large'} style={style}>
                     {children}
                 </Heading>
             );
         case Typografi.ForsideHeadingH1:
             return (
-                <Heading level={'1'} size={'xlarge'}>
+                <Heading level={'1'} size={'xlarge'} style={style}>
                     {children}
                 </Heading>
             );
         case Typografi.HeadingH2:
             return (
-                <Heading level={'2'} size={'xsmall'} spacing>
+                <Heading level={'2'} size={'xsmall'} spacing style={style}>
                     {children}
                 </Heading>
             );
         case Typografi.Ingress:
-            return <Ingress>{children}</Ingress>;
+            return <Ingress style={style}>{children}</Ingress>;
         case Typografi.BodyLong:
-            return <StyledBodyLong>{children}</StyledBodyLong>;
+            return <StyledBodyLong style={style}>{children}</StyledBodyLong>;
         case Typografi.BodyShort:
-            return <BodyShort>{children}</BodyShort>;
+            return <BodyShort style={style}>{children}</BodyShort>;
         case Typografi.Label:
-            return <StyledLabel spacing>{children}</StyledLabel>;
+            return (
+                <StyledLabel spacing style={style}>
+                    {children}
+                </StyledLabel>
+            );
         case Typografi.Detail:
-            return <Detail>{children}</Detail>;
+            return <Detail style={style}>{children}</Detail>;
         case Typografi.ErrorMessage:
-            return <ErrorMessage>{children}</ErrorMessage>;
+            return <ErrorMessage style={style}>{children}</ErrorMessage>;
         case undefined:
-            return <>{children}</>;
+            return <div style={style}>{children}</div>;
     }
 };
 
@@ -89,7 +94,9 @@ const TekstBlock: React.FC<{
             components={{
                 block: {
                     normal: ({ children }) => (
-                        <TypografiWrapper typografi={typografi}>{children}</TypografiWrapper>
+                        <TypografiWrapper typografi={typografi} style={{ minHeight: '1rem' }}>
+                            {children}
+                        </TypografiWrapper>
                     ),
                     h1: ({ children }) => (
                         <TypografiWrapper typografi={typografi}>{children}</TypografiWrapper>
@@ -118,7 +125,6 @@ const TekstBlock: React.FC<{
                                 target={props.value.blank ? '_blank' : '_self'}
                                 rel={'noopener noreferrer'}
                                 href={encodeURI(props.value.href)}
-                                style={{ display: 'block' }}
                             >
                                 {props.text}
                             </a>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
PortableText fra Sanity klarer ikke rendre linebreaks man putter i tekstfelt (blocks) i sanity. Legger derfor til 1 rem, sånn at vi får linebreaks på alle textblocks

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
FØR:
<img width="654" alt="Screenshot 2022-12-21 at 15 31 38" src="https://user-images.githubusercontent.com/8656966/208931016-ab50607e-1fd9-41e9-860d-3891cfdd39e6.png">


ETTER:
<img width="651" alt="Screenshot 2022-12-21 at 15 29 02" src="https://user-images.githubusercontent.com/8656966/208931011-1b40b98a-41f9-4f3f-94e8-66b2b27e77c9.png">



