### PR TITLE
Erstattet gammel stegindikator med ny fra ds-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,8 +213,6 @@
     "lint-staged": "^10.5.3",
     "lodash.throttle": "^4.1.1",
     "mini-css-extract-plugin": "^2.4.1",
-    "nav-frontend-stegindikator": "^2.0.1",
-    "nav-frontend-stegindikator-style": "^2.0.1",
     "nodemon": "^2.0.18",
     "prettier": "^2.6.2",
     "prop-types": "^15.7.2",

--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
@@ -91,8 +91,6 @@ const Steg: React.FC<ISteg> = ({ tittel, skjema, gåVidereCallback, children }) 
     } = useSteg();
     const { komFra, settKomFra } = useAppNavigation();
 
-    const [aktivtSteg, settAktivtSteg] = useState(hentNåværendeStegIndex());
-
     const nesteRoute = hentNesteSteg();
     const forrigeRoute = hentForrigeSteg();
     const nåværendeStegIndex = hentNåværendeStegIndex();
@@ -158,8 +156,7 @@ const Steg: React.FC<ISteg> = ({ tittel, skjema, gåVidereCallback, children }) 
                     <StegindikatorContainer>
                         <StyledStepper
                             aria-labelledby="Søknadssteg"
-                            activeStep={aktivtSteg}
-                            onStepChange={x => settAktivtSteg(x)}
+                            activeStep={hentNåværendeStegIndex()}
                             orientation="horizontal"
                             interactive={false}
                         >

--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useEffect } from 'react';
 
 import { useHistory } from 'react-router-dom';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { Stepper } from '@navikt/ds-react';
 import { ISkjema } from '@navikt/familie-skjema';
@@ -10,6 +10,7 @@ import { useApp } from '../../../context/AppContext';
 import { useAppNavigation } from '../../../context/AppNavigationContext';
 import { useSteg } from '../../../context/StegContext';
 import useFørsteRender from '../../../hooks/useFørsteRender';
+import { device } from '../../../Theme';
 import { RouteEnum } from '../../../typer/routes';
 import { SkjemaFeltTyper } from '../../../typer/skjema';
 import {
@@ -55,21 +56,34 @@ const Form = styled.form`
     width: 100%;
 `;
 
-const StegindikatorContainer = styled.div`
-    margin: 0 1rem;
-    text-align: center;
-`;
-
-const StyledStepper = styled(Stepper)`
-    display: inline-flex;
-    --navds-stepper-circle-size: 2.125rem;
-    --navds-stepper-border-width: 1px;
-    > li {
-        gap: 0;
+const kompaktStepper = () => css`
+    * {
+        font-size: 0;
+        --navds-stepper-circle-size: 0.75rem;
+        --navds-stepper-border-width: 1px;
+        > li {
+            gap: 0;
+        }
     }
 `;
 
-const StyledStepperStep = styled(Stepper.Step)``;
+const StepperContainer = styled.div<{ antallSteg: number }>`
+    margin: 0 auto;
+    display: flex;
+    justify-content: center;
+  
+    @media all and ${device.mobile} {
+       ${kompaktStepper};
+    }
+
+  ${props =>
+      props.antallSteg > 12 &&
+      css`
+          @media all and ${device.tablet} {
+              ${kompaktStepper};
+          }
+      `}
+}`;
 
 const Steg: React.FC<ISteg> = ({ tittel, skjema, gåVidereCallback, children }) => {
     const history = useHistory();
@@ -153,23 +167,23 @@ const Steg: React.FC<ISteg> = ({ tittel, skjema, gåVidereCallback, children }) 
             <header>
                 <Banner />
                 {nyesteNåværendeRoute !== RouteEnum.Kvittering && (
-                    <StegindikatorContainer>
-                        <StyledStepper
-                            aria-labelledby="Søknadssteg"
+                    <StepperContainer antallSteg={stegIndikatorObjekter.length}>
+                        <Stepper
+                            aria-label={'Søknadssteg'}
                             activeStep={hentNåværendeStegIndex()}
-                            orientation="horizontal"
+                            orientation={'horizontal'}
                             interactive={false}
                         >
-                            {stegIndikatorObjekter.map(value => (
-                                <StyledStepperStep
-                                    href="#"
+                            {stegIndikatorObjekter.map((value, index) => (
+                                <Stepper.Step
                                     children={''}
                                     title={value.label}
                                     key={value.key}
+                                    completed={index + 1 < hentNåværendeStegIndex()}
                                 />
                             ))}
-                        </StyledStepper>
-                    </StegindikatorContainer>
+                        </Stepper>
+                    </StepperContainer>
                 )}
             </header>
             <InnholdContainer>

--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -1,10 +1,9 @@
-import React, { ReactNode, useEffect } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
-import Stegindikator from 'nav-frontend-stegindikator';
-
+import { Stepper } from '@navikt/ds-react';
 import { ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
@@ -58,7 +57,19 @@ const Form = styled.form`
 
 const StegindikatorContainer = styled.div`
     margin: 0 1rem;
+    text-align: center;
 `;
