### PR TITLE
Tilpasse arbeidsperiode-modal

### DIFF
--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeModal.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeModal.tsx
@@ -66,7 +66,7 @@ export const ArbeidsperiodeModal: React.FC<ArbeidsperiodeModalProps> = ({
         onLeggTilArbeidsperiode({
             arbeidsperiodeAvsluttet: {
                 id: ArbeidsperiodeSpørsmålsId.arbeidsperiodeAvsluttet,
-                svar: arbeidsperiodeAvsluttet.verdi as ESvar,
+                svar: arbeidsperiodeAvsluttet.verdi,
             },
             arbeidsperiodeland: {
                 id: ArbeidsperiodeSpørsmålsId.arbeidsperiodeLand,

--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeModal.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeModal.tsx
@@ -66,31 +66,27 @@ export const ArbeidsperiodeModal: React.FC<ArbeidsperiodeModalProps> = ({
         onLeggTilArbeidsperiode({
             arbeidsperiodeAvsluttet: {
                 id: ArbeidsperiodeSpørsmålsId.arbeidsperiodeAvsluttet,
-                svar: arbeidsperiodeAvsluttet.erSynlig
-                    ? (arbeidsperiodeAvsluttet.verdi as ESvar)
-                    : null,
+                svar: arbeidsperiodeAvsluttet.verdi as ESvar,
             },
             arbeidsperiodeland: {
                 id: ArbeidsperiodeSpørsmålsId.arbeidsperiodeLand,
-                svar: arbeidsperiodeLand.erSynlig ? arbeidsperiodeLand.verdi : '',
+                svar: arbeidsperiodeLand.verdi,
             },
             arbeidsgiver: {
                 id: ArbeidsperiodeSpørsmålsId.arbeidsgiver,
-                svar: arbeidsgiver.erSynlig ? trimWhiteSpace(arbeidsgiver.verdi) : '',
+                svar: trimWhiteSpace(arbeidsgiver.verdi),
             },
             fraDatoArbeidsperiode: {
                 id: ArbeidsperiodeSpørsmålsId.fraDatoArbeidsperiode,
-                svar: fraDatoArbeidsperiode.erSynlig ? fraDatoArbeidsperiode.verdi : '',
+                svar: fraDatoArbeidsperiode.verdi,
             },
             tilDatoArbeidsperiode: {
                 id: ArbeidsperiodeSpørsmålsId.tilDatoArbeidsperiode,
-                svar: tilDatoArbeidsperiode.erSynlig
-                    ? svarForSpørsmålMedUkjent(tilDatoArbeidsperiodeUkjent, tilDatoArbeidsperiode)
-                    : '',
+                svar: svarForSpørsmålMedUkjent(tilDatoArbeidsperiodeUkjent, tilDatoArbeidsperiode),
             },
             adresse: {
                 id: ArbeidsperiodeSpørsmålsId.adresse,
-                svar: adresse.erSynlig ? svarForSpørsmålMedUkjent(adresseUkjent, adresse) : '',
+                svar: svarForSpørsmålMedUkjent(adresseUkjent, adresse),
             },
         });
 

--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering.tsx
@@ -91,31 +91,25 @@ export const ArbeidsperiodeOppsummering: React.FC<ArbeidsperiodeOppsummeringProp
                     søknadsvar={landkodeTilSpråk(arbeidsperiodeland.svar, valgtLocale)}
                 />
             )}
-            {arbeidsgiver.svar && (
-                <OppsummeringFelt
-                    spørsmålstekst={teksterForModal.arbeidsgiver.sporsmal}
-                    søknadsvar={arbeidsgiver.svar}
-                />
-            )}
-            {fraDatoArbeidsperiode.svar && (
-                <OppsummeringFelt
-                    spørsmålstekst={teksterForModal.startdato.sporsmal}
-                    søknadsvar={formaterDato(fraDatoArbeidsperiode.svar)}
-                />
-            )}
-            {tilDatoArbeidsperiode.svar && (
-                <OppsummeringFelt
-                    spørsmålstekst={
-                        periodenErAvsluttet
-                            ? teksterForModal.sluttdatoFortid.sporsmal
-                            : teksterForModal.sluttdatoFremtid.sporsmal
-                    }
-                    søknadsvar={formaterDatoMedUkjent(
-                        tilDatoArbeidsperiode.svar,
-                        plainTekst(teksterForModal.sluttdatoFremtid.checkboxLabel)
-                    )}
-                />
-            )}
+            <OppsummeringFelt
+                spørsmålstekst={teksterForModal.arbeidsgiver.sporsmal}
+                søknadsvar={arbeidsgiver.svar}
+            />
+            <OppsummeringFelt
+                spørsmålstekst={teksterForModal.startdato.sporsmal}
+                søknadsvar={formaterDato(fraDatoArbeidsperiode.svar)}
+            />
+            <OppsummeringFelt
+                spørsmålstekst={
+                    periodenErAvsluttet
+                        ? teksterForModal.sluttdatoFortid.sporsmal
+                        : teksterForModal.sluttdatoFremtid.sporsmal
+                }
+                søknadsvar={formaterDatoMedUkjent(
+                    tilDatoArbeidsperiode.svar,
+                    plainTekst(teksterForModal.sluttdatoFremtid.checkboxLabel)
+                )}
+            />
             {adresse.svar && (
                 <OppsummeringFelt
                     spørsmålstekst={adresseTekst.sporsmal}

--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/useArbeidsperiodeSkjema.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/useArbeidsperiodeSkjema.tsx
@@ -2,7 +2,6 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
-import { useEøs } from '../../../context/EøsContext';
 import useDatovelgerFelt from '../../../hooks/useDatovelgerFelt';
 import useDatovelgerFeltMedUkjent from '../../../hooks/useDatovelgerFeltMedUkjent';
 import useInputFelt from '../../../hooks/useInputFelt';
@@ -34,7 +33,6 @@ export const useArbeidsperiodeSkjema = (
     erDød = false
 ): IUsePeriodeSkjemaVerdi<IArbeidsperioderFeltTyper> => {
     const { tekster, plainTekst } = useApp();
-    const { erEøsLand } = useEøs();
     const teksterForPersonType: IArbeidsperiodeTekstinnhold =
         tekster().FELLES.modaler.arbeidsperiode[personType];
 
@@ -67,18 +65,18 @@ export const useArbeidsperiodeSkjema = (
     const arbeidsgiver = useInputFelt({
         søknadsfelt: { id: ArbeidsperiodeSpørsmålsId.arbeidsgiver, svar: '' },
         feilmelding: teksterForPersonType.arbeidsgiver.feilmelding,
-        skalVises: gjelderUtlandet
-            ? erEøsLand(arbeidsperiodeLand.verdi)
-            : arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
-              andreForelderErDød,
+        skalVises:
+            gjelderUtlandet &&
+            (arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
+                andreForelderErDød),
     });
 
     const fraDatoArbeidsperiode = useDatovelgerFelt({
         søknadsfelt: { id: ArbeidsperiodeSpørsmålsId.fraDatoArbeidsperiode, svar: '' },
-        skalFeltetVises: gjelderUtlandet
-            ? !!erEøsLand(arbeidsperiodeLand.verdi)
-            : arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
-              andreForelderErDød,
+        skalFeltetVises:
+            gjelderUtlandet &&
+            (arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
+                andreForelderErDød),
         feilmelding: teksterForPersonType.startdato.feilmelding,
         sluttdatoAvgrensning: periodenErAvsluttet ? gårsdagensDato() : dagensDato(),
     });
@@ -88,9 +86,9 @@ export const useArbeidsperiodeSkjema = (
         feltId: ArbeidsperiodeSpørsmålsId.tilDatoArbeidsperiodeVetIkke,
         skalFeltetVises: avhengigheter => {
             if (avhengigheter.arbeidsperiodeAvsluttet?.verdi !== ESvar.NEI) return false;
-            return gjelderUtlandet ? !!erEøsLand(avhengigheter.arbeidsperiodeLand?.verdi) : true;
+            return gjelderUtlandet;
         },
-        avhengigheter: { arbeidsperiodeAvsluttet, arbeidsperiodeLand },
+        avhengigheter: { arbeidsperiodeAvsluttet },
     });
 
     const tilDatoArbeidsperiode = useDatovelgerFeltMedUkjent({
@@ -100,10 +98,10 @@ export const useArbeidsperiodeSkjema = (
         feilmelding: periodenErAvsluttet
             ? teksterForPersonType.sluttdatoFortid.feilmelding
             : teksterForPersonType.sluttdatoFremtid.feilmelding,
-        skalFeltetVises: gjelderUtlandet
-            ? !!erEøsLand(arbeidsperiodeLand.verdi)
-            : arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
-              andreForelderErDød,
+        skalFeltetVises:
+            gjelderUtlandet &&
+            (arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
+                andreForelderErDød),
         sluttdatoAvgrensning: periodenErAvsluttet ? dagensDato() : undefined,
         startdatoAvgrensning: minTilDatoForUtbetalingEllerArbeidsperiode(
             periodenErAvsluttet,
@@ -122,9 +120,11 @@ export const useArbeidsperiodeSkjema = (
     const adresseUkjent = useFelt<ESvar>({
         verdi: ESvar.NEI,
         feltId: ArbeidsperiodeSpørsmålsId.adresseVetIkke,
-        skalFeltetVises: avhengigheter =>
-            gjelderUtlandet && !!erEøsLand(avhengigheter.arbeidsperiodeLand?.verdi),
-        avhengigheter: { arbeidsperiodeAvsluttet, arbeidsperiodeLand },
+        skalFeltetVises: () =>
+            gjelderUtlandet &&
+            (arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
+                andreForelderErDød),
+        avhengigheter: { arbeidsperiodeAvsluttet },
         nullstillVedAvhengighetEndring: false,
     });
 
@@ -135,7 +135,10 @@ export const useArbeidsperiodeSkjema = (
         },
         avhengighet: adresseUkjent,
         feilmelding: adresseTekst.feilmelding,
-        skalVises: gjelderUtlandet && !!erEøsLand(arbeidsperiodeLand.verdi),
+        skalVises:
+            gjelderUtlandet &&
+            (arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
+                andreForelderErDød),
     });
 
     const skjema = useSkjema<IArbeidsperioderFeltTyper, string>({

--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/useArbeidsperiodeSkjema.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/useArbeidsperiodeSkjema.tsx
@@ -66,17 +66,15 @@ export const useArbeidsperiodeSkjema = (
         søknadsfelt: { id: ArbeidsperiodeSpørsmålsId.arbeidsgiver, svar: '' },
         feilmelding: teksterForPersonType.arbeidsgiver.feilmelding,
         skalVises:
-            gjelderUtlandet &&
-            (arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
-                andreForelderErDød),
+            arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
+            andreForelderErDød,
     });
 
     const fraDatoArbeidsperiode = useDatovelgerFelt({
         søknadsfelt: { id: ArbeidsperiodeSpørsmålsId.fraDatoArbeidsperiode, svar: '' },
         skalFeltetVises:
-            gjelderUtlandet &&
-            (arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
-                andreForelderErDød),
+            arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
+            andreForelderErDød,
         feilmelding: teksterForPersonType.startdato.feilmelding,
         sluttdatoAvgrensning: periodenErAvsluttet ? gårsdagensDato() : dagensDato(),
     });
@@ -84,10 +82,8 @@ export const useArbeidsperiodeSkjema = (
     const tilDatoArbeidsperiodeUkjent = useFelt<ESvar>({
         verdi: ESvar.NEI,
         feltId: ArbeidsperiodeSpørsmålsId.tilDatoArbeidsperiodeVetIkke,
-        skalFeltetVises: avhengigheter => {
-            if (avhengigheter.arbeidsperiodeAvsluttet?.verdi !== ESvar.NEI) return false;
-            return gjelderUtlandet;
-        },
+        skalFeltetVises: avhengigheter =>
+            avhengigheter?.arbeidsperiodeAvsluttet?.verdi === ESvar.NEI,
         avhengigheter: { arbeidsperiodeAvsluttet },
     });
 
@@ -99,9 +95,8 @@ export const useArbeidsperiodeSkjema = (
             ? teksterForPersonType.sluttdatoFortid.feilmelding
             : teksterForPersonType.sluttdatoFremtid.feilmelding,
         skalFeltetVises:
-            gjelderUtlandet &&
-            (arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
-                andreForelderErDød),
+            arbeidsperiodeAvsluttet.valideringsstatus === Valideringsstatus.OK ||
+            andreForelderErDød,
         sluttdatoAvgrensning: periodenErAvsluttet ? dagensDato() : undefined,
         startdatoAvgrensning: minTilDatoForUtbetalingEllerArbeidsperiode(
             periodenErAvsluttet,

--- a/src/frontend/typer/kontrakt/v1.ts
+++ b/src/frontend/typer/kontrakt/v1.ts
@@ -158,12 +158,12 @@ export interface IAndreForelderIKontraktFormat {
 }
 
 export interface IArbeidsperiodeIKontraktFormat {
-    arbeidsperiodeAvsluttet: ISøknadsfelt<string> | null;
-    arbeidsperiodeland: ISøknadsfelt<string> | null;
-    arbeidsgiver: ISøknadsfelt<string> | null;
-    fraDatoArbeidsperiode: ISøknadsfelt<ISODateString> | null;
-    tilDatoArbeidsperiode: ISøknadsfelt<ISODateString> | null;
-    adresse: ISøknadsfelt<string> | null;
+    arbeidsperiodeAvsluttet: ISøknadsfelt<string>;
+    arbeidsperiodeland: ISøknadsfelt<string>;
+    arbeidsgiver: ISøknadsfelt<string>;
+    fraDatoArbeidsperiode: ISøknadsfelt<ISODateString>;
+    tilDatoArbeidsperiode: ISøknadsfelt<ISODateString>;
+    adresse: ISøknadsfelt<string>;
 }
 
 export interface IIdNummerIKontraktFormat {

--- a/src/frontend/typer/kontrakt/v1.ts
+++ b/src/frontend/typer/kontrakt/v1.ts
@@ -160,9 +160,9 @@ export interface IAndreForelderIKontraktFormat {
 export interface IArbeidsperiodeIKontraktFormat {
     arbeidsperiodeAvsluttet: ISøknadsfelt<string> | null;
     arbeidsperiodeland: ISøknadsfelt<string> | null;
-    arbeidsgiver: ISøknadsfelt<string> | null;
-    fraDatoArbeidsperiode: ISøknadsfelt<ISODateString> | null;
-    tilDatoArbeidsperiode: ISøknadsfelt<ISODateString> | null;
+    arbeidsgiver: ISøknadsfelt<string>;
+    fraDatoArbeidsperiode: ISøknadsfelt<ISODateString>;
+    tilDatoArbeidsperiode: ISøknadsfelt<ISODateString>;
     adresse: ISøknadsfelt<string> | null;
 }
 

--- a/src/frontend/typer/kontrakt/v1.ts
+++ b/src/frontend/typer/kontrakt/v1.ts
@@ -159,11 +159,11 @@ export interface IAndreForelderIKontraktFormat {
 
 export interface IArbeidsperiodeIKontraktFormat {
     arbeidsperiodeAvsluttet: ISøknadsfelt<string> | null;
-    arbeidsperiodeland: ISøknadsfelt<string> | null;
+    arbeidsperiodeland: ISøknadsfelt<string>;
     arbeidsgiver: ISøknadsfelt<string>;
     fraDatoArbeidsperiode: ISøknadsfelt<ISODateString>;
     tilDatoArbeidsperiode: ISøknadsfelt<ISODateString>;
-    adresse: ISøknadsfelt<string> | null;
+    adresse: ISøknadsfelt<string>;
 }
 
 export interface IIdNummerIKontraktFormat {

--- a/src/frontend/typer/kontrakt/v1.ts
+++ b/src/frontend/typer/kontrakt/v1.ts
@@ -158,12 +158,12 @@ export interface IAndreForelderIKontraktFormat {
 }
 
 export interface IArbeidsperiodeIKontraktFormat {
-    arbeidsperiodeAvsluttet: ISøknadsfelt<string>;
-    arbeidsperiodeland: ISøknadsfelt<string>;
-    arbeidsgiver: ISøknadsfelt<string>;
-    fraDatoArbeidsperiode: ISøknadsfelt<ISODateString>;
-    tilDatoArbeidsperiode: ISøknadsfelt<ISODateString>;
-    adresse: ISøknadsfelt<string>;
+    arbeidsperiodeAvsluttet: ISøknadsfelt<string> | null;
+    arbeidsperiodeland: ISøknadsfelt<string> | null;
+    arbeidsgiver: ISøknadsfelt<string> | null;
+    fraDatoArbeidsperiode: ISøknadsfelt<ISODateString> | null;
+    tilDatoArbeidsperiode: ISøknadsfelt<ISODateString> | null;
+    adresse: ISøknadsfelt<string> | null;
 }
 
 export interface IIdNummerIKontraktFormat {

--- a/src/frontend/typer/kontrakt/v1.ts
+++ b/src/frontend/typer/kontrakt/v1.ts
@@ -159,11 +159,11 @@ export interface IAndreForelderIKontraktFormat {
 
 export interface IArbeidsperiodeIKontraktFormat {
     arbeidsperiodeAvsluttet: ISøknadsfelt<string> | null;
-    arbeidsperiodeland: ISøknadsfelt<string>;
+    arbeidsperiodeland: ISøknadsfelt<string> | null;
     arbeidsgiver: ISøknadsfelt<string>;
     fraDatoArbeidsperiode: ISøknadsfelt<ISODateString>;
     tilDatoArbeidsperiode: ISøknadsfelt<ISODateString>;
-    adresse: ISøknadsfelt<string>;
+    adresse: ISøknadsfelt<string> | null;
 }
 
 export interface IIdNummerIKontraktFormat {

--- a/src/frontend/typer/perioder.ts
+++ b/src/frontend/typer/perioder.ts
@@ -16,7 +16,7 @@ export interface IUtenlandsperiode {
 }
 
 export interface IArbeidsperiode {
-    arbeidsperiodeAvsluttet: ISøknadSpørsmål<ESvar>;
+    arbeidsperiodeAvsluttet: ISøknadSpørsmål<ESvar | null>;
     arbeidsperiodeland: ISøknadSpørsmål<Alpha3Code | ''>;
     arbeidsgiver: ISøknadSpørsmål<string>;
     fraDatoArbeidsperiode: ISøknadSpørsmål<ISODateString | ''>;

--- a/src/frontend/typer/perioder.ts
+++ b/src/frontend/typer/perioder.ts
@@ -16,7 +16,7 @@ export interface IUtenlandsperiode {
 }
 
 export interface IArbeidsperiode {
-    arbeidsperiodeAvsluttet: ISøknadSpørsmål<ESvar | null>;
+    arbeidsperiodeAvsluttet: ISøknadSpørsmål<ESvar>;
     arbeidsperiodeland: ISøknadSpørsmål<Alpha3Code | ''>;
     arbeidsgiver: ISøknadSpørsmål<string>;
     fraDatoArbeidsperiode: ISøknadSpørsmål<ISODateString | ''>;

--- a/src/frontend/utils/mappingTilKontrakt/arbeidsperioder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/arbeidsperioder.ts
@@ -59,12 +59,14 @@ export const tilIArbeidsperiodeIKontraktFormat = ({
                       verdi: sammeVerdiAlleSpråk(arbeidsperiodeAvsluttet.svar),
                   }
                 : null,
-            arbeidsperiodeland: {
-                label: tilRestLocaleRecord(landTekst.sporsmal, { barnetsNavn: barn?.navn }),
-                verdi: verdiCallbackAlleSpråk(locale =>
-                    landkodeTilSpråk(arbeidsperiodeland.svar, locale)
-                ),
-            },
+            arbeidsperiodeland: arbeidsperiodeland.svar
+                ? {
+                      label: tilRestLocaleRecord(landTekst.sporsmal, { barnetsNavn: barn?.navn }),
+                      verdi: verdiCallbackAlleSpråk(locale =>
+                          landkodeTilSpråk(arbeidsperiodeland.svar, locale)
+                      ),
+                  }
+                : null,
             arbeidsgiver: {
                 label: tilRestLocaleRecord(tekster.arbeidsgiver.sporsmal),
                 verdi: sammeVerdiAlleSpråk(arbeidsgiver.svar),
@@ -81,14 +83,16 @@ export const tilIArbeidsperiodeIKontraktFormat = ({
                     tekster.sluttdatoFremtid.checkboxLabel
                 ),
             },
-            adresse: søknadsfelt(
-                adresseTekst.sporsmal,
-                sammeVerdiAlleSpråkEllerUkjent(
-                    tilRestLocaleRecord,
-                    adresse.svar,
-                    adresseTekst.checkboxLabel
-                )
-            ),
+            adresse: adresse.svar
+                ? søknadsfelt(
+                      adresseTekst.sporsmal,
+                      sammeVerdiAlleSpråkEllerUkjent(
+                          tilRestLocaleRecord,
+                          adresse.svar,
+                          adresseTekst.checkboxLabel
+                      )
+                  )
+                : null,
         }),
     };
 };

--- a/src/frontend/utils/mappingTilKontrakt/arbeidsperioder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/arbeidsperioder.ts
@@ -67,28 +67,22 @@ export const tilIArbeidsperiodeIKontraktFormat = ({
                       ),
                   }
                 : null,
-            arbeidsgiver: arbeidsgiver.svar
-                ? {
-                      label: tilRestLocaleRecord(tekster.arbeidsgiver.sporsmal),
-                      verdi: sammeVerdiAlleSpråk(arbeidsgiver.svar),
-                  }
-                : null,
-            fraDatoArbeidsperiode: fraDatoArbeidsperiode.svar
-                ? {
-                      label: tilRestLocaleRecord(tekster.startdato.sporsmal),
-                      verdi: sammeVerdiAlleSpråk(fraDatoArbeidsperiode.svar),
-                  }
-                : null,
-            tilDatoArbeidsperiode: tilDatoArbeidsperiode.svar
-                ? {
-                      label: tilRestLocaleRecord(sluttdatoTekst.sporsmal),
-                      verdi: sammeVerdiAlleSpråkEllerUkjent(
-                          tilRestLocaleRecord,
-                          tilDatoArbeidsperiode.svar,
-                          tekster.sluttdatoFremtid.checkboxLabel
-                      ),
-                  }
-                : null,
+            arbeidsgiver: {
+                label: tilRestLocaleRecord(tekster.arbeidsgiver.sporsmal),
+                verdi: sammeVerdiAlleSpråk(arbeidsgiver.svar),
+            },
+            fraDatoArbeidsperiode: {
+                label: tilRestLocaleRecord(tekster.startdato.sporsmal),
+                verdi: sammeVerdiAlleSpråk(fraDatoArbeidsperiode.svar),
+            },
+            tilDatoArbeidsperiode: {
+                label: tilRestLocaleRecord(sluttdatoTekst.sporsmal),
+                verdi: sammeVerdiAlleSpråkEllerUkjent(
+                    tilRestLocaleRecord,
+                    tilDatoArbeidsperiode.svar,
+                    tekster.sluttdatoFremtid.checkboxLabel
+                ),
+            },
             adresse: adresse.svar
                 ? søknadsfelt(
                       adresseTekst.sporsmal,

--- a/src/frontend/utils/mappingTilKontrakt/arbeidsperioder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/arbeidsperioder.ts
@@ -53,52 +53,40 @@ export const tilIArbeidsperiodeIKontraktFormat = ({
             gjelderUtland: gjelderUtlandet,
         }),
         verdi: sammeVerdiAlleSpråk({
-            arbeidsperiodeAvsluttet: arbeidsperiodeAvsluttet.svar
-                ? {
-                      label: tilRestLocaleRecord(tekster.arbeidsperiodenAvsluttet.sporsmal),
-                      verdi: sammeVerdiAlleSpråk(arbeidsperiodeAvsluttet.svar),
-                  }
-                : null,
-            arbeidsperiodeland: arbeidsperiodeland.svar
-                ? {
-                      label: tilRestLocaleRecord(landTekst.sporsmal, { barnetsNavn: barn?.navn }),
-                      verdi: verdiCallbackAlleSpråk(locale =>
-                          landkodeTilSpråk(arbeidsperiodeland.svar, locale)
-                      ),
-                  }
-                : null,
-            arbeidsgiver: arbeidsgiver.svar
-                ? {
-                      label: tilRestLocaleRecord(tekster.arbeidsgiver.sporsmal),
-                      verdi: sammeVerdiAlleSpråk(arbeidsgiver.svar),
-                  }
-                : null,
-            fraDatoArbeidsperiode: fraDatoArbeidsperiode.svar
-                ? {
-                      label: tilRestLocaleRecord(tekster.startdato.sporsmal),
-                      verdi: sammeVerdiAlleSpråk(fraDatoArbeidsperiode.svar),
-                  }
-                : null,
-            tilDatoArbeidsperiode: tilDatoArbeidsperiode.svar
-                ? {
-                      label: tilRestLocaleRecord(sluttdatoTekst.sporsmal),
-                      verdi: sammeVerdiAlleSpråkEllerUkjent(
-                          tilRestLocaleRecord,
-                          tilDatoArbeidsperiode.svar,
-                          tekster.sluttdatoFremtid.checkboxLabel
-                      ),
-                  }
-                : null,
-            adresse: adresse.svar
-                ? søknadsfelt(
-                      adresseTekst.sporsmal,
-                      sammeVerdiAlleSpråkEllerUkjent(
-                          tilRestLocaleRecord,
-                          adresse.svar,
-                          adresseTekst.checkboxLabel
-                      )
-                  )
-                : null,
+            arbeidsperiodeAvsluttet: {
+                label: tilRestLocaleRecord(tekster.arbeidsperiodenAvsluttet.sporsmal),
+                verdi: sammeVerdiAlleSpråk(arbeidsperiodeAvsluttet.svar),
+            },
+            arbeidsperiodeland: {
+                label: tilRestLocaleRecord(landTekst.sporsmal, { barnetsNavn: barn?.navn }),
+                verdi: verdiCallbackAlleSpråk(locale =>
+                    landkodeTilSpråk(arbeidsperiodeland.svar, locale)
+                ),
+            },
+            arbeidsgiver: {
+                label: tilRestLocaleRecord(tekster.arbeidsgiver.sporsmal),
+                verdi: sammeVerdiAlleSpråk(arbeidsgiver.svar),
+            },
+            fraDatoArbeidsperiode: {
+                label: tilRestLocaleRecord(tekster.startdato.sporsmal),
+                verdi: sammeVerdiAlleSpråk(fraDatoArbeidsperiode.svar),
+            },
+            tilDatoArbeidsperiode: {
+                label: tilRestLocaleRecord(sluttdatoTekst.sporsmal),
+                verdi: sammeVerdiAlleSpråkEllerUkjent(
+                    tilRestLocaleRecord,
+                    tilDatoArbeidsperiode.svar,
+                    tekster.sluttdatoFremtid.checkboxLabel
+                ),
+            },
+            adresse: søknadsfelt(
+                adresseTekst.sporsmal,
+                sammeVerdiAlleSpråkEllerUkjent(
+                    tilRestLocaleRecord,
+                    adresse.svar,
+                    adresseTekst.checkboxLabel
+                )
+            ),
         }),
     };
 };

--- a/src/frontend/utils/mappingTilKontrakt/arbeidsperioder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/arbeidsperioder.ts
@@ -53,40 +53,52 @@ export const tilIArbeidsperiodeIKontraktFormat = ({
             gjelderUtland: gjelderUtlandet,
         }),
         verdi: sammeVerdiAlleSpråk({
-            arbeidsperiodeAvsluttet: {
-                label: tilRestLocaleRecord(tekster.arbeidsperiodenAvsluttet.sporsmal),
-                verdi: sammeVerdiAlleSpråk(arbeidsperiodeAvsluttet.svar),
-            },
-            arbeidsperiodeland: {
-                label: tilRestLocaleRecord(landTekst.sporsmal, { barnetsNavn: barn?.navn }),
-                verdi: verdiCallbackAlleSpråk(locale =>
-                    landkodeTilSpråk(arbeidsperiodeland.svar, locale)
-                ),
-            },
-            arbeidsgiver: {
-                label: tilRestLocaleRecord(tekster.arbeidsgiver.sporsmal),
-                verdi: sammeVerdiAlleSpråk(arbeidsgiver.svar),
-            },
-            fraDatoArbeidsperiode: {
-                label: tilRestLocaleRecord(tekster.startdato.sporsmal),
-                verdi: sammeVerdiAlleSpråk(fraDatoArbeidsperiode.svar),
-            },
-            tilDatoArbeidsperiode: {
-                label: tilRestLocaleRecord(sluttdatoTekst.sporsmal),
-                verdi: sammeVerdiAlleSpråkEllerUkjent(
-                    tilRestLocaleRecord,
-                    tilDatoArbeidsperiode.svar,
-                    tekster.sluttdatoFremtid.checkboxLabel
-                ),
-            },
-            adresse: søknadsfelt(
-                adresseTekst.sporsmal,
-                sammeVerdiAlleSpråkEllerUkjent(
-                    tilRestLocaleRecord,
-                    adresse.svar,
-                    adresseTekst.checkboxLabel
-                )
-            ),
+            arbeidsperiodeAvsluttet: arbeidsperiodeAvsluttet.svar
+                ? {
+                      label: tilRestLocaleRecord(tekster.arbeidsperiodenAvsluttet.sporsmal),
+                      verdi: sammeVerdiAlleSpråk(arbeidsperiodeAvsluttet.svar),
+                  }
+                : null,
+            arbeidsperiodeland: arbeidsperiodeland.svar
+                ? {
+                      label: tilRestLocaleRecord(landTekst.sporsmal, { barnetsNavn: barn?.navn }),
+                      verdi: verdiCallbackAlleSpråk(locale =>
+                          landkodeTilSpråk(arbeidsperiodeland.svar, locale)
+                      ),
+                  }
+                : null,
+            arbeidsgiver: arbeidsgiver.svar
+                ? {
+                      label: tilRestLocaleRecord(tekster.arbeidsgiver.sporsmal),
+                      verdi: sammeVerdiAlleSpråk(arbeidsgiver.svar),
+                  }
+                : null,
+            fraDatoArbeidsperiode: fraDatoArbeidsperiode.svar
+                ? {
+                      label: tilRestLocaleRecord(tekster.startdato.sporsmal),
+                      verdi: sammeVerdiAlleSpråk(fraDatoArbeidsperiode.svar),
+                  }
+                : null,
+            tilDatoArbeidsperiode: tilDatoArbeidsperiode.svar
+                ? {
+                      label: tilRestLocaleRecord(sluttdatoTekst.sporsmal),
+                      verdi: sammeVerdiAlleSpråkEllerUkjent(
+                          tilRestLocaleRecord,
+                          tilDatoArbeidsperiode.svar,
+                          tekster.sluttdatoFremtid.checkboxLabel
+                      ),
+                  }
+                : null,
+            adresse: adresse.svar
+                ? søknadsfelt(
+                      adresseTekst.sporsmal,
+                      sammeVerdiAlleSpråkEllerUkjent(
+                          tilRestLocaleRecord,
+                          adresse.svar,
+                          adresseTekst.checkboxLabel
+                      )
+                  )
+                : null,
         }),
     };
 };

--- a/src/frontend/utils/mappingTilKontrakt/arbeidsperioder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/arbeidsperioder.ts
@@ -59,14 +59,12 @@ export const tilIArbeidsperiodeIKontraktFormat = ({
                       verdi: sammeVerdiAlleSpråk(arbeidsperiodeAvsluttet.svar),
                   }
                 : null,
-            arbeidsperiodeland: arbeidsperiodeland.svar
-                ? {
-                      label: tilRestLocaleRecord(landTekst.sporsmal, { barnetsNavn: barn?.navn }),
-                      verdi: verdiCallbackAlleSpråk(locale =>
-                          landkodeTilSpråk(arbeidsperiodeland.svar, locale)
-                      ),
-                  }
-                : null,
+            arbeidsperiodeland: {
+                label: tilRestLocaleRecord(landTekst.sporsmal, { barnetsNavn: barn?.navn }),
+                verdi: verdiCallbackAlleSpråk(locale =>
+                    landkodeTilSpråk(arbeidsperiodeland.svar, locale)
+                ),
+            },
             arbeidsgiver: {
                 label: tilRestLocaleRecord(tekster.arbeidsgiver.sporsmal),
                 verdi: sammeVerdiAlleSpråk(arbeidsgiver.svar),
@@ -83,16 +81,14 @@ export const tilIArbeidsperiodeIKontraktFormat = ({
                     tekster.sluttdatoFremtid.checkboxLabel
                 ),
             },
-            adresse: adresse.svar
-                ? søknadsfelt(
-                      adresseTekst.sporsmal,
-                      sammeVerdiAlleSpråkEllerUkjent(
-                          tilRestLocaleRecord,
-                          adresse.svar,
-                          adresseTekst.checkboxLabel
-                      )
-                  )
-                : null,
+            adresse: søknadsfelt(
+                adresseTekst.sporsmal,
+                sammeVerdiAlleSpråkEllerUkjent(
+                    tilRestLocaleRecord,
+                    adresse.svar,
+                    adresseTekst.checkboxLabel
+                )
+            ),
         }),
     };
 };


### PR DESCRIPTION
Viser nå feltene arbeidsgiver, fom, tom og adresse uavhengig av hvilket land man har arbeidet i, i ArbeidsperiodeModal. Dette vil fungere likt for søknad, andre forelder og omsorgsperson.

Har endret litt i kontrakt slik at ingen av feltene lenger er nullable. Har man lagt til en arbeidsperiode skal alle felter være utfylt.

Etter svar på om perioden er avsluttet eller ikke: 
![image](https://user-images.githubusercontent.com/70642183/226361903-f7a6e3f5-87f8-4e71-8d1d-d6bdd82b96e3.png)
