### PR TITLE
Bumpet types/node til 18.17.12 og oppdatert node versjon i README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Dette er en skinnet kopi av barnetrygdsøknaden (kopiert 2.8.22): https://github
 ADR-dokument: https://github.com/navikt/familie/blob/master/doc/adr/0008-KS-lager-egen-søknadsdialog-app.md
 
 ## Avhengigheter
-1. Node versjon >=16
+1. Node versjon >=18
 2. familie-baks-soknad-api (https://github.com/navikt/familie-baks-soknad-api)
 
 ## Log in på https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/mustache-express": "^1.2.2",
-    "@types/node": "^16.11.0",
+    "@types/node": "^18.17.12",
     "@types/react": "^18.2.21",
     "@types/react-collapse": "^5.0.1",
     "@types/react-dom": "^18.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2595,10 +2595,15 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz#4b8ecac87fbefbc92f431d09c30e176fc0a7c377"
   integrity sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==
 
-"@types/node@^16.11.0", "@types/node@^16.18.39":
+"@types/node@^16.18.39":
   version "16.18.46"
   resolved "https://registry.npmjs.org/@types/node/-/node-16.18.46.tgz#9f2102d0ba74a318fcbe170cbff5463f119eab59"
   integrity sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg==
+
+"@types/node@^18.17.12":
+  version "18.18.1"
+  resolved "https://registry.npmjs.org/@types/node/-/node-18.18.1.tgz#80b22f3df719f15c9736207980e95f35d01ec1aa"
+  integrity sha512-3G42sxmm0fF2+Vtb9TJQpnjmP+uKlWvFa8KoEGquh4gqRmoUG/N0ufuhikw6HEsdG2G2oIKhog1GCTfz9v5NdQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Oppdatert node-versjon i README og bumpet `@types/node` til 18.17.12.