### PR TITLE
Hent kun KS-tekster fra Sanity

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-lint-staged
+npx lint-staged
 yarn run typecheck

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Frontend - søknad for kontantstøtte.
 Dette er en skinnet kopi av barnetrygdsøknaden (kopiert 2.8.22): https://github.com/navikt/familie-ba-soknad
 ADR-dokument: https://github.com/navikt/familie/blob/master/doc/adr/0008-KS-lager-egen-søknadsdialog-app.md
 
+# Lokal utvikling
+
 ## Avhengigheter
 1. Node versjon >=16
 2. familie-baks-soknad-api (https://github.com/navikt/familie-baks-soknad-api)
@@ -29,6 +31,9 @@ For å kjøre med mellomlagring må du ha familie-dokument kjørende (https://gi
 
 # Bygg og deploy
 Appen bygges hos github actions, og gir beskjed til nais deploy om å deployere appen i gcp. Alle commits til brancher går til dev miljøet, appen er ikke satt opp i produksjon enda.
+
+# Tekster
+Tekster hentes fra Sanity. Se [repo](https://github.com/navikt/familie-baks-soknad-sanity) og [Sanity studio](https://familie-baks-soknad.sanity.studio/production/structure)
 
 # Feature toggles (Unleash)
 

--- a/src/frontend/context/SanityContext.ts
+++ b/src/frontend/context/SanityContext.ts
@@ -31,7 +31,7 @@ const [SanityProvider, useSanity] = createUseContext(() => {
         settTeksterRessurs(byggHenterRessurs());
 
         sanityKlient
-            .fetch<SanityDokument[]>('*')
+            .fetch<SanityDokument[]>('*["KONTANTSTØTTE" in ytelse]')
             .then(dokumenter => {
                 fjernRessursSomLaster(ressursId);
                 settTeksterRessurs({


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Favro: NAV-18565

Vi rigger opp til å bruke Sanity i BA-søknaden også. Legger derfor på et filter slik at vi kun henter KS-tekster fra Sanity hit til KS-søknaden

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Vi har gått gjennom søknaden for å kontrollere at alle tekster vi forventer fortsatt er her. Tror det 😇 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
