### PR TITLE
Token support 4 støtter ikke token i cookie

### DIFF
--- a/src/backend/routes/api.ts
+++ b/src/backend/routes/api.ts
@@ -4,7 +4,7 @@ import Miljø, { basePath } from '../../shared-utils/Miljø';
 import { erklaeringInterceptor } from '../middlewares/erklaering-interceptor';
 import { escapeBody } from '../middlewares/escape';
 import { modellVersjonInterceptor } from '../middlewares/modell-versjon-interceptor';
-import { addCallId, doProxy, fjernAutentiseringHeaderHvisLokalt } from '../middlewares/proxy';
+import { addCallId, doProxy } from '../middlewares/proxy';
 import attachToken from '../middlewares/tokenProxy';
 
 export const konfigurerApi = (app: Express): Express => {
@@ -24,7 +24,6 @@ export const konfigurerApi = (app: Express): Express => {
         `${basePath}dokument`,
         addCallId(),
         attachToken('familie-dokument'),
-        fjernAutentiseringHeaderHvisLokalt(),
         doProxy(Miljø().dokumentUrl, `${basePath}dokument`)
     );
 

--- a/src/shared-utils/Miljø.ts
+++ b/src/shared-utils/Miljø.ts
@@ -67,8 +67,7 @@ const Miljø = (): MiljøProps => {
             dokumentProxyUrl: `http://localhost:3000/dokument`,
             dokumentUrl: `http://localhost:8082/familie/dokument/api`,
             modellVersjon: modellVersjon,
-            wonderwallUrl:
-                'http://localhost:8080/local/cookie?issuerId=tokenx&audience=familie-app&cookiename=localhost-idtoken&subject=12345678901&redirect=',
+            wonderwallUrl: '',
             oauthCallbackUri: 'http://localhost:3000/',
             port: 55554,
         };


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Hvorfor er denne endringen nødvendig? ✨
Oppgraderingen av token-support 4 krevde mest endringer i config for lokal kjøring da ny versjon ikke lenger støtter tokens i cookie.

Før ble token hentet fra token-support sitt local/cookie endepunkt som igjen hentet fra mockOAuth. Dette kunne blitt re-implementert men vi valgte heller å hente og validere tokens med [fakedings](https://github.com/navikt/fakedings) da dette blir mer likt som i preprod/prod og at man ikke lenger er avhengig av å kjøre opp en lokal mock oauth server. Ulempen er at man må ha internett for å kjøre opp appen lokalt.
Basert på det [EF](https://github.com/navikt/familie-ef-soknad/pull/1635) har gjort

Tilhørende PR i: 
[familie-ba-soknad
](https://github.com/navikt/familie-ba-soknad/pull/1148)
[familie-baks-soknad-api
](https://github.com/navikt/familie-baks-soknad-api/pull/196)


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

Kun endringer i oppstart av lokalt utviklingsmiljø(start:dev)
