### PR TITLE
Feat: støtte for ny implementasjon av flettefelter

### DIFF
--- a/src/frontend/components/Felleskomponenter/TekstBlock.tsx
+++ b/src/frontend/components/Felleskomponenter/TekstBlock.tsx
@@ -122,6 +122,10 @@ const TekstBlock: React.FC<{
                         );
                     },
                 },
+                types: {
+                    flettefelt: props =>
+                        flettefeltTilTekst(props.value.flettefelt, flettefelter, valgtLocale),
+                },
             }}
         />
     ) : null;

--- a/src/frontend/utils/sanity.ts
+++ b/src/frontend/utils/sanity.ts
@@ -291,6 +291,8 @@ export const plainTekstHof =
                         ? pipe(node => node, ...transformedMarks)(child).text
                         : pipe(node => node)(child).text;
                     previousElementIsNonSpan = false;
+                } else if (child._type == 'flettefelt') {
+                    tekst += flettefeltTilTekst(child.flettefelt, flettefelter, spesifikkLocale);
                 } else {
                     previousElementIsNonSpan = true;
                 }


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._
Legger til støtte for ny implementasjon av flettefelt. I en mellomfase vil koden nå støtte både gammel og ny variant, frem til alt gammelt er slettet fra Sanity. Alle tekster i ks i dag bruker det gamle flettefeltet, men ved å legge til støtte for den nye så kan vi starte å fase ut det gamle.

Tilsvarende som i ba-soknad: https://github.com/navikt/familie-ba-soknad/pull/1129
Her er sanity-implementasjonen: https://github.com/navikt/familie-baks-soknad-sanity/pull/467

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Har testet manuelt at det funker som det skal, både for plainTekst-funksjon og TekstBlock-komponent.

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Kun 1 commit:)

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
Skal ikke være noen visuelle endringer, skal funke som før.
