### PR TITLE
Forbedring av beskrivelse og utseende på vedlegg

### DIFF
--- a/src/frontend/components/Felleskomponenter/VedleggNotis.tsx
+++ b/src/frontend/components/Felleskomponenter/VedleggNotis.tsx
@@ -1,41 +1,30 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 
-import styled from 'styled-components';
+import { Alert, BodyShort, Box } from '@navikt/ds-react';
 
-import { FileTextIcon } from '@navikt/aksel-icons';
+import { useApp } from '../../context/AppContext';
+import { LocaleRecordBlock } from '../../typer/common';
+import { FlettefeltVerdier } from '../../typer/kontrakt/generelle';
+import { ESanitySteg } from '../../typer/sanity/sanity';
 
-const NotisWrapper = styled.div`
-    display: flex;
-    margin-top: 1rem;
-`;
-
-const StyledFileContent = styled(FileTextIcon)`
-    max-width: 1.5rem;
-    min-width: 1.5rem;
-    max-height: fit-content;
-    margin-right: 1rem;
-    font-size: 1.5rem;
-`;
-
-const NotisInnhold = styled.div`
-    ul {
-        margin: 0;
-        padding-left: 1.3rem; // For kulepunkt
-    }
-
-    p {
-        margin: 0;
-    }
-`;
+import TekstBlock from './TekstBlock';
 
 export const VedleggNotis: React.FC<{
-    children?: ReactNode;
+    block: LocaleRecordBlock;
+    flettefelter?: FlettefeltVerdier;
     dynamisk?: boolean;
-}> = ({ dynamisk = false, children }) => {
+}> = ({ block, flettefelter, dynamisk = false }) => {
+    const { tekster, plainTekst } = useApp();
+
+    const dokumentasjonTekster = tekster()[ESanitySteg.DOKUMENTASJON];
+    const { lastOppSenereISoknad } = dokumentasjonTekster;
+
     return (
-        <NotisWrapper aria-live={dynamisk ? 'polite' : 'off'}>
-            <StyledFileContent role={'img'} focusable={false} aria-label={'vedleggsikon'} />
-            <NotisInnhold>{children ? children : null}</NotisInnhold>
-        </NotisWrapper>
+        <Alert variant="info" aria-live={dynamisk ? 'polite' : 'off'}>
+            <TekstBlock block={block} flettefelter={flettefelter} />
+            <Box marginBlock="4 0">
+                <BodyShort>{plainTekst(lastOppSenereISoknad)}</BodyShort>
+            </Box>
+        </Alert>
     );
 };

--- a/src/frontend/components/Felleskomponenter/VedleggNotis.tsx
+++ b/src/frontend/components/Felleskomponenter/VedleggNotis.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Alert, BodyShort, Box } from '@navikt/ds-react';
 
 import { useApp } from '../../context/AppContext';
+import { useFeatureToggles } from '../../context/FeatureToggleContext';
 import { LocaleRecordBlock } from '../../typer/common';
 import { FlettefeltVerdier } from '../../typer/kontrakt/generelle';
 import { ESanitySteg } from '../../typer/sanity/sanity';
