### PR TITLE
Fjernet referanser til dockerstuff

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,6 @@
 node_modules/
 build/
 dist/
-dockerstuff/
-docker-compose.yml
 .git/
 .idea/
 .vscode/

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "test": "jest",
     "start": "NODE_ENV=production node --es-module-specifier-resolution=node build/backend/server.js",
     "clean": "rm -rf dist build",
-    "typecheck": "tsc --noEmit -p src/frontend/tsconfig.json",
-    "setup:docker:env": "node dockerstuff/dcp-configurator.js"
+    "typecheck": "tsc --noEmit -p src/frontend/tsconfig.json"
   },
   "jest": {
     "roots": [


### PR DESCRIPTION
Vi bruker ikke lenger noe som lå i mappa `dockerstuff`. Fjerner derfor alle referanser din den mappa.