### PR TITLE
Feat/opphold utenfor norge andre forelder

### DIFF
--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering.tsx
@@ -4,10 +4,9 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { useSprakContext } from '@navikt/familie-sprakvelger';
 
 import { useApp } from '../../../context/AppContext';
-import { IBarnMedISøknad } from '../../../typer/barn';
 import { AlternativtSvarForInput, Typografi } from '../../../typer/common';
 import { IArbeidsperiode } from '../../../typer/perioder';
-import { PersonType } from '../../../typer/personType';
+import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { IArbeidsperiodeTekstinnhold } from '../../../typer/sanity/modaler/arbeidsperiode';
 import { formaterDato, formaterDatoMedUkjent } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
@@ -22,12 +21,7 @@ interface Props {
     gjelderUtlandet: boolean;
 }
 
-type ArbeidperiodeOppsummeringPersonTypeProps =
-    | { personType: PersonType.søker; erDød?: boolean; barn?: IBarnMedISøknad | undefined }
-    | { personType: PersonType.omsorgsperson; erDød?: boolean; barn: IBarnMedISøknad | undefined }
-    | { personType: PersonType.andreForelder; erDød: boolean; barn: IBarnMedISøknad | undefined };
-
-type ArbeidsperiodeOppsummeringProps = Props & ArbeidperiodeOppsummeringPersonTypeProps;
+type ArbeidsperiodeOppsummeringProps = Props & PeriodePersonTypeMedBarnProps;
 
 export const ArbeidsperiodeOppsummering: React.FC<ArbeidsperiodeOppsummeringProps> = ({
     arbeidsperiode,

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering.tsx
@@ -4,10 +4,9 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { useSprakContext } from '@navikt/familie-sprakvelger';
 
 import { useApp } from '../../../context/AppContext';
-import { IBarnMedISøknad } from '../../../typer/barn';
 import { Typografi } from '../../../typer/common';
 import { IPensjonsperiode } from '../../../typer/perioder';
-import { PersonType } from '../../../typer/personType';
+import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { formaterDato } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
 import { OppsummeringFelt } from '../../SøknadsSteg/Oppsummering/OppsummeringFelt';
@@ -21,12 +20,7 @@ interface Props {
     gjelderUtlandet: boolean;
 }
 
-type PensjonsperiodeOppsummeringPersonTypeProps =
-    | { personType: PersonType.søker; erDød?: boolean; barn?: IBarnMedISøknad | undefined }
-    | { personType: PersonType.omsorgsperson; erDød?: boolean; barn: IBarnMedISøknad | undefined }
-    | { personType: PersonType.andreForelder; erDød: boolean; barn: IBarnMedISøknad | undefined };
-
-type PensjonsperiodeOppsummeringProps = Props & PensjonsperiodeOppsummeringPersonTypeProps;
+type PensjonsperiodeOppsummeringProps = Props & PeriodePersonTypeMedBarnProps;
 
 export const PensjonsperiodeOppsummering: React.FC<PensjonsperiodeOppsummeringProps> = ({
     pensjonsperiode,

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering.tsx
@@ -4,10 +4,9 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { useSprakContext } from '@navikt/familie-sprakvelger';
 
 import { useApp } from '../../../context/AppContext';
-import { IBarnMedISøknad } from '../../../typer/barn';
 import { Typografi } from '../../../typer/common';
 import { IUtbetalingsperiode } from '../../../typer/perioder';
-import { PersonType } from '../../../typer/personType';
+import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { IAndreUtbetalingerTekstinnhold } from '../../../typer/sanity/modaler/andreUtbetalinger';
 import { formaterDato, formaterDatoMedUkjent } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
@@ -21,12 +20,7 @@ interface Props {
     fjernPeriodeCallback?: (utbetalingsperiode: IUtbetalingsperiode) => void;
 }
 
-type UtbetalingsperiodeOppsummeringPersonTypeProps =
-    | { personType: PersonType.søker; erDød?: boolean; barn?: IBarnMedISøknad | undefined }
-    | { personType: PersonType.omsorgsperson; erDød?: boolean; barn: IBarnMedISøknad | undefined }
-    | { personType: PersonType.andreForelder; erDød: boolean; barn: IBarnMedISøknad | undefined };
-
-type UtbetalingsperiodeOppsummeringProps = Props & UtbetalingsperiodeOppsummeringPersonTypeProps;
+type UtbetalingsperiodeOppsummeringProps = Props & PeriodePersonTypeMedBarnProps;
 
 export const UtbetalingsperiodeOppsummering: React.FC<UtbetalingsperiodeOppsummeringProps> = ({
     utbetalingsperiode,

--- a/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/UtenlandsoppholdModal.tsx
+++ b/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/UtenlandsoppholdModal.tsx
@@ -3,9 +3,8 @@ import React from 'react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
-import { IBarnMedISøknad } from '../../../typer/barn';
 import { IUtenlandsperiode } from '../../../typer/perioder';
-import { PersonType } from '../../../typer/personType';
+import { PeriodePersonTypeMedBarnProps } from '../../../typer/personType';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { EUtenlandsoppholdÅrsak } from '../../../typer/utenlandsopphold';
 import { visFeiloppsummering } from '../../../utils/hjelpefunksjoner';
@@ -34,11 +33,10 @@ import {
     hentUtenlandsoppholdÅrsak,
 } from './utenlandsoppholdSpråkUtils';
 
-type Props = ReturnType<typeof useModal> & {
-    onLeggTilUtenlandsperiode: (periode: IUtenlandsperiode) => void;
-    personType: PersonType;
-    barn?: IBarnMedISøknad;
-};
+type Props = PeriodePersonTypeMedBarnProps &
+    ReturnType<typeof useModal> & {
+        onLeggTilUtenlandsperiode: (periode: IUtenlandsperiode) => void;
+    };
 
 export const UtenlandsoppholdModal: React.FC<Props> = ({
     erÅpen,
@@ -46,6 +44,9 @@ export const UtenlandsoppholdModal: React.FC<Props> = ({
     onLeggTilUtenlandsperiode,
     personType,
     barn,
+    // Midlertidig ubrukt erDød til todo lenger ned er fikset
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    erDød,
 }) => {
     const { tekster, plainTekst } = useApp();
     const { skjema, valideringErOk, nullstillSkjema, validerFelterOgVisFeilmelding } =
@@ -54,8 +55,6 @@ export const UtenlandsoppholdModal: React.FC<Props> = ({
         });
 
     const teksterForPersonType = tekster()[ESanitySteg.FELLES].modaler.utenlandsopphold[personType];
-
-    const barnetsNavn = barn?.navn;
 
     const onLeggTil = () => {
         if (!validerFelterOgVisFeilmelding()) {
@@ -91,11 +90,13 @@ export const UtenlandsoppholdModal: React.FC<Props> = ({
         nullstillSkjema();
     };
 
+    // Todo: håndtere gjenlevende (kun perioder som er avsluttet som alternativer dersom erDød)
+
     return (
         <SkjemaModal
             erÅpen={erÅpen}
             tittel={teksterForPersonType.tittel}
-            flettefelter={{ barnetsNavn }}
+            flettefelter={{ barnetsNavn: barn?.navn }}
             submitKnappTekst={<TekstBlock block={teksterForPersonType.leggTilKnapp} />}
             onSubmitCallback={onLeggTil}
             toggleModal={toggleModal}
@@ -136,6 +137,7 @@ export const UtenlandsoppholdModal: React.FC<Props> = ({
                                 skjema.felter.utenlandsoppholdÅrsak.verdi,
                                 teksterForPersonType
                             )}
+                            flettefelter={{ barnetsNavn: barn?.navn }}
                         />
                     }
                     dynamisk

--- a/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/Utenlandsperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/Utenlandsperiode.tsx
@@ -3,10 +3,9 @@ import React from 'react';
 import { Felt, ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
-import { IBarnMedISøknad } from '../../../typer/barn';
 import { Typografi } from '../../../typer/common';
 import { IUtenlandsperiode } from '../../../typer/perioder';
-import { PersonType } from '../../../typer/personType';
+import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { IDinLivssituasjonFeltTyper, IOmBarnetFeltTyper } from '../../../typer/skjema';
 import { LeggTilKnapp } from '../LeggTilKnapp/LeggTilKnapp';
@@ -15,12 +14,7 @@ import TekstBlock from '../TekstBlock';
 import { UtenlandsoppholdModal } from './UtenlandsoppholdModal';
 import { UtenlandsperiodeOppsummering } from './UtenlandsperiodeOppsummering';
 
-type PersonTypeMedBarn =
-    | { personType: PersonType.søker; barn?: never }
-    | { personType: PersonType.barn; barn: IBarnMedISøknad }
-    | { personType: PersonType.andreForelder; barn: IBarnMedISøknad };
-
-type Props = PersonTypeMedBarn & {
+type Props = PeriodePersonTypeMedBarnProps & {
     skjema: ISkjema<IDinLivssituasjonFeltTyper | IOmBarnetFeltTyper, string>;
     leggTilUtenlandsperiode: (periode: IUtenlandsperiode) => void;
     fjernUtenlandsperiode: (periode: IUtenlandsperiode) => void;
@@ -34,6 +28,7 @@ export const Utenlandsperiode: React.FC<Props> = ({
     registrerteUtenlandsperioder,
     barn,
     personType,
+    erDød,
 }) => {
     const { tekster } = useApp();
     const { erÅpen, toggleModal } = useModal();
@@ -53,7 +48,8 @@ export const Utenlandsperiode: React.FC<Props> = ({
                 toggleModal={toggleModal}
                 onLeggTilUtenlandsperiode={leggTilUtenlandsperiode}
                 personType={personType}
-                barn={barn}
+                barn={personType !== PersonType.søker ? barn : undefined}
+                erDød={personType === PersonType.andreForelder && erDød}
             />
             {registrerteUtenlandsperioder.verdi.map((periode, index) => (
                 <UtenlandsperiodeOppsummering
@@ -62,6 +58,8 @@ export const Utenlandsperiode: React.FC<Props> = ({
                     nummer={index + 1}
                     fjernPeriodeCallback={fjernUtenlandsperiode}
                     personType={personType}
+                    barn={personType !== PersonType.søker ? barn : undefined}
+                    erDød={personType === PersonType.andreForelder && erDød}
                 />
             ))}
             {registrerteUtenlandsperioder.verdi.length > 0 && (

--- a/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/UtenlandsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/UtenlandsperiodeOppsummering.tsx
@@ -5,7 +5,7 @@ import { useSprakContext } from '@navikt/familie-sprakvelger';
 import { useApp } from '../../../context/AppContext';
 import { Typografi } from '../../../typer/common';
 import { IUtenlandsperiode } from '../../../typer/perioder';
-import { PersonType } from '../../../typer/personType';
+import { PeriodePersonTypeMedBarnProps } from '../../../typer/personType';
 import { IUtenlandsoppholdTekstinnhold } from '../../../typer/sanity/modaler/utenlandsopphold';
 import { formaterDato, formaterDatoMedUkjent } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
@@ -23,14 +23,19 @@ type Props = {
     periode: IUtenlandsperiode;
     nummer: number;
     fjernPeriodeCallback?: (periode: IUtenlandsperiode) => void;
-    personType: PersonType;
 };
 
-export const UtenlandsperiodeOppsummering: React.FC<Props> = ({
+type UtenlandsperiodeOppsummeringProps = Props & PeriodePersonTypeMedBarnProps;
+
+export const UtenlandsperiodeOppsummering: React.FC<UtenlandsperiodeOppsummeringProps> = ({
     periode,
     nummer,
     fjernPeriodeCallback,
     personType,
+    barn,
+    // Midlertidig ubrukt erDød til todo lenger ned er fikset
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    erDød,
 }) => {
     const [valgtLocale] = useSprakContext();
     const { plainTekst, tekster } = useApp();
@@ -39,6 +44,8 @@ export const UtenlandsperiodeOppsummering: React.FC<Props> = ({
     const årsak = utenlandsoppholdÅrsak.svar;
     const teksterForPersonType: IUtenlandsoppholdTekstinnhold =
         tekster().FELLES.modaler.utenlandsopphold[personType];
+
+    // Todo: håndtere gjenlevende (kun perioder som er avsluttet som alternativer dersom erDød)
 
     return (
         <>
@@ -64,6 +71,7 @@ export const UtenlandsperiodeOppsummering: React.FC<Props> = ({
                         teksterForPersonType
                     )}
                     søknadsvar={landkodeTilSpråk(oppholdsland.svar, valgtLocale)}
+                    flettefelter={{ barnetsNavn: barn?.navn }}
                 />
 
                 {oppholdslandFraDato && (

--- a/src/frontend/components/SøknadsSteg/OmBarnet/AndreForelder.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/AndreForelder.tsx
@@ -6,12 +6,13 @@ import { ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
 import { IBarnMedISøknad } from '../../../typer/barn';
-import { AlternativtSvarForInput } from '../../../typer/common';
-import { IArbeidsperiode, IPensjonsperiode } from '../../../typer/perioder';
+import { AlternativtSvarForInput, Typografi } from '../../../typer/common';
+import { IArbeidsperiode, IPensjonsperiode, IUtenlandsperiode } from '../../../typer/perioder';
 import { PersonType } from '../../../typer/personType';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { IOmBarnetFeltTyper } from '../../../typer/skjema';
 import { dagensDato } from '../../../utils/dato';
+import AlertStripe from '../../Felleskomponenter/AlertStripe/AlertStripe';
 import { Arbeidsperiode } from '../../Felleskomponenter/Arbeidsperiode/Arbeidsperiode';
 import Datovelger from '../../Felleskomponenter/Datovelger/Datovelger';
 import JaNeiSpm from '../../Felleskomponenter/JaNeiSpm/JaNeiSpm';
@@ -21,6 +22,7 @@ import { SkjemaCheckbox } from '../../Felleskomponenter/SkjemaCheckbox/SkjemaChe
 import { SkjemaFeltInput } from '../../Felleskomponenter/SkjemaFeltInput/SkjemaFeltInput';
 import SkjemaFieldset from '../../Felleskomponenter/SkjemaFieldset';
 import TekstBlock from '../../Felleskomponenter/TekstBlock';
+import { Utenlandsperiode } from '../../Felleskomponenter/UtenlandsoppholdModal/Utenlandsperiode';
 import AndreForelderOppsummering from '../Oppsummering/OppsummeringSteg/OmBarnet/AndreForelderOppsummering';
 import SammeSomAnnetBarnRadio from './SammeSomAnnetBarnRadio';
 
@@ -32,6 +34,8 @@ const AndreForelder: React.FC<{
     fjernArbeidsperiode: (periode: IArbeidsperiode) => void;
     leggTilPensjonsperiode: (periode: IPensjonsperiode) => void;
     fjernPensjonsperiode: (periode: IPensjonsperiode) => void;
+    leggTilUtenlandsperiode: (periode: IUtenlandsperiode) => void;
+    fjernUtenlandsperiode: (periode: IUtenlandsperiode) => void;
 }> = ({
     barn,
     skjema,
@@ -40,6 +44,8 @@ const AndreForelder: React.FC<{
     fjernArbeidsperiode,
     leggTilPensjonsperiode,
     fjernPensjonsperiode,
+    leggTilUtenlandsperiode,
+    fjernUtenlandsperiode,
 }) => {
     const { tekster, plainTekst } = useApp();
     const barnMedSammeForelder: IBarnMedISøknad | undefined = andreBarnSomErFyltUt.find(
@@ -53,7 +59,11 @@ const AndreForelder: React.FC<{
         foedselsdatoAndreForelder,
         foedselsnummerDnummerAndreForelder,
         medlemAvFolktetrygdenAndreForelder,
+        utenlandsoppholdUtenArbeidAndreForelder,
+        utenlandsoppholdUtenArbeidAndreForelderGjenlevende,
     } = teksterForSteg;
+
+    const andreForelderErDød = barn.andreForelderErDød.svar === ESvar.JA;
 
     return (
         <SkjemaFieldset
@@ -168,11 +178,52 @@ const AndreForelder: React.FC<{
                                     gjelderUtlandet
                                     personType={PersonType.andreForelder}
                                     barn={barn}
-                                    erDød={barn.andreForelderErDød.svar === ESvar.JA}
+                                    erDød={andreForelderErDød}
                                     registrerteArbeidsperioder={
                                         skjema.felter.andreForelderArbeidsperioderUtland
                                     }
                                 />
+
+                                <>
+                                    <JaNeiSpm
+                                        skjema={skjema}
+                                        felt={skjema.felter.andreForelderUtenlandsoppholdUtenArbeid}
+                                        spørsmålDokument={
+                                            andreForelderErDød
+                                                ? utenlandsoppholdUtenArbeidAndreForelderGjenlevende
+                                                : utenlandsoppholdUtenArbeidAndreForelder
+                                        }
+                                        tilleggsinfo={
+                                            <AlertStripe variant={'info'}>
+                                                <TekstBlock
+                                                    block={
+                                                        andreForelderErDød
+                                                            ? utenlandsoppholdUtenArbeidAndreForelderGjenlevende.alert
+                                                            : utenlandsoppholdUtenArbeidAndreForelder.alert
+                                                    }
+                                                    typografi={Typografi.BodyShort}
+                                                />
+                                            </AlertStripe>
+                                        }
+                                        flettefelter={{ barnetsNavn: barn?.navn }}
+                                        inkluderVetIkke
+                                    />
+                                    {skjema.felter.andreForelderUtenlandsoppholdUtenArbeid.verdi ===
+                                        ESvar.JA && (
+                                        <Utenlandsperiode
+                                            personType={PersonType.andreForelder}
+                                            skjema={skjema}
+                                            leggTilUtenlandsperiode={leggTilUtenlandsperiode}
+                                            fjernUtenlandsperiode={fjernUtenlandsperiode}
+                                            registrerteUtenlandsperioder={
+                                                skjema.felter.andreForelderUtenlandsperioder
+                                            }
+                                            barn={barn}
+                                            erDød={andreForelderErDød}
+                                        />
+                                    )}
+                                </>
+
                                 <Pensjonsperiode
                                     skjema={skjema}
                                     mottarEllerMottattPensjonFelt={
@@ -182,7 +233,7 @@ const AndreForelder: React.FC<{
                                     fjernPensjonsperiode={fjernPensjonsperiode}
                                     gjelderUtlandet={true}
                                     personType={PersonType.andreForelder}
-                                    erDød={barn.andreForelderErDød.svar === ESvar.JA}
+                                    erDød={andreForelderErDød}
                                     barn={barn}
                                     registrertePensjonsperioder={
                                         skjema.felter.andreForelderPensjonsperioderUtland

--- a/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
@@ -40,6 +40,8 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
         leggTilBarnehageplassPeriode,
         fjernBarnehageplassPeriode,
         harPeriodeMedGradertBarnehageplass,
+        leggTilUtenlandsperiodeAndreForelder,
+        fjernUtenlandsperiodeAndreForelder,
     } = useOmBarnet(barnetsId);
 
     const teksterForSteg: IOmBarnetTekstinnhold = tekster()[ESanitySteg.OM_BARNET];
@@ -100,6 +102,8 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                     fjernArbeidsperiode={fjernArbeidsperiode}
                     leggTilPensjonsperiode={leggTilPensjonsperiode}
                     fjernPensjonsperiode={fjernPensjonsperiode}
+                    leggTilUtenlandsperiode={leggTilUtenlandsperiodeAndreForelder}
+                    fjernUtenlandsperiode={fjernUtenlandsperiodeAndreForelder}
                 />
             )}
 

--- a/src/frontend/components/SøknadsSteg/OmBarnet/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/innholdTyper.ts
@@ -39,4 +39,5 @@ export interface IOmBarnetTekstinnhold {
     borForeldreSammen: ISanitySpørsmålDokument;
     soekerDeltKontantstoette: ISanitySpørsmålDokument;
     utenlandsoppholdUtenArbeidAndreForelder: ISanitySpørsmålDokument;
+    utenlandsoppholdUtenArbeidAndreForelderGjenlevende: ISanitySpørsmålDokument;
 }

--- a/src/frontend/components/SøknadsSteg/OmBarnet/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/innholdTyper.ts
@@ -38,4 +38,5 @@ export interface IOmBarnetTekstinnhold {
     medlemAvFolktetrygdenAndreForelder: ISanitySpørsmålDokument;
     borForeldreSammen: ISanitySpørsmålDokument;
     soekerDeltKontantstoette: ISanitySpørsmålDokument;
+    utenlandsoppholdUtenArbeidAndreForelder: ISanitySpørsmålDokument;
 }

--- a/src/frontend/components/SøknadsSteg/OmBarnet/spørsmål.ts
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/spørsmål.ts
@@ -17,4 +17,6 @@ export enum OmBarnetSpørsmålsId {
     andreForelderPensjonUtlandEnke = 'andre-forelder-pensjon-utland-enke',
     borFastMedSøker = 'bor-barnet-fast-med-deg',
     sammeForelderSomAnnetBarn = 'samme-forelder-som-annet-barn',
+    andreForelderUtenlandsoppholdUtenArbeid = 'andre-forelder-utenlandsopphold',
+    andreForelderUtenlandsoppholdUtenArbeidGjenlevende = 'andre-forelder-utenlandsopphold-gjenlevende',
 }

--- a/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/useOmBarnet.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../../typer/perioder';
 import { IIdNummer } from '../../../typer/person';
 import { PersonType } from '../../../typer/personType';
+import { IUtenlandsoppholdTekstinnhold } from '../../../typer/sanity/modaler/utenlandsopphold';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { IOmBarnetFeltTyper } from '../../../typer/skjema';
 import {
@@ -73,11 +74,15 @@ export const useOmBarnet = (
     fjernKontantstøttePeriode: (periode: IEøsKontantstøttePeriode) => void;
     leggTilBarnehageplassPeriode: (periode: IBarnehageplassPeriode) => void;
     fjernBarnehageplassPeriode: (periode: IBarnehageplassPeriode) => void;
+    leggTilUtenlandsperiodeAndreForelder: (periode: IUtenlandsperiode) => void;
+    fjernUtenlandsperiodeAndreForelder: (periode: IUtenlandsperiode) => void;
 } => {
     const { søknad, settSøknad, tekster, plainTekst } = useApp();
     const { skalTriggeEøsForBarn, barnSomTriggerEøs, settBarnSomTriggerEøs, erEøsLand } = useEøs();
     const teksterForSteg: IOmBarnetTekstinnhold = tekster()[ESanitySteg.OM_BARNET];
     const teksterForModaler = tekster()[ESanitySteg.FELLES].modaler;
+    const teksterForUtenlandsperiode: IUtenlandsoppholdTekstinnhold =
+        teksterForModaler.utenlandsopphold.andreForelder;
 
     const gjeldendeBarn = søknad.barnInkludertISøknaden.find(barn => barn.id === barnetsUuid);
 
@@ -339,7 +344,6 @@ export const useOmBarnet = (
                     : undefined,
         },
         skalSkjules: andreForelderKanIkkeGiOpplysninger.verdi === ESvar.JA,
-        flettefelter: { barnetsNavn: gjeldendeBarn.navn },
     });
 
     const andreForelderYrkesaktivFemÅr = useJaNeiSpmFelt({
@@ -385,6 +389,44 @@ export const useOmBarnet = (
         }
     );
 
+    const andreForelderUtenlandsoppholdUtenArbeid = useJaNeiSpmFelt({
+        søknadsfelt: andreForelder?.[andreForelderDataKeySpørsmål.utenlandsoppholdUtenArbeid],
+        feilmelding: andreForelderErDød
+            ? teksterForSteg.utenlandsoppholdUtenArbeidAndreForelderGjenlevende.feilmelding
+            : teksterForSteg.utenlandsoppholdUtenArbeidAndreForelder.feilmelding,
+        avhengigheter: {
+            andreForelderNavn: {
+                hovedSpørsmål: andreForelderNavn,
+            },
+            andreForelderFnr:
+                andreForelderKanIkkeGiOpplysninger.verdi === ESvar.NEI
+                    ? {
+                          hovedSpørsmål: andreForelderFnr,
+                          tilhørendeFelter: [andreForelderFødselsdato],
+                      }
+                    : undefined,
+        },
+        skalSkjules: andreForelderKanIkkeGiOpplysninger.verdi === ESvar.JA,
+    });
+
+    const {
+        fjernPeriode: fjernUtenlandsperiodeAndreForelder,
+        leggTilPeriode: leggTilUtenlandsperiodeAndreForelder,
+        registrertePerioder: andreForelderUtenlandsperioder,
+    } = usePerioder<IUtenlandsperiode>(
+        `${UtenlandsoppholdSpørsmålId.utenlandsopphold}-${PersonType.andreForelder}`,
+        andreForelder?.utenlandsperioder ?? [],
+        { andreForelderUtenlandsoppholdUtenArbeid },
+        avhengigheter => avhengigheter.andreForelderUtenlandsoppholdUtenArbeid.verdi === ESvar.JA,
+        (felt, avhengigheter) => {
+            return avhengigheter?.andreForelderUtenlandsoppholdUtenArbeid.verdi === ESvar.NEI ||
+                (avhengigheter?.andreForelderUtenlandsoppholdUtenArbeid.verdi === ESvar.JA &&
+                    felt.verdi.length)
+                ? ok(felt)
+                : feil(felt, plainTekst(teksterForUtenlandsperiode.leggTilFeilmelding));
+        }
+    );
+
     const andreForelderPensjonUtland = useJaNeiSpmFelt({
         søknadsfelt: andreForelder?.[andreForelderDataKeySpørsmål.pensjonUtland],
         feilmelding: andreForelderErDød
@@ -403,7 +445,6 @@ export const useOmBarnet = (
                     : undefined,
         },
         skalSkjules: andreForelderKanIkkeGiOpplysninger.verdi === ESvar.JA,
-        flettefelter: { barnetsNavn: gjeldendeBarn.navn },
     });
 
     const {
@@ -478,6 +519,8 @@ export const useOmBarnet = (
             andreForelderYrkesaktivFemÅr,
             andreForelderArbeidUtlandet,
             andreForelderArbeidsperioderUtland,
+            andreForelderUtenlandsoppholdUtenArbeid,
+            andreForelderUtenlandsperioder,
             andreForelderPensjonUtland,
             andreForelderPensjonsperioderUtland,
             borFastMedSøker,
@@ -534,6 +577,10 @@ export const useOmBarnet = (
                     pensjonsperioderUtland:
                         andreForelderPensjonUtland.verdi === ESvar.JA
                             ? andreForelderPensjonsperioderUtland.verdi
+                            : [],
+                    utenlandsperioder:
+                        andreForelderUtenlandsoppholdUtenArbeid.verdi === ESvar.JA
+                            ? andreForelderUtenlandsperioder.verdi
                             : [],
                 },
                 erEøsLand
@@ -593,6 +640,14 @@ export const useOmBarnet = (
                 arbeidsperioderUtland:
                     andreForelderArbeidUtlandet.verdi === ESvar.JA
                         ? andreForelderArbeidsperioderUtland.verdi
+                        : [],
+                utenlandsoppholdUtenArbeid: {
+                    ...andreForelder[andreForelderDataKeySpørsmål.utenlandsoppholdUtenArbeid],
+                    svar: andreForelderUtenlandsoppholdUtenArbeid.verdi,
+                },
+                utenlandsperioder:
+                    andreForelderUtenlandsoppholdUtenArbeid.verdi === ESvar.JA
+                        ? andreForelderUtenlandsperioder.verdi
                         : [],
                 pensjonUtland: {
                     ...andreForelder[andreForelderDataKeySpørsmål.pensjonUtland],
@@ -799,5 +854,7 @@ export const useOmBarnet = (
         leggTilBarnehageplassPeriode,
         fjernBarnehageplassPeriode,
         harPeriodeMedGradertBarnehageplass,
+        fjernUtenlandsperiodeAndreForelder,
+        leggTilUtenlandsperiodeAndreForelder,
     };
 };

--- a/src/frontend/typer/barn.ts
+++ b/src/frontend/typer/barn.ts
@@ -22,8 +22,8 @@ export enum andreForelderDataKeySpørsmål {
     fnr = 'fnr',
     yrkesaktivFemÅr = 'yrkesaktivFemÅr',
     fødselsdato = 'fødselsdato',
-
     arbeidUtlandet = 'arbeidUtlandet',
+    utenlandsoppholdUtenArbeid = 'utenlandsoppholdUtenArbeid',
     pensjonUtland = 'pensjonUtland',
     adresse = 'adresse',
 
@@ -63,6 +63,7 @@ export enum barnDataKeySpørsmål {
 
 export interface IAndreForelder {
     arbeidsperioderUtland: IArbeidsperiode[];
+    utenlandsperioder: IUtenlandsperiode[];
     pensjonsperioderUtland: IPensjonsperiode[];
     kanIkkeGiOpplysninger: ISøknadSpørsmål<ESvar>;
     [andreForelderDataKeySpørsmål.navn]: ISøknadSpørsmål<string | ''>;
@@ -70,6 +71,7 @@ export interface IAndreForelder {
     [andreForelderDataKeySpørsmål.fødselsdato]: ISøknadSpørsmål<DatoMedUkjent>;
     [andreForelderDataKeySpørsmål.yrkesaktivFemÅr]: ISøknadSpørsmål<ESvar | null>;
     [andreForelderDataKeySpørsmål.arbeidUtlandet]: ISøknadSpørsmål<ESvar | null>;
+    [andreForelderDataKeySpørsmål.utenlandsoppholdUtenArbeid]: ISøknadSpørsmål<ESvar | null>;
     [andreForelderDataKeySpørsmål.pensjonUtland]: ISøknadSpørsmål<ESvar | null>;
 
     //EØS

--- a/src/frontend/typer/personType.ts
+++ b/src/frontend/typer/personType.ts
@@ -8,9 +8,10 @@ export enum PersonType {
 }
 
 export type PeriodePersonTypeMedBarnProps =
-    | { personType: PersonType.søker; barn?: never; erDød?: never }
-    | { personType: PersonType.omsorgsperson; barn: IBarnMedISøknad; erDød?: never }
-    | { personType: PersonType.andreForelder; barn: IBarnMedISøknad; erDød: boolean };
+    | { personType: PersonType.søker; erDød?: boolean; barn?: IBarnMedISøknad | undefined }
+    | { personType: PersonType.omsorgsperson; erDød?: boolean; barn: IBarnMedISøknad | undefined }
+    | { personType: PersonType.andreForelder; erDød: boolean; barn: IBarnMedISøknad | undefined }
+    | { personType: PersonType.barn; erDød?: boolean; barn?: IBarnMedISøknad | undefined };
 
 export type PeriodePersonTypeProps =
     | { personType: PersonType.søker; erDød?: never }

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -83,6 +83,7 @@ export interface IModalerTekstinnhold {
     utenlandsopphold: {
         søker: IUtenlandsoppholdTekstinnhold;
         barn: IUtenlandsoppholdTekstinnhold;
+        andreForelder: IUtenlandsoppholdTekstinnhold;
     };
     barnehageplass: IBarnehageplassTekstinnhold;
     andreUtbetalinger: {

--- a/src/frontend/typer/skjema.ts
+++ b/src/frontend/typer/skjema.ts
@@ -63,6 +63,8 @@ export interface IOmBarnetFeltTyper {
     andreForelderYrkesaktivFemÅr: ESvar | null;
     andreForelderArbeidUtlandet: ESvar | null;
     andreForelderArbeidsperioderUtland: IArbeidsperiode[];
+    andreForelderUtenlandsoppholdUtenArbeid: ESvar | null;
+    andreForelderUtenlandsperioder: IUtenlandsperiode[];
     andreForelderPensjonUtland: ESvar | null;
     andreForelderPensjonsperioderUtland: IPensjonsperiode[];
     borFastMedSøker: ESvar | null;

--- a/src/frontend/utils/barn.ts
+++ b/src/frontend/utils/barn.ts
@@ -34,6 +34,7 @@ export const genererInitiellAndreForelder = (
         pensjonsperioderNorge: andreForelder?.pensjonsperioderNorge ?? [],
         pensjonsperioderUtland: andreForelder?.pensjonsperioderUtland ?? [],
         eøsKontantstøttePerioder: andreForelder?.eøsKontantstøttePerioder ?? [],
+        utenlandsperioder: andreForelder?.utenlandsperioder ?? [],
         idNummer: andreForelder?.idNummer ?? [],
         navn: {
             id: OmBarnetSpørsmålsId.andreForelderNavn,
@@ -56,6 +57,12 @@ export const genererInitiellAndreForelder = (
             id: andreForelderErDød
                 ? OmBarnetSpørsmålsId.andreForelderArbeidUtlandetEnke
                 : OmBarnetSpørsmålsId.andreForelderArbeidUtlandet,
+        },
+        utenlandsoppholdUtenArbeid: {
+            svar: andreForelder?.utenlandsoppholdUtenArbeid.svar ?? null,
+            id: andreForelderErDød
+                ? OmBarnetSpørsmålsId.andreForelderUtenlandsoppholdUtenArbeidGjenlevende
+                : OmBarnetSpørsmålsId.andreForelderUtenlandsoppholdUtenArbeid,
         },
         pensjonUtland: {
             svar: andreForelder?.pensjonUtland.svar ?? null,

--- a/src/frontend/utils/sanity.ts
+++ b/src/frontend/utils/sanity.ts
@@ -126,6 +126,7 @@ const strukturertInnholdForModaler = (dokumenter: SanityDokument[]): IModalerTek
         utenlandsopphold: {
             søker: utenlandsopphold(SanityPersonType.SOKER),
             barn: utenlandsopphold(SanityPersonType.BARN),
+            andreForelder: utenlandsopphold(SanityPersonType.ANDRE_FORELDER),
         },
         eøsYtelse: {
             søker: eøsYtelse(SanityPersonType.SOKER),


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Legger til utenlandsperioder for andre forelder.
Denne featuren er ikke ferdig utviklet. Lager en PR for å dele opp oppgaven litt. Denne PR'en inneholder:
- Legge til sanitytekster for utenlandsperiode for andre forelder
- Legge til støtte i utenlandsperiode-komponenten for å ta inn andre forelder
- Legge til selve spørsmål om utenlanderperiode uten arbeid, og utenlandsperiodene på steg "Om Barnet" og lagrer dette på søknadsobjektet.


Til info, her er det som mangler
- Håndtere utelandsbegrunnelser-alternativer for gjenlevende dersom andre forelder er død
- Adressefelt på utenlandsperioden
- Legge til utenlandsperioden i oppsummeringssteget
- Legge til utenlandsperioden i kontrakten
- Trigge eøs-steg, fungerer ikke helt.


### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Usikker på hvorfor eøs-steget ikke fungerer som det skal, men kan se på det i en egen oppgave

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
![Screenshot 2023-03-29 at 12 35 53](https://user-images.githubusercontent.com/8656966/228508042-c2964f0b-73ee-4601-a481-d18d098dd8aa.png)
![Screenshot 2023-03-29 at 12 36 00](https://user-images.githubusercontent.com/8656966/228508047-5e30ce1f-cee7-480a-bcf9-ab9fba6436da.png)
![Screenshot 2023-03-29 at 12 36 10](https://user-images.githubusercontent.com/8656966/228508049-7accd7cb-b80d-4c95-af3f-2f06e21927b0.png)
![Screenshot 2023-03-29 at 12 36 18](https://user-images.githubusercontent.com/8656966/228508051-8323ff34-18b0-4625-8fc0-585ac47ac4bf.png)

