### PR TITLE
Sørger for at planlegger-du-spm alltid vises

### DIFF
--- a/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
@@ -91,24 +91,21 @@ const OmDeg: React.FC = () => {
                         />
                     )}
                 </>
-                {skjema.felter.planleggerÅBoINorgeTolvMnd.erSynlig && (
-                    <KomponentGruppe inline dynamisk>
-                        <JaNeiSpm
-                            skjema={skjema}
-                            felt={skjema.felter.planleggerÅBoINorgeTolvMnd}
-                            spørsmålDokument={planleggerAaBoSammenhengende}
-                        />
-                        {skjema.felter.planleggerÅBoINorgeTolvMnd.erSynlig &&
-                            skjema.felter.planleggerÅBoINorgeTolvMnd.verdi === ESvar.NEI && (
-                                <AlertStripe variant={'warning'} dynamisk>
-                                    <TekstBlock
-                                        block={planleggerAaBoSammenhengende.alert}
-                                        typografi={Typografi.BodyLong}
-                                    />
-                                </AlertStripe>
-                            )}
-                    </KomponentGruppe>
-                )}
+                <KomponentGruppe inline dynamisk>
+                    <JaNeiSpm
+                        skjema={skjema}
+                        felt={skjema.felter.planleggerÅBoINorgeTolvMnd}
+                        spørsmålDokument={planleggerAaBoSammenhengende}
+                    />
+                    {skjema.felter.planleggerÅBoINorgeTolvMnd.verdi === ESvar.NEI && (
+                        <AlertStripe variant={'warning'} dynamisk>
+                            <TekstBlock
+                                block={planleggerAaBoSammenhengende.alert}
+                                typografi={Typografi.BodyLong}
+                            />
+                        </AlertStripe>
+                    )}
+                </KomponentGruppe>
             </KomponentGruppe>
             <KomponentGruppe>
                 <JaNeiSpm

--- a/src/frontend/components/SøknadsSteg/OmDeg/useOmdeg.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/useOmdeg.tsx
@@ -16,7 +16,6 @@ import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { IOmDegFeltTyper } from '../../../typer/skjema';
 import { nullstilteEøsFelterForBarn } from '../../../utils/barn';
 import { nullstilteEøsFelterForSøker } from '../../../utils/søker';
-import { flyttetPermanentFraNorge } from '../../../utils/utenlandsopphold';
 import { UtenlandsoppholdSpørsmålId } from '../../Felleskomponenter/UtenlandsoppholdModal/spørsmål';
 import { idNummerLandMedPeriodeType, PeriodeType } from '../EøsSteg/idnummerUtils';
 import { IOmDegTekstinnhold } from './innholdTyper';
