### PR TITLE
Fjern import av IsoDateString fra ekstern pakke

### DIFF
--- a/src/frontend/components/Felleskomponenter/Datovelger/Datovelger.tsx
+++ b/src/frontend/components/Felleskomponenter/Datovelger/Datovelger.tsx
@@ -8,15 +8,12 @@ import { Feilmelding } from 'nav-frontend-typografi';
 
 import { BodyShort } from '@navikt/ds-react';
 import { ARed500 } from '@navikt/ds-tokens/dist/tokens';
-import {
-    DatepickerLimitations,
-    FamilieDatovelger,
-    ISODateString,
-} from '@navikt/familie-form-elements';
+import { DatepickerLimitations, FamilieDatovelger } from '@navikt/familie-form-elements';
 import { Felt, ISkjema } from '@navikt/familie-skjema';
 import { useSprakContext } from '@navikt/familie-sprakvelger';
 
 import { useApp } from '../../../context/AppContext';
+import { ISODateString } from '../../../typer/common';
 import { SkjemaFeltTyper } from '../../../typer/skjema';
 import { dagensDato } from '../../../utils/dato';
 

--- a/src/frontend/hooks/useDatovelgerFelt.ts
+++ b/src/frontend/hooks/useDatovelgerFelt.ts
@@ -1,8 +1,7 @@
-import { ISODateString } from '@navikt/familie-form-elements';
 import { Avhengigheter, useFelt } from '@navikt/familie-skjema';
 
 import { useApp } from '../context/AppContext';
-import { LocaleRecordBlock } from '../typer/common';
+import { ISODateString, LocaleRecordBlock } from '../typer/common';
 import { ISøknadSpørsmål } from '../typer/spørsmål';
 import { validerDato } from '../utils/dato';
 

--- a/src/frontend/hooks/useDatovelgerFeltMedJaNeiAvhengighet.ts
+++ b/src/frontend/hooks/useDatovelgerFeltMedJaNeiAvhengighet.ts
@@ -1,10 +1,10 @@
 import { useEffect } from 'react';
 
-import { ESvar, ISODateString } from '@navikt/familie-form-elements';
+import { ESvar } from '@navikt/familie-form-elements';
 import { Felt, useFelt } from '@navikt/familie-skjema';
 
 import { useApp } from '../context/AppContext';
-import { LocaleRecordBlock } from '../typer/common';
+import { ISODateString, LocaleRecordBlock } from '../typer/common';
 import { ISøknadSpørsmål } from '../typer/spørsmål';
 import { validerDato } from '../utils/dato';
 

--- a/src/frontend/hooks/useDatovelgerFeltMedUkjent.ts
+++ b/src/frontend/hooks/useDatovelgerFeltMedUkjent.ts
@@ -1,10 +1,10 @@
 import { useEffect } from 'react';
 
-import { ESvar, ISODateString } from '@navikt/familie-form-elements';
+import { ESvar } from '@navikt/familie-form-elements';
 import { Avhengigheter, Felt, FeltState, ok, useFelt } from '@navikt/familie-skjema';
 
 import { useApp } from '../context/AppContext';
