### PR TITLE
Legg søknaden på ekstern-subdomenet i preprod

### DIFF
--- a/build_n_deploy/naiserator/naiserator_dev.yaml
+++ b/build_n_deploy/naiserator/naiserator_dev.yaml
@@ -24,7 +24,7 @@ spec:
     path: /internal/isReady
     initialDelay: 5
   ingresses:
-    - "https://familie-ks-soknad.intern.dev.nav.no/familie/kontantstotte/soknad"
+    - "https://familie-ks-soknad.ekstern.dev.nav.no/familie/kontantstotte/soknad"
   accessPolicy:
     outbound:
       rules:

--- a/src/shared-utils/Miljø.ts
+++ b/src/shared-utils/Miljø.ts
@@ -36,15 +36,15 @@ const Miljø = (): MiljøProps => {
     if (erDev()) {
         return {
             sanityDataset: 'production',
-            soknadApiProxyUrl: `https://familie-ks-soknad.intern.dev.nav.no${basePath}api`,
+            soknadApiProxyUrl: `https://familie-ks-soknad.ekstern.dev.nav.no${basePath}api`,
             soknadApiUrl: `http://familie-baks-soknad-api/api`,
-            dokumentProxyUrl: `https://familie-ks-soknad.intern.dev.nav.no${basePath}dokument`,
+            dokumentProxyUrl: `https://familie-ks-soknad.ekstern.dev.nav.no${basePath}dokument`,
             dokumentUrl: 'http://familie-dokument/familie/dokument/api', //Vil uansett gå til bucket "familievedlegg" enn så lenge
             modellVersjon: modellVersjon,
             wonderwallUrl:
-                'https://familie-ks-soknad.dev.nav.no/familie/kontantstotte/soknad/oauth2/login?redirect=',
+                'https://familie-ks-soknad.ekstern.dev.nav.no/familie/kontantstotte/soknad/oauth2/login?redirect=',
             oauthCallbackUri:
-                'https://familie-ks-soknad.dev.nav.no/familie/kontantstotte/soknad/oauth2/callback',
+                'https://familie-ks-soknad.ekstern.dev.nav.no/familie/kontantstotte/soknad/oauth2/callback',
             port: 9000,
         };
     } else if (erProd()) {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Favro: [NAV-20732](https://favro.com/organization/98c34fb974ce445eac854de0/?card=NAV-20732)
Tilsvarer https://github.com/navikt/familie-ba-soknad/pull/1238

Legger søknadene på ekstern-subdomenet i preprod heller enn intern, slik at de kan brukertestes av folk som ikke er på naisdevice

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
  
### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
