### PR TITLE
Fjerner vedleggsnotis dersom barn er adoptert

### DIFF
--- a/src/frontend/components/SøknadsSteg/OmBarnaDine/OmBarnaDine.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnaDine/OmBarnaDine.tsx
@@ -124,15 +124,6 @@ const OmBarnaDine: React.FC = () => {
                     nullstillValgteBarn={skjema.felter.erBarnAdoptert.verdi === ESvar.NEI}
                     visFeilmelding={skjema.visFeilmeldinger}
                 />
-                {skjema.felter.erBarnAdoptert.verdi === ESvar.JA && (
-                    <VedleggNotisWrapper>
-                        <VedleggNotis dynamisk>
-                            <BodyShort>
-                                {plainTekst(adoptertKontantstoette.vedleggsnotis)}
-                            </BodyShort>
-                        </VedleggNotis>
-                    </VedleggNotisWrapper>
-                )}
                 <JaNeiSpm
                     skjema={skjema}
                     felt={skjema.felter.søktAsylForBarn}


### PR DESCRIPTION
Vi har fjernet teksten `adoptertKontantstoette.vedleggsnotis` fra Sanity etter beskjed fra fag. Fjerner derfor også koden som forsøker å hente teksten fra frontend.