@@ -15,6 +16,7 @@ export const VedleggNotis: React.FC<{
     dynamisk?: boolean;
 }> = ({ block, flettefelter, dynamisk = false }) => {
     const { tekster, plainTekst } = useApp();
+    const { toggles } = useFeatureToggles();
 
     const dokumentasjonTekster = tekster()[ESanitySteg.DOKUMENTASJON];
     const { lastOppSenereISoknad } = dokumentasjonTekster;
@@ -22,9 +24,11 @@ export const VedleggNotis: React.FC<{
     return (
         <Alert variant="info" aria-live={dynamisk ? 'polite' : 'off'}>
             <TekstBlock block={block} flettefelter={flettefelter} />
-            <Box marginBlock="4 0">
-                <BodyShort>{plainTekst(lastOppSenereISoknad)}</BodyShort>
-            </Box>
+            {toggles.NYE_VEDLEGGSTEKSTER && (
+                <Box marginBlock="4 0">
+                    <BodyShort>{plainTekst(lastOppSenereISoknad)}</BodyShort>
+                </Box>
+            )}
         </Alert>
     );
 };

--- a/src/frontend/components/SøknadsSteg/DinLivssituasjon/DinLivssituasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/DinLivssituasjon/DinLivssituasjon.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { BodyShort } from '@navikt/ds-react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { Typografi } from '../../../typer/common';
 import { PersonType } from '../../../typer/personType';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
@@ -20,7 +20,7 @@ import { IDinLivssituasjonTekstinnhold } from './innholdTyper';
 import { useDinLivssituasjon } from './useDinLivssituasjon';
 
 const DinLivssituasjon: React.FC = () => {
-    const { tekster, plainTekst } = useApp();
+    const { tekster } = useApp();
     const {
         skjema,
         validerFelterOgVisFeilmelding,
@@ -33,10 +33,13 @@ const DinLivssituasjon: React.FC = () => {
         leggTilUtenlandsperiode,
         fjernUtenlandsperiode,
     } = useDinLivssituasjon();
+    const { toggles } = useFeatureToggles();
 
     const teksterForSteg: IDinLivssituasjonTekstinnhold = tekster()[ESanitySteg.DIN_LIVSSITUASJON];
-
     const { dinLivssituasjonTittel, asylsoeker, utenlandsoppholdUtenArbeid } = teksterForSteg;
+
+    const dokumentasjonTekster = tekster()[ESanitySteg.DOKUMENTASJON];
+    const { vedtakOmOppholdstillatelse } = dokumentasjonTekster;
 
     return (
         <Steg
@@ -56,13 +59,14 @@ const DinLivssituasjon: React.FC = () => {
                     felt={skjema.felter.erAsylsøker}
                     spørsmålDokument={asylsoeker}
                 />
-                {skjema.felter.erAsylsøker.verdi === ESvar.JA && (
-                    <VedleggNotis dynamisk>
-                        <BodyShort size={'medium'}>
-                            {plainTekst(asylsoeker.vedleggsnotis)}
-                        </BodyShort>
-                    </VedleggNotis>
-                )}
+                {skjema.felter.erAsylsøker.verdi === ESvar.JA &&
+                    (toggles.NYE_VEDLEGGSTEKSTER ? (
+                        <VedleggNotis block={vedtakOmOppholdstillatelse} dynamisk />
+                    ) : (
+                        asylsoeker.vedleggsnotis && (
+                            <VedleggNotis block={asylsoeker.vedleggsnotis} dynamisk />
+                        )
+                    ))}
 
                 <Arbeidsperiode
                     skjema={skjema}

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
@@ -42,4 +42,6 @@ export type IDokumentasjonTekstinnhold = {
     [BeskrivelseSanityApiNavn.bekreftelsePaaAtBarnBorSammenMedDeg]: LocaleRecordBlock;
     [BeskrivelseSanityApiNavn.vedtakOmOppholdstillatelse]: LocaleRecordBlock;
     [BeskrivelseSanityApiNavn.bekreftelsePaaBarnehageplass]: LocaleRecordBlock;
+    [BeskrivelseSanityApiNavn.bekreftelsePaaBarnehageplassEttEllerFlereBarn]: LocaleRecordBlock;
+    [BeskrivelseSanityApiNavn.lastOppSenereISoknad]: LocaleRecordBlock;
 };

--- a/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { Alert, BodyShort } from '@navikt/ds-react';
+import { Alert } from '@navikt/ds-react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
 import { useEøs } from '../../../context/EøsContext';
+import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { BarnetsId, Typografi } from '../../../typer/common';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import JaNeiSpm from '../../Felleskomponenter/JaNeiSpm/JaNeiSpm';
@@ -43,6 +44,7 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
         leggTilUtenlandsperiodeAndreForelder,
         fjernUtenlandsperiodeAndreForelder,
     } = useOmBarnet(barnetsId);
+    const { toggles } = useFeatureToggles();
 
     const teksterForSteg: IOmBarnetTekstinnhold = tekster()[ESanitySteg.OM_BARNET];
 
@@ -63,6 +65,9 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
         foreldreBorSammen,
         søkerDeltKontantstøtte,
     } = skjema.felter;
+
+    const dokumentasjonTekster = tekster()[ESanitySteg.DOKUMENTASJON];
+    const { bekreftelsePaaAtBarnBorSammenMedDeg, avtaleOmDeltBosted } = dokumentasjonTekster;
 
     return barn ? (
         <Steg
@@ -121,11 +126,19 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                     </Alert>
                 )}
 
-                {borFastMedSøker.verdi === ESvar.JA && !barn.borMedSøker && (
-                    <VedleggNotis dynamisk>
-                        <BodyShort>{plainTekst(borBarnFastSammenMedDeg.vedleggsnotis)}</BodyShort>
-                    </VedleggNotis>
-                )}
+                {borFastMedSøker.verdi === ESvar.JA &&
+                    !barn.borMedSøker &&
+                    (toggles.NYE_VEDLEGGSTEKSTER ? (
+                        <VedleggNotis
+                            block={bekreftelsePaaAtBarnBorSammenMedDeg}
+                            flettefelter={{ barnetsNavn }}
+                            dynamisk
+                        />
+                    ) : (
+                        borBarnFastSammenMedDeg.vedleggsnotis && (
+                            <VedleggNotis block={borBarnFastSammenMedDeg.vedleggsnotis} dynamisk />
+                        )
+                    ))}
 
                 <JaNeiSpm
                     skjema={skjema}
@@ -150,13 +163,21 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                         }
                     />
                     {søkerDeltKontantstøtte.erSynlig &&
-                        søkerDeltKontantstøtte.verdi === ESvar.JA && (
-                            <VedleggNotis dynamisk>
-                                <BodyShort>
-                                    {plainTekst(soekerDeltKontantstoette.vedleggsnotis)}
-                                </BodyShort>
-                            </VedleggNotis>
-                        )}
+                        søkerDeltKontantstøtte.verdi === ESvar.JA &&
+                        (toggles.NYE_VEDLEGGSTEKSTER ? (
+                            <VedleggNotis
+                                block={avtaleOmDeltBosted}
+                                flettefelter={{ barnetsNavn }}
+                                dynamisk
+                            />
+                        ) : (
+                            soekerDeltKontantstoette.vedleggsnotis && (
+                                <VedleggNotis
+                                    block={soekerDeltKontantstoette.vedleggsnotis}
+                                    dynamisk
+                                />
+                            )
+                        ))}
                 </>
             </SkjemaFieldset>
         </Steg>

