### PR TITLE
Erstattet feilmeldinger i modal med feilmeldinger under filopplastingsboks

### DIFF
--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/Filopplaster.tsx
@@ -6,14 +6,11 @@ import styled from 'styled-components';
 import { Normaltekst } from 'nav-frontend-typografi';
 
 import { Upload } from '@navikt/ds-icons';
-import { Modal } from '@navikt/ds-react';
 import { ABlue500, ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
 
 import { useApp } from '../../../../context/AppContext';
 import { IDokumentasjon, IVedlegg } from '../../../../typer/dokumentasjon';
 import { Dokumentasjonsbehov } from '../../../../typer/kontrakt/dokumentasjon';
-import AlertStripe from '../../../Felleskomponenter/AlertStripe/AlertStripe';
-import ModalContent from '../../../Felleskomponenter/ModalContent';
 import OpplastedeFiler from './OpplastedeFiler';
 import { useFilopplaster } from './useFilopplaster';
 
@@ -28,11 +25,15 @@ interface Props {
     maxFilstørrelse: number;
 }
 
-const FilopplastningBoks = styled.button`
+interface FilopplastningBoksProps {
+    harFeil: boolean;
+}
+
+const FilopplastningBoks = styled.button<FilopplastningBoksProps>`
     display: flex;
     justify-content: center;
     align-items: center;
-    border: 2px dashed ${ABorderDefault};
+    border: 2px dashed ${props => (props.harFeil ? '#ba3a26' : ABorderDefault)};
     border-radius: 4px;
     background-color: rgba(204, 222, 230, 0.5);
     width: 100%;
@@ -43,7 +44,7 @@ const FilopplastningBoks = styled.button`
 
     :focus,
     :hover {
-        border: 2px solid ${ABlue500};
+        border: 2px solid ${props => (props.harFeil ? '#ba3a26' : ABlue500)};
         cursor: pointer;
     }
 `;
@@ -53,8 +54,11 @@ const StyledUpload = styled(Upload)`
     min-width: 1rem;
 `;
 
-const FeilmeldingWrapper = styled.div`
-    margin-right: 3rem;
+const StyledFeilmeldingList = styled.ul`
+    > li {
+        font-weight: 600;
+        color: #ba3a26;
+    }
 `;
 
 const Filopplaster: React.FC<Props> = ({
@@ -63,7 +67,7 @@ const Filopplaster: React.FC<Props> = ({
     tillatteFiltyper,
     maxFilstørrelse,
 }) => {
-    const { onDrop, åpenModal, lukkModal, feilmeldinger, slettVedlegg } = useFilopplaster(
+    const { onDrop, åpenModal, feilmeldinger, slettVedlegg } = useFilopplaster(
         maxFilstørrelse,
         dokumentasjon,
         oppdaterDokumentasjon
@@ -75,29 +79,27 @@ const Filopplaster: React.FC<Props> = ({
     const { tekster, plainTekst } = useApp();
     const { lastOppKnapp, slippFilenHer } = tekster().DOKUMENTASJON;
 
+    const feilmeldingListe = Array.from(feilmeldinger).map(([key, value], index) => (
+        <li key={index}>
+            {plainTekst(key)}
+            {
+                <ul>
+                    {value.map((fil, index) => (
+                        <li key={index}>{fil.name}</li>
+                    ))}
+                </ul>
+            }
+        </li>
+    ));
+
     return (
         <>
-            <Modal
-                open={åpenModal}
-                onClose={() => lukkModal()}
-                closeButton={true}
-                aria-label={plainTekst(lastOppKnapp)}
-            >
-                <ModalContent>
-                    <FeilmeldingWrapper>
-                        {feilmeldinger.map((feilmelding, index) => (
-                            <AlertStripe variant={'error'} key={index} inline={false}>
-                                {feilmelding}
-                            </AlertStripe>
-                        ))}
-                    </FeilmeldingWrapper>
-                </ModalContent>
-            </Modal>
-            <FilopplastningBoks type={'button'} {...getRootProps()}>
+            <FilopplastningBoks type={'button'} {...getRootProps()} harFeil={åpenModal}>
                 <input {...getInputProps()} />
                 <StyledUpload focusable={false} />
                 <Normaltekst>{plainTekst(isDragActive ? slippFilenHer : lastOppKnapp)}</Normaltekst>
             </FilopplastningBoks>
+            {åpenModal && <StyledFeilmeldingList>{feilmeldingListe}</StyledFeilmeldingList>}
             <OpplastedeFiler
                 filliste={dokumentasjon.opplastedeVedlegg}
                 slettVedlegg={slettVedlegg}

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/Filopplaster.tsx
@@ -55,6 +55,7 @@ const StyledUpload = styled(Upload)`
 `;
 
 const StyledFeilmeldingList = styled.ul`
+    padding-inline-start: 1.25rem;
     > li {
         font-weight: 600;
         color: #ba3a26;
@@ -67,7 +68,7 @@ const Filopplaster: React.FC<Props> = ({
     tillatteFiltyper,
     maxFilstørrelse,
 }) => {
-    const { onDrop, åpenModal, feilmeldinger, slettVedlegg } = useFilopplaster(
+    const { onDrop, harFeil, feilmeldinger, slettVedlegg } = useFilopplaster(
         maxFilstørrelse,
         dokumentasjon,
         oppdaterDokumentasjon
@@ -79,31 +80,33 @@ const Filopplaster: React.FC<Props> = ({
     const { tekster, plainTekst } = useApp();
     const { lastOppKnapp, slippFilenHer } = tekster().DOKUMENTASJON;
 
-    const feilmeldingListe = Array.from(feilmeldinger).map(([key, value], index) => (
-        <li key={index}>
-            {plainTekst(key)}
-            {
-                <ul>
-                    {value.map((fil, index) => (
-                        <li key={index}>{fil.name}</li>
-                    ))}
-                </ul>
-            }
-        </li>
-    ));
-
     return (
         <>
-            <FilopplastningBoks type={'button'} {...getRootProps()} harFeil={åpenModal}>
+            <FilopplastningBoks type={'button'} {...getRootProps()} harFeil={harFeil}>
                 <input {...getInputProps()} />
                 <StyledUpload focusable={false} />
                 <Normaltekst>{plainTekst(isDragActive ? slippFilenHer : lastOppKnapp)}</Normaltekst>
             </FilopplastningBoks>
-            {åpenModal && <StyledFeilmeldingList>{feilmeldingListe}</StyledFeilmeldingList>}
             <OpplastedeFiler
                 filliste={dokumentasjon.opplastedeVedlegg}
                 slettVedlegg={slettVedlegg}
             />
+            {harFeil && (
+                <StyledFeilmeldingList>
+                    {Array.from(feilmeldinger).map(([key, value], index) => (
+                        <li key={index}>
+                            {plainTekst(key)}
+                            {
+                                <StyledFeilmeldingList>
+                                    {value.map((fil, index) => (
+                                        <li key={index}>{fil.name}</li>
+                                    ))}
+                                </StyledFeilmeldingList>
+                            }
+                        </li>
+                    ))}
+                </StyledFeilmeldingList>
+            )}
         </>
     );
 };

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/useFilopplaster.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/useFilopplaster.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import axios from 'axios';
 import { FileRejection } from 'react-dropzone';
@@ -39,9 +39,9 @@ export const useFilopplaster = (
     ) => void
 ) => {
     const { wrapMedSystemetLaster } = useLastRessurserContext();
-    const { tekster, plainTekst } = useApp();
+    const { tekster } = useApp();
     const [feilmeldinger, settFeilmeldinger] = useState<Map<LocaleRecordString, File[]>>(new Map());
-    const [åpenModal, settÅpenModal] = useState<boolean>(false);
+    const [harFeil, settHarFeil] = useState<boolean>(false);
 
     const dokumentasjonTekster = tekster().DOKUMENTASJON;
 
@@ -52,7 +52,6 @@ export const useFilopplaster = (
 
     const onDrop = useCallback(
         async (filer: File[], filRejections: FileRejection[]) => {
-            const feilmeldingsliste: ReactNode[] = [];
             const nyeVedlegg: IVedlegg[] = [];
             const feilmeldingMap: Map<LocaleRecordString, File[]> = new Map();
 
@@ -65,9 +64,6 @@ export const useFilopplaster = (
                     filer.push(fil);
                     feilmeldingMap.set(feilmelding, filer);
                 }
-                feilmeldingsliste.push(
-                    `${plainTekst(feilmelding)} ${plainTekst(dokumentasjonTekster.fil)} ${fil.name}`
-                );
             };
 
             if (filRejections.length > 0) {
@@ -127,7 +123,7 @@ export const useFilopplaster = (
 
             if (feilmeldingMap.size > 0) {
                 settFeilmeldinger(feilmeldingMap);
-                settÅpenModal(true);
+                settHarFeil(true);
             }
 
             oppdaterDokumentasjon(
@@ -150,16 +146,10 @@ export const useFilopplaster = (
         );
     };
 
-    const lukkModal = () => {
-        settÅpenModal(false);
-    };
-
     return {
         onDrop,
-        åpenModal,
-        settÅpenModal,
+        harFeil,
         feilmeldinger,
         slettVedlegg,
-        lukkModal,
     };
 };

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/useFilopplaster.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/useFilopplaster.tsx
@@ -40,7 +40,7 @@ export const useFilopplaster = (
 ) => {
     const { wrapMedSystemetLaster } = useLastRessurserContext();
     const { tekster, plainTekst } = useApp();
-    const [feilmeldinger, settFeilmeldinger] = useState<ReactNode[]>([]);
+    const [feilmeldinger, settFeilmeldinger] = useState<Map<LocaleRecordString, File[]>>(new Map());
     const [åpenModal, settÅpenModal] = useState<boolean>(false);
 
     const dokumentasjonTekster = tekster().DOKUMENTASJON;
@@ -54,8 +54,17 @@ export const useFilopplaster = (
         async (filer: File[], filRejections: FileRejection[]) => {
             const feilmeldingsliste: ReactNode[] = [];
             const nyeVedlegg: IVedlegg[] = [];
+            const feilmeldingMap: Map<LocaleRecordString, File[]> = new Map();
 
             const pushFeilmelding = (feilmelding: LocaleRecordString, fil: File) => {
+                if (!feilmeldingMap.has(feilmelding)) {
+                    feilmeldingMap.set(feilmelding, []);
+                }
+                const filer = feilmeldingMap.get(feilmelding);
+                if (filer) {
+                    filer.push(fil);
+                    feilmeldingMap.set(feilmelding, filer);
+                }
                 feilmeldingsliste.push(
                     `${plainTekst(feilmelding)} ${plainTekst(dokumentasjonTekster.fil)} ${fil.name}`
                 );
@@ -116,8 +125,8 @@ export const useFilopplaster = (
                 )
             );
 
-            if (feilmeldingsliste.length > 0) {
-                settFeilmeldinger(feilmeldingsliste);
+            if (feilmeldingMap.size > 0) {
+                settFeilmeldinger(feilmeldingMap);
                 settÅpenModal(true);
             }
 


### PR DESCRIPTION
Tidligere poppet det opp en modal med feilmeldinger dersom opplasting av vedlegg feilet. Dette er nå erstattet med feilmeldinger under opplastingsboks.

Før:
![image](https://user-images.githubusercontent.com/70642183/220362997-c5732745-ef49-4246-b234-d21f7933bd21.png)

Nå:
Dersom man laster opp flere filer av gangen og man får feil på disse "samles" like feil:
![image](https://user-images.githubusercontent.com/70642183/220362404-0012e2b3-1d7b-4545-923f-44dea95394e7.png)