+
+const StyledStepper = styled(Stepper)`
+    display: inline-flex;
+    --navds-stepper-circle-size: 2.125rem;
+    --navds-stepper-border-width: 1px;
+    > li {
+        gap: 0;
+    }
+`;
+
+const StyledStepperStep = styled(Stepper.Step)``;
 
 const Steg: React.FC<ISteg> = ({ tittel, skjema, gåVidereCallback, children }) => {
     const history = useHistory();
@@ -77,9 +88,10 @@ const Steg: React.FC<ISteg> = ({ tittel, skjema, gåVidereCallback, children }) 
         hentNåværendeStegIndex,
         stegIndikatorObjekter,
         erPåKvitteringsside,
-        hentNåværendeStegindikatorNummer,
     } = useSteg();
     const { komFra, settKomFra } = useAppNavigation();
+
+    const [aktivtSteg, settAktivtSteg] = useState(hentNåværendeStegIndex());
 
     const nesteRoute = hentNesteSteg();
     const forrigeRoute = hentForrigeSteg();
@@ -144,12 +156,22 @@ const Steg: React.FC<ISteg> = ({ tittel, skjema, gåVidereCallback, children }) 
                 <Banner />
                 {nyesteNåværendeRoute !== RouteEnum.Kvittering && (
                     <StegindikatorContainer>
-                        <Stegindikator
-                            autoResponsiv={true}
-                            aktivtSteg={hentNåværendeStegindikatorNummer()}
-                            steg={stegIndikatorObjekter}
-                            visLabel={false}
-                        />
+                        <StyledStepper
+                            aria-labelledby="Søknadssteg"
+                            activeStep={aktivtSteg}
+                            onStepChange={x => settAktivtSteg(x)}
+                            orientation="horizontal"
+                            interactive={false}
+                        >
+                            {stegIndikatorObjekter.map(value => (
+                                <StyledStepperStep
+                                    href="#"
+                                    children={''}
+                                    title={value.label}
+                                    key={value.key}
+                                />
+                            ))}
+                        </StyledStepper>
                     </StegindikatorContainer>
                 )}
             </header>

--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -100,7 +100,7 @@ const Steg: React.FC<ISteg> = ({ tittel, skjema, gåVidereCallback, children }) 
         hentForrigeSteg,
         hentNåværendeSteg,
         hentNåværendeStegIndex,
-        stegIndikatorObjekter,
+        stepperObjekter,
         erPåKvitteringsside,
     } = useSteg();
     const { komFra, settKomFra } = useAppNavigation();
