### PR TITLE
Viser varsel dersom valgt barn er under 11 mnd

### DIFF
--- a/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/Barnekort.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { Checkbox } from 'nav-frontend-skjema';
 
-import { Heading } from '@navikt/ds-react';
+import { Alert, Heading } from '@navikt/ds-react';
 import {
     NavdsGlobalColorGray100,
     NavdsGlobalColorPurple400,
@@ -72,6 +72,10 @@ const StyledHeading = styled(Heading)`
     margin-bottom: 1rem;
 `;
 
+const StyledWarningAlert = styled(Alert)`
+    margin-top: 1.5rem;
+`;
+
 const Barnekort: React.FC<IBarnekortProps> = ({
     barn,
     velgBarnCallback,
@@ -92,6 +96,7 @@ const Barnekort: React.FC<IBarnekortProps> = ({
         soekOmYtelseForBarnetSjekkboks,
         foedselsnummerLabel,
         navnErstatterForAdressesperre,
+        under1Aar,
     } = teksterForSteg;
 
     const erMedISøknad = !!barnSomSkalVæreMed.find(barnMedISøknad => barnMedISøknad.id === barn.id);
@@ -139,6 +144,11 @@ const Barnekort: React.FC<IBarnekortProps> = ({
                     onChange={() => velgBarnCallback(barn, erMedISøknad)}
                     data-testid={'velg-barn-checkbox'}
                 />
+                {erMedISøknad && barn.erUnder11Mnd && (
+                    <StyledWarningAlert inline variant={'warning'}>
+                        <TekstBlock block={under1Aar} />
+                    </StyledWarningAlert>
+                )}
             </InformasjonsboksInnhold>
             {erRegistrertManuelt && (
                 <FjernBarnKnapp barnId={barn.id} fjernBarnCallback={fjernBarnCallback} />

--- a/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/FjernBarnKnapp.test.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/Barnekort/FjernBarnKnapp.test.tsx
@@ -28,6 +28,7 @@ describe('FjernBarnKnapp', () => {
             navn: 'Test',
             borMedSøker: true,
             alder: null,
+            erUnder11Mnd: false,
             adressebeskyttelse: false,
         };
         const pdlBarn: IBarn = {
@@ -36,6 +37,7 @@ describe('FjernBarnKnapp', () => {
             navn: 'Også test',
             borMedSøker: true,
             alder: null,
+            erUnder11Mnd: false,
             adressebeskyttelse: false,
         };
 
@@ -66,6 +68,7 @@ describe('FjernBarnKnapp', () => {
             navn: 'Test',
             borMedSøker: true,
             alder: null,
+            erUnder11Mnd: false,
             adressebeskyttelse: false,
         };
 

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/useLeggTilBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/useLeggTilBarn.tsx
@@ -133,6 +133,7 @@ export const useLeggTilBarn = (): {
                     ident: ident.verdi,
                     borMedSøker: undefined,
                     alder: null,
+                    erUnder11Mnd: false,
                     adressebeskyttelse: false,
                 },
             ]),

--- a/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/useLeggTilBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/LeggTilBarn/useLeggTilBarn.tsx
@@ -15,8 +15,14 @@ import { ESvarMedUbesvart, LocaleRecordBlock } from '../../../../typer/common';
 import { ILeggTilBarnTekstinnhold } from '../../../../typer/sanity/modaler/leggTilBarn';
 import { ESanitySteg } from '../../../../typer/sanity/sanity';
 import { ILeggTilBarnTyper } from '../../../../typer/skjema';
-import { erBarnRegistrertFraFør, hentUid } from '../../../../utils/barn';
+import {
+    erBarnRegistrertFraFør,
+    erBarnUnder11Mnd,
+    hentAlder,
+    hentUid,
+} from '../../../../utils/barn';
 import { trimWhiteSpace } from '../../../../utils/hjelpefunksjoner';
+import { identTilFødselsdato } from '../../../../utils/ident';
 import { VelgBarnSpørsmålId } from '../spørsmål';
 
 export const useLeggTilBarn = (): {
@@ -26,7 +32,7 @@ export const useLeggTilBarn = (): {
     nullstillSkjema: () => void;
     leggTilBarn: () => void;
 } => {
-    const { søknad, settSøknad, mellomlagre, tekster, plainTekst } = useApp();
+    const { søknad, settSøknad, tekster, plainTekst } = useApp();
 
     const teksterForModal: ILeggTilBarnTekstinnhold =
         tekster()[ESanitySteg.FELLES].modaler.leggTilBarn;
@@ -124,6 +130,7 @@ export const useLeggTilBarn = (): {
     };
 
     const leggTilBarn = () => {
+        const fødselsdato = identTilFødselsdato(ident.verdi);
         settSøknad({
             ...søknad,
             barnRegistrertManuelt: søknad.barnRegistrertManuelt.concat([
@@ -132,14 +139,13 @@ export const useLeggTilBarn = (): {
                     navn: fulltNavn() || plainTekst(navnIkkeBestemtTekst),
                     ident: ident.verdi,
                     borMedSøker: undefined,
-                    alder: null,
-                    erUnder11Mnd: false,
+                    alder: hentAlder(fødselsdato),
+                    erUnder11Mnd: erBarnUnder11Mnd(fødselsdato),
                     adressebeskyttelse: false,
                 },
             ]),
         });
         nullstillSkjema();
-        mellomlagre();
     };
 
     return {

--- a/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import Masonry from 'react-masonry-css';
 import styled from 'styled-components';
 
+import { Alert } from '@navikt/ds-react';
+
 import { useApp } from '../../../context/AppContext';
 import { Typografi } from '../../../typer/common';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
@@ -30,6 +32,10 @@ const LenkeContainer = styled.div`
     margin-top: 1.5rem;
 `;
 
+const StyledWarningAlert = styled(Alert)`
+    margin-top: 1.5rem;
+`;
+
 const VelgBarn: React.FC = () => {
     const { søknad, tekster } = useApp();
     const { toggleModal, erÅpen } = useModal();
@@ -46,10 +52,15 @@ const VelgBarn: React.FC = () => {
     const barnFraRespons = søknad.søker.barn;
     const barnManueltLagtTil = søknad.barnRegistrertManuelt;
     const barn = barnFraRespons.concat(barnManueltLagtTil);
+    const finnesBarnUnder1År = barnSomSkalVæreMed.some(barn => barn.erUnder11Mnd);
 
     const teksterForSteg: IVelgBarnTekstinnhold = tekster()[ESanitySteg.VELG_BARN];
-    const { velgBarnTittel, hvisOpplysningeneIkkeStemmer, leseMerOmRegleneKontantstoette } =
-        teksterForSteg;
+    const {
+        velgBarnTittel,
+        hvisOpplysningeneIkkeStemmer,
+        leseMerOmRegleneKontantstoette,
+        kanIkkeBestemmeRettUnder1Aar,
+    } = teksterForSteg;
 
     return (
         <>
@@ -90,6 +101,13 @@ const VelgBarn: React.FC = () => {
                     ))}
                     <NyttBarnKort onLeggTilBarn={toggleModal} />
                 </BarnekortContainer>
+
+                {finnesBarnUnder1År && (
+                    <StyledWarningAlert inline variant={'warning'}>
+                        <TekstBlock block={kanIkkeBestemmeRettUnder1Aar} />
+                    </StyledWarningAlert>
+                )}
+
                 <LenkeContainer>
                     <TekstBlock block={leseMerOmRegleneKontantstoette} />
                 </LenkeContainer>

--- a/src/frontend/components/SøknadsSteg/VelgBarn/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/innholdTyper.ts
@@ -16,4 +16,6 @@ export interface IVelgBarnTekstinnhold {
     navnErstatterForAdressesperre: LocaleRecordBlock;
     maaVelgeEtBarnForAaGaaVidere: LocaleRecordBlock;
     navnIkkeBestemtLabel: LocaleRecordBlock;
+    under1Aar: LocaleRecordBlock;
+    kanIkkeBestemmeRettUnder1Aar: LocaleRecordBlock;
 }

--- a/src/frontend/components/SøknadsSteg/VelgBarn/useVelgBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/useVelgBarn.tsx
@@ -38,6 +38,10 @@ export const useVelgBarn = (): {
         settBarnForSteg(barnSomSkalVæreMed);
     }, [barnSomSkalVæreMed]);
 
+    useEffect(() => {
+        mellomlagre();
+    }, [søknad.barnRegistrertManuelt]);
+
     const fjernBarn = (id: BarnetsId) => {
         settSøknad({
             ...søknad,
@@ -45,7 +49,6 @@ export const useVelgBarn = (): {
         });
         settBarnSomSkalVæreMed(barnSomSkalVæreMed.filter(barn => id !== barn.id));
         settBarnSomTriggerEøs(prevState => prevState.filter(barnetsId => id !== barnetsId));
-        mellomlagre();
     };
 
     const barnMedISøknad = useFelt<IBarn[]>({

--- a/src/frontend/typer/person.ts
+++ b/src/frontend/typer/person.ts
@@ -36,6 +36,7 @@ export interface IBarn extends IPerson {
     navn: string;
     borMedSøker: boolean | undefined;
     alder: string | null;
+    erUnder11Mnd: boolean;
 }
 
 export interface IIdNummer {

--- a/src/frontend/typer/skjema.ts
+++ b/src/frontend/typer/skjema.ts
@@ -140,7 +140,13 @@ export interface IVelgBarnFeltTyper {
 export interface ILeggTilBarnTyper
     extends Omit<
         IBarn,
-        'borMedSøker' | 'alder' | 'navn' | 'adressebeskyttelse' | 'id' | barnDataKeySpørsmål
+        | 'borMedSøker'
+        | 'alder'
+        | 'erUnder11Mnd'
+        | 'navn'
+        | 'adressebeskyttelse'
+        | 'id'
+        | barnDataKeySpørsmål
     > {
     erFødt: ESvarMedUbesvart;
     fornavn: string;

--- a/src/frontend/utils/barn.ts
+++ b/src/frontend/utils/barn.ts
@@ -122,6 +122,17 @@ export const hentAlder = (dato: string): string => {
     return alder.toString();
 };
 
+export const erBarnUnder11Mnd = (dato: string): boolean => {
+    const idag = new Date();
+    const fødselsdato = new Date(dato);
+    const differanseIMnd =
+        idag.getMonth() -
+        fødselsdato.getMonth() +
+        (idag.getFullYear() - fødselsdato.getFullYear()) * 12 -
+        (idag.getDate() - fødselsdato.getDate() < 0 ? 1 : 0);
+    return differanseIMnd < 11;
+};
+
 export const erBarnRegistrertFraFør = (søknad: ISøknad, ident: string) => {
     const barnFraPdl = søknad.søker.barn.find(barn => barn.ident === ident);
     const barnRegistrertManuelt = søknad.barnRegistrertManuelt.find(barn => barn.ident === ident);
@@ -240,6 +251,7 @@ export const mapBarnResponsTilBarn = (
         navn: barnetsNavnValue(barnRespons, tekster, plainTekst),
         ident: barnRespons.ident,
         alder: barnRespons.fødselsdato ? hentAlder(barnRespons.fødselsdato) : null,
+        erUnder11Mnd: barnRespons.fødselsdato ? erBarnUnder11Mnd(barnRespons.fødselsdato) : false,
         borMedSøker: barnRespons.borMedSøker,
         adressebeskyttelse: barnRespons.adressebeskyttelse,
     }));

--- a/src/frontend/utils/ident.test.ts
+++ b/src/frontend/utils/ident.test.ts
@@ -1,0 +1,19 @@
+import { identTilFødselsdato } from './ident';
+
+describe('finnFødselsdatoFraIdent', () => {
+    test('Skal finne fødselsdato for HNR', () => {
+        expect(identTilFødselsdato('13527248013')).toEqual('1972-12-13');
+    });
+
+    test('Skal finne fødselsdato for DNR', () => {
+        expect(identTilFødselsdato('64012252500')).toEqual('2022-01-24');
+    });
+
+    test('Skal finne fødselsdato for FNR', () => {
+        expect(identTilFødselsdato('24012252500')).toEqual('2022-01-24');
+    });
+
+    test('Skal finne fødselsdato for TNR', () => {
+        expect(identTilFødselsdato('10915596784')).toEqual('1955-11-10');
+    });
+});

--- a/src/frontend/utils/ident.ts
+++ b/src/frontend/utils/ident.ts
@@ -1,0 +1,89 @@
+enum IdentType {
+    DNR_AND_HNR,
+    DNR,
+    TNR,
+    HNR,
+    FNR,
+}
+
+// Kopiert fra https://github.com/navikt/fnrvalidator/blob/master/src/validator.js
+const getIdentType = (digits: string): IdentType => {
+    if (Number(digits.substring(0, 1)) >= 4 && Number(digits.substring(2, 3)) >= 4) {
+        return IdentType.DNR_AND_HNR;
+    } else if (Number(digits.substring(0, 1)) >= 4) {
+        return IdentType.DNR;
+    } else if (Number(digits.substring(2, 3)) >= 8) {
+        return IdentType.TNR;
+    } else if (Number(digits.substring(2, 3)) >= 4) {
+        return IdentType.HNR;
+    }
+    return IdentType.FNR;
+};
+// Kopiert fra https://github.com/navikt/fnrvalidator/blob/master/src/validator.js
+export const identTilFødselsdato = (ident: string): string => {
+    const type = getIdentType(ident);
+    console.log(type);
+    let fnr = '';
+    switch (type) {
+        case IdentType.DNR:
+            fnr = Number(ident.substring(0, 1)) - 4 + ident.substring(1);
+            break;
+        case IdentType.HNR:
+            fnr = ident.substring(0, 2) + (Number(ident.substring(2, 3)) - 4) + ident.substring(3);
+            break;
+        case IdentType.TNR:
+            fnr = ident.substring(0, 2) + (Number(ident.substring(2, 3)) - 8) + ident.substring(3);
+            break;
+        case IdentType.DNR_AND_HNR:
+            fnr =
+                Number(ident.substring(0, 1)) -
+                4 +
+                ident.substring(1, 2) +
+                (Number(ident.substring(2, 3)) - 4) +
+                ident.substring(3);
+            break;
+        default:
+            fnr = ident;
+    }
+
+    const dag = Number(fnr.substring(0, 2));
+    const mnd = Number(fnr.substring(2, 4));
+    const år = Number(fnr.substring(4, 6));
+    const individnummer = Number(fnr.substring(6, 9));
+
+    const fulltÅrstall = bestemÅrstall(år, individnummer);
+
+    return datoTilDatoString(fulltÅrstall, mnd, dag);
+};
+
+// https://www.skatteetaten.no/person/folkeregister/fodsel-og-navnevalg/barn-fodt-i-norge/fodselsnummer/
+const bestemÅrstall = (fødselsårIFnr: number, individNummer: number): number => {
+    if (individnummerGyldigForIntervallOgÅr(500, 759, individNummer, () => fødselsårIFnr > 54)) {
+        return 1800 + fødselsårIFnr;
+    } else if (individnummerGyldigForIntervallOgÅr(0, 499, individNummer)) {
+        return 1900 + fødselsårIFnr;
+    } else if (
+        individnummerGyldigForIntervallOgÅr(900, 999, individNummer, () => fødselsårIFnr > 39)
+    ) {
+        return 1900 + fødselsårIFnr;
+    } else if (
+        individnummerGyldigForIntervallOgÅr(500, 999, individNummer, () => fødselsårIFnr < 40)
+    ) {
+        return 2000 + fødselsårIFnr;
+    } else {
+        throw new Error('Individnummer og fødselsår i fnr passer ikke inn i gyldige intervaller');
+    }
+};
+
+const individnummerGyldigForIntervallOgÅr = (
+    min: number,
+    max: number,
+    individNummer: number,
+    triggerForFødselsår?: () => boolean
+): boolean =>
+    individNummer >= min &&
+    individNummer <= max &&
+    (triggerForFødselsår ? triggerForFødselsår() : true);
+
+const datoTilDatoString = (år: number, mnd: number, dag: number) =>
+    år + '-' + ('0' + mnd).slice(-2) + '-' + ('0' + dag).slice(-2);


### PR DESCRIPTION
Utleder feltet `erUnder11Mnd` fra fødselsdato og bruker det til å bestemme om vi skal vise alders-varsel på "Velg barn"-steget.

![image](https://user-images.githubusercontent.com/70642183/214009807-4a38af8c-a886-4812-ada5-526bc48f6044.png)

