### PR TITLE
Legger ved flettefeltet barnetsNavn for dokumentasjonsbehov BOR_FAST_MED_SØKER

### DIFF
--- a/src/frontend/utils/mappingTilKontrakt/dokumentasjon.ts
+++ b/src/frontend/utils/mappingTilKontrakt/dokumentasjon.ts
@@ -8,16 +8,20 @@ import {
     ISøknadKontraktDokumentasjon,
     ISøknadKontraktVedlegg,
 } from '../../typer/kontrakt/dokumentasjon';
-import { TilRestLocaleRecord } from '../../typer/kontrakt/generelle';
+import { FlettefeltVerdier, TilRestLocaleRecord } from '../../typer/kontrakt/generelle';
 import { ESanitySteg } from '../../typer/sanity/sanity';
 import { ITekstinnhold } from '../../typer/sanity/tekstInnhold';
+import { ISøknad } from '../../typer/søknad';
+import { slåSammen } from '../slåSammen';
 
 export const dokumentasjonISøknadFormat = (
     dokumentasjon: IDokumentasjon,
     tekster: ITekstinnhold,
-    tilRestLocaleRecord: TilRestLocaleRecord
+    tilRestLocaleRecord: TilRestLocaleRecord,
+    søknad: ISøknad
 ): ISøknadKontraktDokumentasjon => {
     const dokumentsjonstekster = tekster[ESanitySteg.DOKUMENTASJON];
+
     return {
         dokumentasjonsbehov: dokumentasjon.dokumentasjonsbehov,
         harSendtInn: dokumentasjon.harSendtInn,
@@ -27,9 +31,22 @@ export const dokumentasjonISøknadFormat = (
         dokumentasjonSpråkTittel: tilRestLocaleRecord(
             dokumentsjonstekster[
                 dokumentasjonsbehovTilTittelSanityApiNavn(dokumentasjon.dokumentasjonsbehov)
-            ]
+            ],
+            flettefelterForDokumentasjonTittel(dokumentasjon.dokumentasjonsbehov, søknad)
         ),
     };
+};
+
+const flettefelterForDokumentasjonTittel = (
+    dokumentasjonsbehov: Dokumentasjonsbehov,
+    søknad: ISøknad
+): FlettefeltVerdier => {
+    switch (dokumentasjonsbehov) {
+        case Dokumentasjonsbehov.BOR_FAST_MED_SØKER:
+            return { barnetsNavn: slåSammen(søknad.barnRegistrertManuelt.map(barn => barn.navn)) };
+        default:
+            return {};
+    }
 };
 
 export const vedleggISøknadFormat = (

--- a/src/frontend/utils/mappingTilKontrakt/søknad.ts
+++ b/src/frontend/utils/mappingTilKontrakt/søknad.ts
@@ -88,7 +88,7 @@ export const dataISøknadKontraktFormatV1 = (
         ),
         dokumentasjon: søknad.dokumentasjon
             .filter(dok => erDokumentasjonRelevant(dok))
-            .map(dok => dokumentasjonISøknadFormat(dok, tekster, tilRestLocaleRecord)),
+            .map(dok => dokumentasjonISøknadFormat(dok, tekster, tilRestLocaleRecord, søknad)),
         teksterTilPdf: {
             ...Object.values(ESivilstand).reduce(
                 (map, sivilstand) => ({


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi får feilen: `Flettefeltet barnetsNavn ikke sendt med` ved innsendelse av søknad dersom vi har lagt til barn manuelt på "Velg barn"-steget og valgt at barnet bor fast hos søker. Teksten tilknyttet dokumentasjonsbehovet `BOR_FAST_MED_SØKER` trigges av barn som manuelt er lagt til og krever flettefeltet `barnetsNavn`.

Sørger nå for at vi sender med flettefeltet `barnetsNavn` dersom dokumentasjonsbehovet er `BOR_FAST_MED_SØKER`.
