### PR TITLE
Fiks at man kan merge dependabot-PR'er

### DIFF
--- a/.github/workflows/build_n_deploy_dev.yaml
+++ b/.github/workflows/build_n_deploy_dev.yaml
@@ -35,6 +35,7 @@ jobs:
 
   bygg:
     name: Bygg app/image og push til GitHub
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: "read"

--- a/.github/workflows/build_n_deploy_dev.yaml
+++ b/.github/workflows/build_n_deploy_dev.yaml
@@ -33,6 +33,31 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
         run: yarn test
 
+  bygg-yarn-for-dependabot:
+    name: Bygg yarn
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          registry-url: "https://npm.pkg.github.com"
+      - name: Yarn install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_RELEASE: ${{ github.sha }}
+          BASE_PATH: ${{ env.BASE_PATH }}
+        run: |
+          yarn --prefer-offline --frozen-lockfile
+          yarn build
+    
+
   bygg:
     name: Bygg app/image og push til GitHub
     if: ${{ github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
Ikke kjør bygg og push steg dersom det er dependabot som initierer action. Når det er dependabot som initierer så får den ikke tak i  secrets, så blir bygget rødt, og da får vi ikke merget. Hopp over dette steget dersom det er dependabot.
