### PR TITLE
Fiks styling på feilmeldinger på velg-barn-modalen

### DIFF
--- a/src/frontend/components/Felleskomponenter/TekstBlock.tsx
+++ b/src/frontend/components/Felleskomponenter/TekstBlock.tsx
@@ -3,15 +3,7 @@ import React from 'react';
 import { PortableText } from '@portabletext/react';
 import styled from 'styled-components';
 
-import {
-    BodyLong,
-    BodyShort,
-    Detail,
-    ErrorMessage,
-    Heading,
-    Ingress,
-    Label,
-} from '@navikt/ds-react';
+import { BodyLong, BodyShort, Detail, Heading, Ingress, Label } from '@navikt/ds-react';
 import { useSprakContext } from '@navikt/familie-sprakvelger';
 
 import { useApp } from '../../context/AppContext';
@@ -73,8 +65,6 @@ export const TypografiWrapper: React.FC<Props> = ({ typografi, style, children }
             );
         case Typografi.Detail:
             return <Detail style={style}>{children}</Detail>;
-        case Typografi.ErrorMessage:
-            return <ErrorMessage style={style}>{children}</ErrorMessage>;
         case undefined:
             return <div style={style}>{children}</div>;
     }

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/useLeggTilBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/useLeggTilBarn.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ESvar } from '@navikt/familie-form-elements';
 import {
     feil,
@@ -13,13 +11,12 @@ import {
 
 import { useApp } from '../../../../context/AppContext';
 import useInputFeltMedUkjent from '../../../../hooks/useInputFeltMedUkjent';
-import { ESvarMedUbesvart, LocaleRecordBlock, Typografi } from '../../../../typer/common';
+import { ESvarMedUbesvart, LocaleRecordBlock } from '../../../../typer/common';
 import { ILeggTilBarnTekstinnhold } from '../../../../typer/sanity/modaler/leggTilBarn';
 import { ESanitySteg } from '../../../../typer/sanity/sanity';
 import { ILeggTilBarnTyper } from '../../../../typer/skjema';
 import { erBarnRegistrertFraFør, hentUid } from '../../../../utils/barn';
 import { trimWhiteSpace } from '../../../../utils/hjelpefunksjoner';
-import TekstBlock from '../../../Felleskomponenter/TekstBlock';
 import { VelgBarnSpørsmålId } from '../spørsmål';
 
 export const useLeggTilBarn = (): {
@@ -45,21 +42,9 @@ export const useLeggTilBarn = (): {
                 case ESvar.JA:
                     return ok(felt);
                 case ESvar.NEI:
-                    return feil(
-                        felt,
-                        <TekstBlock
-                            block={teksterForModal.barnIkkeFoedtFeilmelding}
-                            typografi={Typografi.ErrorMessage}
-                        />
-                    );
+                    return feil(felt, plainTekst(teksterForModal.barnIkkeFoedtFeilmelding));
                 default:
-                    return feil(
-                        felt,
-                        <TekstBlock
-                            block={teksterForModal.erBarnetFoedt.feilmelding}
-                            typografi={Typografi.ErrorMessage}
-                        />
-                    );
+                    return feil(felt, plainTekst(teksterForModal.erBarnetFoedt.feilmelding));
             }
         },
     });
@@ -96,13 +81,7 @@ export const useLeggTilBarn = (): {
         valideringsfunksjon: felt =>
             felt.verdi === ESvar.NEI
                 ? ok(felt)
-                : feil(
-                      felt,
-                      <TekstBlock
-                          block={teksterForModal.foedselsnummerFeilmelding}
-                          typografi={Typografi.ErrorMessage}
-                      />
-                  ),
+                : feil(felt, plainTekst(teksterForModal.foedselsnummerFeilmelding)),
         skalFeltetVises: ({ erFødt }) => erFødt.verdi === ESvar.JA,
         avhengigheter: { erFødt },
     });
@@ -118,13 +97,7 @@ export const useLeggTilBarn = (): {
         skalVises: erFødt.valideringsstatus === Valideringsstatus.OK,
         customValidering: (felt: FeltState<string>) => {
             return erBarnRegistrertFraFør(søknad, felt.verdi)
-                ? feil(
-                      felt,
-                      <TekstBlock
-                          block={teksterForModal.sammeFoedselsnummerFeilmelding}
-                          typografi={Typografi.ErrorMessage}
-                      />
-                  )
+                ? feil(felt, plainTekst(teksterForModal.sammeFoedselsnummerFeilmelding))
                 : ok(felt);
         },
     });

--- a/src/frontend/typer/common.ts
+++ b/src/frontend/typer/common.ts
@@ -35,6 +35,5 @@ export enum Typografi {
     BodyShort = 'BodyShort',
     Label = 'Label',
     Detail = 'Detail',
-    ErrorMessage = 'ErrorMessage',
     HeadingH2 = 'HeadingH2',
 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Fikser feil styling på feilmeldinger på velg-barn modalen. Vi kommer nok ikke til å bruke den feilmelding-typografien foreløpig, så bare fjernet den helt til vi eventuelt skulle trenger den en dag

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
FØR:

![image](https://user-images.githubusercontent.com/8656966/212631394-33e6109b-fd82-4536-86b3-637959594af8.png)


ETTER:
![Screenshot 2023-01-16 at 09 17 47](https://user-images.githubusercontent.com/8656966/212631435-80491715-9578-4698-93ff-0dc5f47f7179.png)