@@ -167,14 +167,14 @@ const Steg: React.FC<ISteg> = ({ tittel, skjema, gåVidereCallback, children }) 
             <header>
                 <Banner />
                 {nyesteNåværendeRoute !== RouteEnum.Kvittering && (
-                    <StepperContainer antallSteg={stegIndikatorObjekter.length}>
+                    <StepperContainer antallSteg={stepperObjekter.length}>
                         <Stepper
                             aria-label={'Søknadssteg'}
                             activeStep={hentNåværendeStegIndex()}
                             orientation={'horizontal'}
                             interactive={false}
                         >
-                            {stegIndikatorObjekter.map((value, index) => (
+                            {stepperObjekter.map((value, index) => (
                                 <Stepper.Step
                                     children={''}
                                     title={value.label}

--- a/src/frontend/context/Steg.test.tsx
+++ b/src/frontend/context/Steg.test.tsx
@@ -28,7 +28,7 @@ describe('Steg', () => {
         expect(result.current.steg.length).toEqual(9);
     });
 
-    test(`hentStegObjekterForStegIndikator skal returnere en liste uten forside`, () => {
+    test(`stepperObjekter skal returnere en liste uten forside`, () => {
         spyOnUseApp({
             barnInkludertISøknaden: [],
         });
@@ -38,7 +38,7 @@ describe('Steg', () => {
             </RoutesProvider>
         );
         const { result } = renderHook(() => useSteg(), { wrapper });
-        expect(result.current.stegIndikatorObjekter.length).toEqual(8);
+        expect(result.current.stepperObjekter.length).toEqual(8);
     });
 
     test(`Kan hente neste steg fra forsiden`, () => {

--- a/src/frontend/context/StegContext.tsx
+++ b/src/frontend/context/StegContext.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 
 import createUseContext from 'constate';
-import { StegindikatorStegProps } from 'nav-frontend-stegindikator/lib/stegindikator-steg';
 import { matchPath, useLocation } from 'react-router-dom';
 
 import { IBarnMedISøknad } from '../typer/barn';
@@ -9,6 +8,12 @@ import { ISteg, RouteEnum } from '../typer/routes';
 import { useApp } from './AppContext';
 import { useEøs } from './EøsContext';
 import { useRoutes } from './RoutesContext';
+
+interface StegindikatorStegProps {
+    label: string;
+    index: number;
+    key: number;
+}
 
 const [StegProvider, useSteg] = createUseContext(() => {
     const { søknad } = useApp();

--- a/src/frontend/context/StegContext.tsx
+++ b/src/frontend/context/StegContext.tsx
@@ -9,7 +9,7 @@ import { useApp } from './AppContext';
 import { useEøs } from './EøsContext';
 import { useRoutes } from './RoutesContext';
 
-interface StegindikatorStegProps {
+interface StepperStegProps {
     label: string;
     index: number;
     key: number;
@@ -71,7 +71,7 @@ const [StegProvider, useSteg] = createUseContext(() => {
         })
         .flat();
 
-    const stegIndikatorObjekter: StegindikatorStegProps[] = steg
+    const stepperObjekter: StepperStegProps[] = steg
         .filter(steg => steg.route !== RouteEnum.Forside)
         .map((steg, index) => ({
             label: steg.label,
@@ -126,15 +126,11 @@ const [StegProvider, useSteg] = createUseContext(() => {
         );
     };
 
-    const hentNåværendeStegindikatorNummer = (): number => {
-        return Math.max(steg.findIndex(steg => steg === hentNåværendeSteg()) - 1, 0);
-    };
-
     const erPåKvitteringsside = () => hentNåværendeSteg().route === RouteEnum.Kvittering;
 
     return {
         steg,
-        stegIndikatorObjekter,
+        stepperObjekter,
         hentStegNummer,
         hentStegObjektForBarn,
         hentNesteSteg,
@@ -143,7 +139,6 @@ const [StegProvider, useSteg] = createUseContext(() => {
         hentNåværendeStegIndex,
         erPåKvitteringsside,
         settBarnForSteg,
-        hentNåværendeStegindikatorNummer,
         hentStegObjektForBarnEøs,
     };
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9836,16 +9836,6 @@ nav-frontend-skjema@^4.0.x:
   resolved "https://registry.npmjs.org/nav-frontend-skjema/-/nav-frontend-skjema-4.0.6.tgz#17714d105e026ad7c079abf586bfa327aed336f7"
   integrity sha512-lnlrBuab+sX+mOmzPtQXXNEzA/Z7bun4snBcGkl2AfSzw2DF0tXmmf0nQW3c7BRQksX3lZw07E8I7ka/Dxr1ng==
 
-nav-frontend-stegindikator-style@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/nav-frontend-stegindikator-style/-/nav-frontend-stegindikator-style-2.0.1.tgz#abd5dcc875cc8e7d08644ea1cd5b7eb3d73f773a"
-  integrity sha512-WIvg2kthzhJ6AIfxlRcVTEzMqSA/qERsHZU17qqlJb1RaNf/Cn/ZggeBIq3aD/7QVZgn0GEYvFOlnLo7bLOJ1w==
-
-nav-frontend-stegindikator@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/nav-frontend-stegindikator/-/nav-frontend-stegindikator-2.0.1.tgz#bedc3fe39d54c8550f7f6a2e69ddd36864b62f64"
-  integrity sha512-IlCD6ys9Ft6IKZOD40ZENAzxk02D+9+KO/8WXmXDv/2/mC9qDicSMKsDXNcc78DvJgns4o6r2X+3cDNWhOlofQ==
-
 nav-frontend-typografi-style@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/nav-frontend-typografi-style/-/nav-frontend-typografi-style-2.0.1.tgz#6522b2f8b007535831ec003008823fbd508f90b8"


### PR DESCRIPTION
Gammel:
![image](https://user-images.githubusercontent.com/70642183/224272302-6bd6f6c3-7fdc-4a48-9226-43dcd7f4077b.png)

Ny:
![image](https://user-images.githubusercontent.com/70642183/224270686-95e32edb-df80-403e-b70a-87596ec06469.png)

En utfordring med den nye Stegindikatoren er at den ikke fungerer så bra når skjermen blir for smal for å vise alle stegene. Gjelder særlig når man får EØS-stegene på mobil 🤔 På Aksel skriver de at de anbefaler å bruke den vertikale varianten, men dersom vi skal bruke den trenger vi nok litt hjelp av Gunn. Et alternativ er kanskje å fjerne hele visningen av stepper dersom skjermen er for smal.
