### PR TITLE
Sørger for at vi validerer at dato er på rett format for Backend

### DIFF
--- a/src/frontend/utils/dato.tsx
+++ b/src/frontend/utils/dato.tsx
@@ -70,9 +70,9 @@ export const validerDato = (
         return feil(feltState, plainTekst(feilmelding) ?? '');
     }
 
-    const dato = stringTilDate(feltState.verdi);
+    const dato = parseTilGyldigDato(feltState.verdi, 'yyyy-MM-dd');
 
-    if (!erDatoFormatGodkjent(dato)) {
+    if (!dato) {
         return feil(feltState, plainTekst(tekster.ugyldigDato));
     }
     if (!!sluttdatoAvgrensning && erDatoEtterSluttdatoAvgresning(dato, sluttdatoAvgrensning)) {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Validering av datofeltet sjekket ikke at formatet på datoen var riktig. Legger inn korrekt parsing av string til dato slik at dato blir invalid dersom formatet ikke er riktig.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
