### PR TITLE
Kun lytt på endring av valuen til inputProps, sånn at feltet ikke set…

### DIFF
--- a/src/frontend/components/Felleskomponenter/Datovelger/Datovelger.tsx
+++ b/src/frontend/components/Felleskomponenter/Datovelger/Datovelger.tsx
@@ -99,7 +99,7 @@ const Datovelger: React.FC<DatoVelgerProps> = ({
                     : inputProps.value.toString()
             );
         }
-    }, [inputProps, disabled]);
+    }, [inputProps.value, disabled]);
 
     return felt.erSynlig ? (
         <div aria-live={dynamisk ? 'polite' : 'off'}>


### PR DESCRIPTION
…tes ved feil tidspunkt

### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Dersom man lytter til hele inputProps kjører useEffecten en gang for mye og datofeltet blir satt på "nytt" med gammel verdi, etter at nullstillingsfunksjonen kjører i forbindelse med lukking av modal. Dette gjorde at datofeltet fikk opp en lagret verdi, i stedet for en nullstilt verdi når man åpner modalen for å legge inn flere perioder etter man har lagt til en.

Denne PR'en fikser at man kun lytter til inputProps.value sånn at feltet kun blir satt dersom brukeren endrer valuen i input-feltet

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
