### PR TITLE
Bytter fra Stepper til FormProgress for skjema-steg

### DIFF
--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode, useEffect } from 'react';
 
 import { useNavigate } from 'react-router-dom';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
-import { Stepper } from '@navikt/ds-react';
+import { Box, FormProgress } from '@navikt/ds-react';
 import { ISkjema } from '@navikt/familie-skjema';
 import { setAvailableLanguages } from '@navikt/nav-dekoratoren-moduler';
 
@@ -11,7 +11,6 @@ import { useApp } from '../../../context/AppContext';
 import { useAppNavigation } from '../../../context/AppNavigationContext';
 import { useSteg } from '../../../context/StegContext';
 import useFørsteRender from '../../../hooks/useFørsteRender';
-import { device } from '../../../Theme';
 import { RouteEnum } from '../../../typer/routes';
 import { SkjemaFeltTyper } from '../../../typer/skjema';
 import {
@@ -59,35 +58,6 @@ const Form = styled.form`
     width: 100%;
 `;
 
-const kompaktStepper = () => css`
-    * {
-        font-size: 0;
-        --navds-stepper-circle-size: 0.75rem;
-        --navds-stepper-border-width: 1px;
-        > li {
-            gap: 0;
-        }
-    }
-`;
-
-const StepperContainer = styled.div<{ $antallSteg: number }>`
-    margin: 0 auto;
-    display: flex;
-    justify-content: center;
-  
-    @media all and ${device.mobile} {
-       ${kompaktStepper};
-    }
-
-  ${props =>
-      props.$antallSteg > 12 &&
-      css`
-          @media all and ${device.tablet} {
-              ${kompaktStepper};
-          }
-      `}
-}`;
-
 function Steg({ tittel, skjema, gåVidereCallback, children }: ISteg) {
     const navigate = useNavigate();
     const { erÅpen: erModellVersjonModalÅpen, åpneModal: åpneModellVersjonModal } = useModal();
@@ -99,11 +69,11 @@ function Steg({ tittel, skjema, gåVidereCallback, children }: ISteg) {
         modellVersjonOppdatert,
     } = useApp();
     const {
+        formProgressSteps,
         hentNesteSteg,
         hentForrigeSteg,
         hentNåværendeSteg,
         hentNåværendeStegIndex,
-        stepperObjekter,
         erPåKvitteringsside,
     } = useSteg();
     const { komFra, settKomFra } = useAppNavigation();
@@ -169,29 +139,34 @@ function Steg({ tittel, skjema, gåVidereCallback, children }: ISteg) {
         navigate(forrigeRoute.path);
     };
 
+    const håndterGåTilSteg = (stegIndex: number) => {
+        const steg = formProgressSteps[stegIndex];
+        navigate(steg.path);
+    };
+
     return (
         <>
             <ScrollHandler />
             <header>
                 <Banner />
                 {nyesteNåværendeRoute !== RouteEnum.Kvittering && (
-                    <StepperContainer $antallSteg={stepperObjekter.length}>
-                        <Stepper
-                            aria-label={'Søknadssteg'}
+                    <Box marginInline="8">
+                        <FormProgress
+                            totalSteps={formProgressSteps.length}
                             activeStep={hentNåværendeStegIndex()}
-                            orientation={'horizontal'}
-                            interactive={false}
+                            onStepChange={stegIndex => håndterGåTilSteg(stegIndex - 1)}
                         >
-                            {stepperObjekter.map((value, index) => (
-                                <Stepper.Step
-                                    children={''}
-                                    title={value.label}
-                                    key={value.key}
+                            {formProgressSteps.map((value, index) => (
+                                <FormProgress.Step
+                                    key={index}
                                     completed={index + 1 < hentNåværendeStegIndex()}
-                                />
+                                    interactive={index + 1 < hentNåværendeStegIndex()}
+                                >
+                                    {value.label}
+                                </FormProgress.Step>
                             ))}
-                        </Stepper>
-                    </StepperContainer>
+                        </FormProgress>
+                    </Box>
                 )}
             </header>
             <InnholdContainer>

--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Box, FormProgress } from '@navikt/ds-react';
+import { FormProgress } from '@navikt/ds-react';
 import { ISkjema } from '@navikt/familie-skjema';
 import { setAvailableLanguages } from '@navikt/nav-dekoratoren-moduler';
 
@@ -11,6 +11,7 @@ import { useApp } from '../../../context/AppContext';
 import { useAppNavigation } from '../../../context/AppNavigationContext';
 import { useSteg } from '../../../context/StegContext';
 import useFørsteRender from '../../../hooks/useFørsteRender';
+import { device } from '../../../Theme';
 import { RouteEnum } from '../../../typer/routes';
 import { SkjemaFeltTyper } from '../../../typer/skjema';
 import {
@@ -39,6 +40,16 @@ interface ISteg {
     gåVidereCallback?: () => Promise<boolean>;
     children?: ReactNode;
 }
+
+const FormProgressContainer = styled.div`
+    max-width: var(--innhold-bredde);
+    margin: 0 auto;
+
+    @media all and ${device.tablet} {
+        max-width: 100%;
+        margin: 0 var(--a-spacing-8);
+    }
+`;
 
 const ChildrenContainer = styled.div`
     margin-bottom: 2rem;
@@ -150,7 +161,7 @@ function Steg({ tittel, skjema, gåVidereCallback, children }: ISteg) {
             <header>
                 <Banner />
                 {nyesteNåværendeRoute !== RouteEnum.Kvittering && (
-                    <Box marginInline="8">
+                    <FormProgressContainer>
                         <FormProgress
                             totalSteps={formProgressSteps.length}
                             activeStep={hentNåværendeStegIndex()}
@@ -166,7 +177,7 @@ function Steg({ tittel, skjema, gåVidereCallback, children }: ISteg) {
                                 </FormProgress.Step>
                             ))}
                         </FormProgress>
-                    </Box>
+                    </FormProgressContainer>
                 )}
             </header>
             <InnholdContainer>

--- a/src/frontend/context/Steg.test.tsx
+++ b/src/frontend/context/Steg.test.tsx
@@ -29,7 +29,7 @@ describe('Steg', () => {
         expect(result.current.steg.length).toEqual(9);
     });
 
-    test(`stepperObjekter skal returnere en liste uten forside`, () => {
+    test(`formProgressSteps skal returnere en liste uten forside og kvittering`, () => {
         spyOnUseApp({
             barnInkludertISøknaden: [],
         });
@@ -39,7 +39,7 @@ describe('Steg', () => {
             </RoutesProvider>
         );
         const { result } = renderHook(() => useSteg(), { wrapper });
-        expect(result.current.stepperObjekter.length).toEqual(8);
+        expect(result.current.formProgressSteps.length).toEqual(7);
     });
 
     test(`Kan hente neste steg fra forsiden`, () => {

--- a/src/frontend/context/StegContext.tsx
+++ b/src/frontend/context/StegContext.tsx
@@ -10,12 +10,6 @@ import { useApp } from './AppContext';
 import { useEøs } from './EøsContext';
 import { useRoutes } from './RoutesContext';
 
-interface StepperStegProps {
-    label: string;
-    index: number;
-    key: number;
-}
-
 const [StegProvider, useSteg] = createUseContext(() => {
     const { søknad } = useApp();
     const { barnInkludertISøknaden } = søknad;
@@ -72,13 +66,9 @@ const [StegProvider, useSteg] = createUseContext(() => {
         })
         .flat();
 
-    const stepperObjekter: StepperStegProps[] = steg
-        .filter(steg => steg.route !== RouteEnum.Forside)
-        .map((steg, index) => ({
-            label: steg.label,
-            index: index,
-            key: index,
-        }));
+    const formProgressSteps: ISteg[] = steg.filter(
+        steg => steg.route !== RouteEnum.Forside && steg.route !== RouteEnum.Kvittering
+    );
 
     const hentSteg = (pathname: string): ISteg => {
         const index = steg.findIndex(steg => matchPath(steg.path, decodeURIComponent(pathname)));
@@ -131,7 +121,7 @@ const [StegProvider, useSteg] = createUseContext(() => {
 
     return {
         steg,
-        stepperObjekter,
+        formProgressSteps,
         hentStegNummer,
         hentStegObjektForBarn,
         hentNesteSteg,


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21058

### 💰 Hva forsøker du å løse i denne PR'en
- Bytter ut Stepper komponenten med FormProgress

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ingen nye tester er skrevet, men testen for hvor stor listen over hvor mange formProgressSteps (tidligere stepperObjekter) endres ettersom Kvittering ikke skal være del av FormProgress i følge Aksel: https://aksel.nav.no/komponenter/core/formprogress#:~:text=mer%20skreddersydd%20framdriftsindikator.-,Hvilke%20steg%20skal%20v%C3%A6re%20med%3F,-Introside%20og%20kvitteringsside

### 🤷‍♀ ️Hvor er det lurt å starte?
- Gå gjennom søknaden og se at FormProgress viser steg på riktig måte.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Før
![image](https://github.com/user-attachments/assets/845d5d26-b9ca-495e-8d49-5057ac67729a)

#### Etter
![image](https://github.com/user-attachments/assets/ed39be83-308e-41d5-8500-acc06dd72fde)