--- a/src/frontend/typer/dokumentasjon.ts
+++ b/src/frontend/typer/dokumentasjon.ts
@@ -57,6 +57,8 @@ export enum BeskrivelseSanityApiNavn {
     bekreftelsePaaAtBarnBorSammenMedDeg = 'bekreftelsePaaAtBarnBorSammenMedDeg',
     vedtakOmOppholdstillatelse = 'vedtakOmOppholdstillatelse',
     bekreftelsePaaBarnehageplass = 'bekreftelsePaaBarnehageplass',
+    bekreftelsePaaBarnehageplassEttEllerFlereBarn = 'bekreftelsePaaBarnehageplassEttEllerFlereBarn',
+    lastOppSenereISoknad = 'lastOppSenereISoknad',
 }
 
 export const dokumentasjonsbehovTilBeskrivelseSanityApiNavn = (

--- a/src/frontend/typer/feature-toggles.ts
+++ b/src/frontend/typer/feature-toggles.ts
@@ -2,9 +2,15 @@ export enum EToggle {
     KONTANTSTOTTE = 'familie-ks-soknad.disable-soknad',
 }
 
-export enum EFeatureToggle {}
+export enum EFeatureToggle {
+    // EKSEMPEL = 'EKSEMPEL',
+    NYE_VEDLEGGSTEKSTER = 'NYE_VEDLEGGSTEKSTER',
+}
 
-export const ToggleKeys: Record<EFeatureToggle, string> = {};
+export const ToggleKeys: Record<EFeatureToggle, string> = {
+    // [EFeatureToggle.EKSEMPEL]: 'familie-ks-soknad.eksempel',
+    [EFeatureToggle.NYE_VEDLEGGSTEKSTER]: 'familie-ks-soknad.nye-vedleggstekster',
+};
 
 export type EAllFeatureToggles = Record<EFeatureToggle, boolean>;
 

--- a/src/frontend/utils/testing.tsx
+++ b/src/frontend/utils/testing.tsx
@@ -25,6 +25,7 @@ import { SanityProvider } from '../context/SanityContext';
 import { SpråkProvider } from '../context/SpråkContext';
 import { StegProvider } from '../context/StegContext';
 import { LocaleType } from '../typer/common';
+import { EFeatureToggle } from '../typer/feature-toggles';
 import { ESivilstand } from '../typer/kontrakt/generelle';
 import { IKvittering } from '../typer/kvittering';
 import { ISøker, ISøkerRespons } from '../typer/person';
@@ -146,7 +147,8 @@ export const mockFeatureToggle = () => {
         .spyOn(featureToggleContext, 'useFeatureToggles')
         .mockImplementation(
             jest.fn().mockReturnValue({
-                toggles: {},
+                // toggles: { [EFeatureToggle.EXAMPLE]: false },
+                toggles: { [EFeatureToggle.NYE_VEDLEGGSTEKSTER]: false },
             })
         );
     return { useFeatureToggle };


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21816

### 💰 Hva forsøker du å løse i denne PR'en
- Endrer utseende og koden for VedleggNotis komponenten slik at den tar i bruk Alert fra Aksel og tar block og flettefelter som props.
- Legger til nye tekster i vedleggnotisene slik at tekstene hentes fra Dokumentasjon steget istedenfor individuelle steg. Dette sees kun når feature toggle er på (https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ks-soknad.nye-vedleggstekster)

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Jeg finner ingen lignende tester for dette.
- Funksjonelle endringer er ikke gjort, kun visuelle endringer og hva slags tekst som vises.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Gå gjennom søknaden og se etter vedleggsnotiser som nå er blå/info alerts.
- Test søknaden med feature toggle skrudd av og på for å se forskjellene.
  - Merk at tekster må endres før feature toggle skrus på i prod. Nå vil flere av tekstene være uferdige og inneholde placeholders markert med `(VEDLEGGSNOTIS MÅ ENDRES)`

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Før
![image](https://github.com/user-attachments/assets/38c6f556-2bc8-4cd7-a57b-d58e45a34cb8)

#### Etter
##### Feature toggle: av
![image](https://github.com/user-attachments/assets/87c98699-c744-4dba-b4aa-de2dda25c9ec)

##### Feature toggle: på
![image](https://github.com/user-attachments/assets/2a284f7b-26c6-43a8-8382-b519f277367b)