-import { LocaleRecordBlock } from '../typer/common';
+import { ISODateString, LocaleRecordBlock } from '../typer/common';
 import { validerDato } from '../utils/dato';
 
 const useDatovelgerFeltMedUkjent = ({

--- a/src/frontend/hooks/useJaNeiSpmFelt.test.ts
+++ b/src/frontend/hooks/useJaNeiSpmFelt.test.ts
@@ -2,11 +2,11 @@ import { renderHook } from '@testing-library/react-hooks';
 import { Alpha3Code } from 'i18n-iso-countries';
 import { mock } from 'jest-mock-extended';
 
-import { ESvar, ISODateString } from '@navikt/familie-form-elements';
+import { ESvar } from '@navikt/familie-form-elements';
 import { Felt, Valideringsstatus } from '@navikt/familie-skjema';
 
 import { OmDegSpørsmålId } from '../components/SøknadsSteg/OmDeg/spørsmål';
-import { LocaleRecordBlock } from '../typer/common';
+import { ISODateString, LocaleRecordBlock } from '../typer/common';
 import { ISøknadSpørsmål } from '../typer/spørsmål';
 import useJaNeiSpmFelt, { erRelevanteAvhengigheterValidert } from './useJaNeiSpmFelt';
 

--- a/src/frontend/typer/common.ts
+++ b/src/frontend/typer/common.ts
@@ -1,9 +1,8 @@
 import { PortableTextBlock } from '@portabletext/types';
 
-import { ESvar, ISODateString } from '@navikt/familie-form-elements';
 import { LocaleType } from '@navikt/familie-sprakvelger';
 
-export type ESvarMedUbesvart = ESvar | null;
+export type ISODateString = string;
 
 export enum AlternativtSvarForInput {
     UKJENT = 'UKJENT',

--- a/src/frontend/typer/kontrakt/v1.ts
+++ b/src/frontend/typer/kontrakt/v1.ts
@@ -1,7 +1,8 @@
-import { ESvar, ISODateString } from '@navikt/familie-form-elements';
+import { ESvar } from '@navikt/familie-form-elements';
 import { LocaleType } from '@navikt/familie-sprakvelger';
 
 import { barnDataKeySpørsmål } from '../barn';
+import { ISODateString } from '../common';
 import { ISøknadKontraktDokumentasjon } from './dokumentasjon';
 import {
     ERegistrertBostedType,

--- a/src/frontend/typer/perioder.ts
+++ b/src/frontend/typer/perioder.ts
@@ -1,9 +1,9 @@
 import { Alpha3Code } from 'i18n-iso-countries';
 
-import { ESvar, ISODateString } from '@navikt/familie-form-elements';
+import { ESvar } from '@navikt/familie-form-elements';
 
 import { EBarnehageplassPeriodeBeskrivelse } from '../components/Felleskomponenter/Barnehagemodal/barnehageplassTyper';
-import { AlternativtSvarForInput, DatoMedUkjent } from './common';
+import { AlternativtSvarForInput, DatoMedUkjent, ISODateString } from './common';
 import { ISøknadSpørsmål } from './spørsmål';
 import { EUtenlandsoppholdÅrsak } from './utenlandsopphold';
 

--- a/src/frontend/typer/skjema.ts
+++ b/src/frontend/typer/skjema.ts
@@ -1,10 +1,10 @@
 import { Alpha3Code } from 'i18n-iso-countries';
 
-import { ESvar, ISODateString } from '@navikt/familie-form-elements';
+import { ESvar } from '@navikt/familie-form-elements';
 
 import { EBarnehageplassPeriodeBeskrivelse } from '../components/Felleskomponenter/Barnehagemodal/barnehageplassTyper';
 import { barnDataKeySpørsmål } from './barn';
-import { AlternativtSvarForInput, BarnetsId, DatoMedUkjent } from './common';
+import { AlternativtSvarForInput, BarnetsId, DatoMedUkjent, ISODateString } from './common';
 import { Slektsforhold } from './kontrakt/generelle';
 import {
     IArbeidsperiode,

--- a/src/frontend/utils/dato.tsx
+++ b/src/frontend/utils/dato.tsx
@@ -1,9 +1,13 @@
 import dayjs from 'dayjs';
 
-import { ISODateString } from '@navikt/familie-form-elements';
 import { feil, FeltState, ok } from '@navikt/familie-skjema';
 
-import { AlternativtSvarForInput, DatoMedUkjent, LocaleRecordBlock } from '../typer/common';
+import {
+    AlternativtSvarForInput,
+    DatoMedUkjent,
+    ISODateString,
+    LocaleRecordBlock,
+} from '../typer/common';
 import { PlainTekst } from '../typer/kontrakt/generelle';
 import { IFormateringsfeilmeldingerTekstinnhold } from '../typer/sanity/tekstInnhold';
 

--- a/src/frontend/utils/perioder.ts
+++ b/src/frontend/utils/perioder.ts
@@ -1,5 +1,4 @@
-import { ISODateString } from '@navikt/familie-form-elements';
-
+import { ISODateString } from '../typer/common';
 import { dagenEtterDato, dagensDato, erSammeDatoSomDagensDato, morgendagensDato } from './dato';
 
 export const minTilDatoForUtbetalingEllerArbeidsperiode = (

--- a/src/frontend/utils/utenlandsopphold.tsx
+++ b/src/frontend/utils/utenlandsopphold.tsx
@@ -1,5 +1,4 @@
-import { ISODateString } from '@navikt/familie-form-elements';
-
+import { ISODateString } from '../typer/common';
 import { IUtenlandsperiode } from '../typer/perioder';
 import { EUtenlandsoppholdÅrsak } from '../typer/utenlandsopphold';
 import { dagensDato, ettÅrTilbakeDato, gårsdagensDato } from './dato';


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Som et forsteg til en stor endring av DatePicker ønsker vi å fjerne bruken av ekstern IsoDateString