@@ -69,14 +68,6 @@ export const useOmdeg = (): {
     const planleggerÅBoINorgeTolvMnd = useJaNeiSpmFelt({
         søknadsfelt: søker.planleggerÅBoINorgeTolvMnd,
         feilmelding: teksterForSteg.planleggerAaBoSammenhengende.feilmelding,
-        avhengigheter: {
-            værtINorgeITolvMåneder: { hovedSpørsmål: værtINorgeITolvMåneder },
-        },
-        skalSkjules:
-            flyttetPermanentFraNorge(registrerteUtenlandsperioder.verdi) ||
-            værtINorgeITolvMåneder.verdi === ESvar.JA ||
-            (værtINorgeITolvMåneder.verdi === ESvar.NEI &&
-                !registrerteUtenlandsperioder.verdi.length),
     });
 
     const yrkesaktivFemÅr = useJaNeiSpmFelt({
@@ -132,11 +123,7 @@ export const useOmdeg = (): {
         },
         planleggerÅBoINorgeTolvMnd: {
             ...søker.planleggerÅBoINorgeTolvMnd,
-            svar:
-                !flyttetPermanentFraNorge(registrerteUtenlandsperioder.verdi) &&
-                værtINorgeITolvMåneder.verdi === ESvar.NEI
-                    ? skjema.felter.planleggerÅBoINorgeTolvMnd.verdi
-                    : null,
+            svar: skjema.felter.planleggerÅBoINorgeTolvMnd.verdi,
         },
         yrkesaktivFemÅr: {
             ...søker.yrkesaktivFemÅr,

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
@@ -98,12 +98,10 @@ const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
                         personType={PersonType.søker}
                     />
                 ))}
-                {søknad.søker.planleggerÅBoINorgeTolvMnd.svar && (
-                    <OppsummeringFelt
-                        spørsmålstekst={omDegTekster.planleggerAaBoSammenhengende.sporsmal}
-                        søknadsvar={søknad.søker.planleggerÅBoINorgeTolvMnd.svar}
-                    />
-                )}
+                <OppsummeringFelt
+                    spørsmålstekst={omDegTekster.planleggerAaBoSammenhengende.sporsmal}
+                    søknadsvar={søknad.søker.planleggerÅBoINorgeTolvMnd.svar}
+                />
                 <OppsummeringFelt
                     spørsmålstekst={omDegTekster.medlemAvFolketrygden.sporsmal}
                     søknadsvar={søknad.søker.yrkesaktivFemÅr.svar}

--- a/src/frontend/typer/kontrakt/v1.ts
+++ b/src/frontend/typer/kontrakt/v1.ts
@@ -44,7 +44,7 @@ export interface ISøknadKontraktSøker {
     borPåRegistrertAdresse: ISøknadsfelt<ESvar> | null;
     værtINorgeITolvMåneder: ISøknadsfelt<ESvar>;
     utenlandsperioder: ISøknadsfelt<IUtenlandsperiodeIKontraktFormat>[];
-    planleggerÅBoINorgeTolvMnd: ISøknadsfelt<ESvar> | null;
+    planleggerÅBoINorgeTolvMnd: ISøknadsfelt<ESvar>;
     yrkesaktivFemÅr: ISøknadsfelt<ESvar>;
 
     // Din livssituasjon

--- a/src/frontend/utils/mappingTilKontrakt/søker.ts
+++ b/src/frontend/utils/mappingTilKontrakt/søker.ts
@@ -81,7 +81,7 @@ export const søkerIKontraktFormat = (
             omDegTekster.oppholdtDegSammenhengende.sporsmal,
             værtINorgeITolvMåneder.svar
         ),
-        planleggerÅBoINorgeTolvMnd: nullableSøknadsfeltForESvar(
+        planleggerÅBoINorgeTolvMnd: søknadsfeltForESvar(
             omDegTekster.planleggerAaBoSammenhengende.sporsmal,
             planleggerÅBoINorgeTolvMnd.svar
         ),

--- a/src/shared-utils/modellversjon.ts
+++ b/src/shared-utils/modellversjon.ts
@@ -1,6 +1,6 @@
 import { ApiRessurs, Ressurs, RessursStatus } from '@navikt/familie-typer';
 
-export const modellVersjon = 3;
+export const modellVersjon = 4;
 
 export const modellVersjonHeaderName = 'Soknad-Modell-Versjon';
 


### PR DESCRIPTION
"Planlegger du å bo sammenhengende i Norge i mer enn tolv måneder?"-spørsmålet vises alltid uavhengig av hva man har svart på "Har du oppholdt deg sammenhengende i Norge de siste tolv månedene?". Fjernet avhengigheter og skalVises-logikk som ikke lenger trengs.

Bumpet `modellversjon` til 4 pga kontrakt endring. Holder vel å gjøre dette én gang for boperioder?

FØR:
![image](https://user-images.githubusercontent.com/70642183/225836045-a485cdc9-3efe-4999-8118-0631947048e8.png)

ETTER:
![image](https://user-images.githubusercontent.com/70642183/225835896-40482eb7-5129-4768-990c-291f884c26f9.png)
