### PR TITLE
Legger til guide på steg og forbedrer layout og spacing på forside

### DIFF
--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -9,6 +9,7 @@ import { setAvailableLanguages } from '@navikt/nav-dekoratoren-moduler';
 
 import { useApp } from '../../../context/AppContext';
 import { useAppNavigation } from '../../../context/AppNavigationContext';
+import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { useSteg } from '../../../context/StegContext';
 import useFørsteRender from '../../../hooks/useFørsteRender';
 import { device } from '../../../Theme';
@@ -108,6 +109,7 @@ function Steg({ tittel, guide = undefined, skjema, gåVidereCallback, children }
         erPåKvitteringsside,
     } = useSteg();
     const { komFra, settKomFra } = useAppNavigation();
+    const { toggles } = useFeatureToggles();
 
     const nesteRoute = hentNesteSteg();
     const forrigeRoute = hentForrigeSteg();
@@ -199,15 +201,11 @@ function Steg({ tittel, guide = undefined, skjema, gåVidereCallback, children }
                 <TittelContainer id={'stegHovedtittel'} tabIndex={-1}>
                     {tittel}
                 </TittelContainer>
-
-                {/* TODO: Legg til feature-toggle */}
-                {guide && (
+                {toggles.VIS_GUIDE_I_STEG && guide && (
                     <Box marginBlock="0 12">
                         <GuidePanel poster>{guide}</GuidePanel>
                     </Box>
                 )}
-                {/*  */}
-
                 <Form onSubmit={event => håndterGåVidere(event)} autoComplete="off">
                     <ChildrenContainer>{children}</ChildrenContainer>
                     {skjema && visFeiloppsummering(skjema.skjema) && (

--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 
-import { Stepper } from '@navikt/ds-react';
+import { Box, GuidePanel, Stepper } from '@navikt/ds-react';
 import { ISkjema } from '@navikt/familie-skjema';
 import { setAvailableLanguages } from '@navikt/nav-dekoratoren-moduler';
 
@@ -31,6 +31,7 @@ import { ScrollHandler } from './ScrollHandler';
 
 interface ISteg {
     tittel: ReactNode;
+    guide?: ReactNode;
     skjema?: {
         validerFelterOgVisFeilmelding: () => boolean;
         valideringErOk: () => boolean;
@@ -88,7 +89,7 @@ const StepperContainer = styled.div<{ $antallSteg: number }>`
       `}
 }`;
 
-function Steg({ tittel, skjema, gåVidereCallback, children }: ISteg) {
+function Steg({ tittel, guide = undefined, skjema, gåVidereCallback, children }: ISteg) {
     const navigate = useNavigate();
     const { erÅpen: erModellVersjonModalÅpen, åpneModal: åpneModellVersjonModal } = useModal();
     const {
@@ -198,6 +199,15 @@ function Steg({ tittel, skjema, gåVidereCallback, children }: ISteg) {
                 <TittelContainer id={'stegHovedtittel'} tabIndex={-1}>
                     {tittel}
                 </TittelContainer>
+
+                {/* TODO: Legg til feature-toggle */}
+                {guide && (
+                    <Box marginBlock="0 12">
+                        <GuidePanel poster>{guide}</GuidePanel>
+                    </Box>
+                )}
+                {/*  */}
+
                 <Form onSubmit={event => håndterGåVidere(event)} autoComplete="off">
                     <ChildrenContainer>{children}</ChildrenContainer>
                     {skjema && visFeiloppsummering(skjema.skjema) && (

--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -90,7 +90,7 @@ const StepperContainer = styled.div<{ $antallSteg: number }>`
       `}
 }`;
 
-function Steg({ tittel, guide = undefined, skjema, gåVidereCallback, children }: ISteg) {
+function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
     const navigate = useNavigate();
     const { erÅpen: erModellVersjonModalÅpen, åpneModal: åpneModellVersjonModal } = useModal();
     const {

--- a/src/frontend/components/SøknadsSteg/DinLivssituasjon/DinLivssituasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/DinLivssituasjon/DinLivssituasjon.tsx
@@ -36,13 +36,19 @@ const DinLivssituasjon: React.FC = () => {
 
     const teksterForSteg: IDinLivssituasjonTekstinnhold = tekster()[ESanitySteg.DIN_LIVSSITUASJON];
 
-    const { dinLivssituasjonTittel, asylsoeker, utenlandsoppholdUtenArbeid } = teksterForSteg;
+    const {
+        dinLivssituasjonTittel,
+        dinLivssituasjonGuide,
+        asylsoeker,
+        utenlandsoppholdUtenArbeid,
+    } = teksterForSteg;
 
     return (
         <Steg
             tittel={
                 <TekstBlock block={dinLivssituasjonTittel} typografi={Typografi.StegHeadingH1} />
             }
+            guide={<TekstBlock block={dinLivssituasjonGuide} />}
             skjema={{
                 validerFelterOgVisFeilmelding,
                 valideringErOk,

--- a/src/frontend/components/SøknadsSteg/DinLivssituasjon/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/DinLivssituasjon/innholdTyper.ts
@@ -3,6 +3,7 @@ import { ISanitySpørsmålDokument } from '../../../typer/sanity/sanity';
 
 export interface IDinLivssituasjonTekstinnhold {
     dinLivssituasjonTittel: LocaleRecordBlock;
+    dinLivssituasjonGuide: LocaleRecordBlock;
     arbeidUtenforNorge: ISanitySpørsmålDokument;
     pensjonUtland: ISanitySpørsmålDokument;
     asylsoeker: ISanitySpørsmålDokument;

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
@@ -6,11 +6,13 @@ import { Alert, BodyShort } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import useFørsteRender from '../../../hooks/useFørsteRender';
 import { useSendInnSkjema } from '../../../hooks/useSendInnSkjema';
 import { Typografi } from '../../../typer/common';
 import { IDokumentasjon, IVedlegg } from '../../../typer/dokumentasjon';
 import { Dokumentasjonsbehov } from '../../../typer/kontrakt/dokumentasjon';
+import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { erDokumentasjonRelevant } from '../../../utils/dokumentasjon';
 import { Feilside } from '../../Felleskomponenter/Feilside/Feilside';
 import KomponentGruppe from '../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
@@ -29,6 +31,7 @@ export const erVedleggstidspunktGyldig = (vedleggTidspunkt: string): boolean => 
 const Dokumentasjon: React.FC = () => {
     const { søknad, settSøknad, innsendingStatus, tekster } = useApp();
     const { sendInnSkjema } = useSendInnSkjema();
+    const { toggles } = useFeatureToggles();
     const [slettaVedlegg, settSlettaVedlegg] = useState<IVedlegg[]>([]);
 
     const { dokumentasjonInfo, dokumentasjonTittel, forLangTidDokumentasjon, nudgeDokumentasjon } =
@@ -68,9 +71,15 @@ const Dokumentasjon: React.FC = () => {
         });
     });
 
+    const stegTekster = tekster()[ESanitySteg.DOKUMENTASJON];
+    const { dokumentasjonGuide } = stegTekster;
+
+    const visNyGuide = toggles.VIS_GUIDE_I_STEG && dokumentasjonGuide;
+
     return (
         <Steg
             tittel={<TekstBlock block={dokumentasjonTittel} typografi={Typografi.StegHeadingH1} />}
+            guide={<TekstBlock block={dokumentasjonGuide} />}
             gåVidereCallback={async () => {
                 const [success, _] = await sendInnSkjema();
                 return success;
@@ -93,14 +102,20 @@ const Dokumentasjon: React.FC = () => {
                     </Alert>
                 </KomponentGruppe>
             )}
-            <KomponentGruppe>
-                <Alert variant={'info'}>
-                    <TekstBlock block={nudgeDokumentasjon} typografi={Typografi.BodyLong} />
-                </Alert>
+            {visNyGuide ? (
+                <KomponentGruppe>
+                    <PictureScanningGuide />
+                </KomponentGruppe>
+            ) : (
+                <KomponentGruppe>
+                    <Alert variant={'info'}>
+                        <TekstBlock block={nudgeDokumentasjon} typografi={Typografi.BodyLong} />
+                    </Alert>
 
-                <TekstBlock block={dokumentasjonInfo} typografi={Typografi.BodyLong} />
-                <PictureScanningGuide />
-            </KomponentGruppe>
+                    <TekstBlock block={dokumentasjonInfo} typografi={Typografi.BodyLong} />
+                    <PictureScanningGuide />
+                </KomponentGruppe>
+            )}
             {søknad.dokumentasjon
                 .filter(dokumentasjon => erDokumentasjonRelevant(dokumentasjon))
                 .map((dokumentasjon, index) => (

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
@@ -3,6 +3,7 @@ import { BeskrivelseSanityApiNavn, TittelSanityApiNavn } from '../../../typer/do
 
 export type IDokumentasjonTekstinnhold = {
     dokumentasjonTittel: LocaleRecordBlock;
+    dokumentasjonGuide: LocaleRecordBlock;
     sendtInnTidligere: LocaleRecordBlock;
     vedleggXavY: LocaleRecordBlock;
     slippFilenHer: LocaleRecordBlock;

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
@@ -72,6 +72,7 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
 
     const {
         eoesForBarnTittel,
+        eosForBarnGuide,
         valgalternativSlektsforholdPlaceholder,
         hvilkenRelasjon,
         borMedAndreForelder,
@@ -93,6 +94,7 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                     {uppercaseFørsteBokstav(plainTekst(eoesForBarnTittel, { barnetsNavn }))}
                 </Heading>
             }
+            guide={<TekstBlock block={eosForBarnGuide} />}
             skjema={{
                 validerFelterOgVisFeilmelding,
                 valideringErOk,

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/innholdTyper.ts
@@ -3,6 +3,7 @@ import { ISanitySpørsmålDokument } from '../../../../typer/sanity/sanity';
 
 export interface IEøsForBarnTekstinnhold {
     eoesForBarnTittel: LocaleRecordBlock;
+    eosForBarnGuide: LocaleRecordBlock;
     idNummerBarn: ISanitySpørsmålDokument;
     slektsforhold: ISanitySpørsmålDokument;
     hvilkenRelasjon: ISanitySpørsmålDokument;

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Søker/EøsForSøker.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Søker/EøsForSøker.tsx
@@ -32,7 +32,7 @@ const EøsForSøker: React.FC = () => {
         settIdNummerFelter,
     } = useEøsForSøker();
 
-    const { eoesForSoekerTittel, hvorBor } = tekster().EØS_FOR_SØKER;
+    const { eoesForSoekerTittel, eosForSokerGuide, hvorBor } = tekster().EØS_FOR_SØKER;
 
     return (
         <Steg
@@ -41,6 +41,7 @@ const EøsForSøker: React.FC = () => {
                     {uppercaseFørsteBokstav(plainTekst(eoesForSoekerTittel))}
                 </Heading>
             }
+            guide={<TekstBlock block={eosForSokerGuide} />}
             skjema={{
                 validerFelterOgVisFeilmelding,
                 valideringErOk,

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Søker/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Søker/innholdTyper.ts
@@ -3,6 +3,7 @@ import { ISanitySpørsmålDokument } from '../../../../typer/sanity/sanity';
 
 export interface IEøsForSøkerTekstinnhold {
     eoesForSoekerTittel: LocaleRecordBlock;
+    eosForSokerGuide: LocaleRecordBlock;
     arbeidNorge: ISanitySpørsmålDokument;
     pensjonNorge: ISanitySpørsmålDokument;
     idNummer: ISanitySpørsmålDokument;

--- a/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
@@ -49,7 +49,7 @@ const Forside: React.FC = () => {
 
     return (
         <InnholdContainer>
-            <Box marginBlock="0 9">
+            <Box marginBlock="0 12">
                 <Heading size="xlarge" align="center">
                     <TekstBlock block={soeknadstittel} />
                 </Heading>

--- a/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect } from 'react';
 
-import styled from 'styled-components';
-
-import { GuidePanel } from '@navikt/ds-react';
+import { Box, GuidePanel, Heading } from '@navikt/ds-react';
 import { setAvailableLanguages } from '@navikt/nav-dekoratoren-moduler';
 
 import Miljø from '../../../../shared-utils/Miljø';
@@ -18,12 +16,6 @@ import TekstBlock from '../../Felleskomponenter/TekstBlock';
 
 import BekreftelseOgStartSoknad from './BekreftelseOgStartSoknad';
 import FortsettPåSøknad from './FortsettPåSøknad';
-
-const TittelContainer = styled.div`
-    && {
-        margin-top: 4rem;
-    }
-`;
 
 const Forside: React.FC = () => {
     const { mellomlagretVerdi, settNåværendeRoute, tekster } = useApp();
@@ -57,13 +49,15 @@ const Forside: React.FC = () => {
 
     return (
         <InnholdContainer>
-            <GuidePanel>
+            <Box marginBlock="0 9">
+                <Heading size="xlarge" align="center">
+                    <TekstBlock block={soeknadstittel} />
+                </Heading>
+            </Box>
+
+            <GuidePanel poster>
                 <TekstBlock block={veilederhilsen} typografi={Typografi.BodyShort} />
             </GuidePanel>
-
-            <TittelContainer>
-                <TekstBlock block={soeknadstittel} typografi={Typografi.ForsideHeadingH1} />
-            </TittelContainer>
 
             <Informasjonsbolk>
                 <TekstBlock block={punktliste} />

--- a/src/frontend/components/SøknadsSteg/OmBarnaDine/OmBarnaDine.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnaDine/OmBarnaDine.tsx
@@ -36,6 +36,7 @@ const OmBarnaDine: React.FC = () => {
     const teksterForSteg: IOmBarnaTekstinnhold = tekster()[ESanitySteg.OM_BARNA];
     const {
         omBarnaTittel,
+        omBarnaGuide,
         hvemBarnehageplass,
         fosterbarn,
         institusjonKontantstoette,
@@ -63,6 +64,7 @@ const OmBarnaDine: React.FC = () => {
     return (
         <Steg
             tittel={<TekstBlock block={omBarnaTittel} typografi={Typografi.StegHeadingH1} />}
+            guide={<TekstBlock block={omBarnaGuide} />}
             skjema={{
                 validerFelterOgVisFeilmelding,
                 valideringErOk,

--- a/src/frontend/components/SøknadsSteg/OmBarnaDine/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/OmBarnaDine/innholdTyper.ts
@@ -3,6 +3,7 @@ import { ISanitySpørsmålDokument } from '../../../typer/sanity/sanity';
 
 export interface IOmBarnaTekstinnhold {
     omBarnaTittel: LocaleRecordBlock;
+    omBarnaGuide: LocaleRecordBlock;
     fosterbarn: ISanitySpørsmålDokument;
     hvemFosterbarn: ISanitySpørsmålDokument;
     institusjonKontantstoette: ISanitySpørsmålDokument;

--- a/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/OmDeg.tsx
@@ -22,6 +22,7 @@ const OmDeg: React.FC = () => {
     const {
         [ESanitySteg.OM_DEG]: {
             omDegTittel,
+            omDegGuide,
             borPaaAdressen,
             oppholdtDegSammenhengende,
             planleggerAaBoSammenhengende,
@@ -32,6 +33,7 @@ const OmDeg: React.FC = () => {
     return (
         <Steg
             tittel={<TekstBlock block={omDegTittel} typografi={Typografi.StegHeadingH1} />}
+            guide={<TekstBlock block={omDegGuide} />}
             skjema={{
                 validerFelterOgVisFeilmelding,
                 valideringErOk,

--- a/src/frontend/components/SøknadsSteg/OmDeg/Personopplysninger.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/Personopplysninger.tsx
@@ -5,6 +5,7 @@ import { Alpha3Code } from 'i18n-iso-countries';
 import { Alert, BodyShort, Label } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { useSpråk } from '../../../context/SpråkContext';
 import { Typografi } from '../../../typer/common';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
@@ -15,8 +16,9 @@ import TekstBlock from '../../Felleskomponenter/TekstBlock';
 
 export const Personopplysninger: React.FC = () => {
     const { valgtLocale } = useSpråk();
-
     const { søknad, tekster, plainTekst } = useApp();
+    const { toggles } = useFeatureToggles();
+
     const søker = søknad.søker;
 
     const {
@@ -32,9 +34,11 @@ export const Personopplysninger: React.FC = () => {
 
     return (
         <>
-            <Alert variant={'info'} inline>
-                <TekstBlock block={personopplysningerAlert} typografi={Typografi.BodyShort} />
-            </Alert>
+            {!toggles.VIS_GUIDE_I_STEG && (
+                <Alert variant={'info'} inline>
+                    <TekstBlock block={personopplysningerAlert} typografi={Typografi.BodyShort} />
+                </Alert>
+            )}
 
             <Informasjonsbolk>
                 <Label>{plainTekst(ident)}</Label>

--- a/src/frontend/components/SøknadsSteg/OmDeg/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/OmDeg/innholdTyper.ts
@@ -3,6 +3,7 @@ import { ISanitySpørsmålDokument } from '../../../typer/sanity/sanity';
 
 export interface IOmDegTekstinnhold {
     omDegTittel: LocaleRecordBlock;
+    omDegGuide: LocaleRecordBlock;
     personopplysningerAlert: LocaleRecordBlock;
     navn: LocaleRecordString;
     adresse: LocaleRecordString;

--- a/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.tsx
@@ -36,7 +36,7 @@ const Oppsummering: React.FC = () => {
         : søknad.barnInkludertISøknaden.filter(barn => barn.triggetEøs);
 
     const {
-        [ESanitySteg.OPPSUMMERING]: { oppsummeringTittel, lesNoeye },
+        [ESanitySteg.OPPSUMMERING]: { oppsummeringTittel, oppsummeringGuide, lesNoeye },
     } = tekster();
 
     const scrollTilFeil = (elementId: string) => {
@@ -54,6 +54,7 @@ const Oppsummering: React.FC = () => {
     return (
         <Steg
             tittel={<TekstBlock block={oppsummeringTittel} typografi={Typografi.StegHeadingH1} />}
+            guide={<TekstBlock block={oppsummeringGuide} />}
             gåVidereCallback={gåVidereCallback}
         >
             <StyledBodyShort>{plainTekst(lesNoeye)}</StyledBodyShort>

--- a/src/frontend/components/SøknadsSteg/Oppsummering/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/innholdTyper.ts
@@ -2,6 +2,7 @@ import { LocaleRecordBlock, LocaleRecordString } from '../../../typer/common';
 
 export interface IOppsummeringTekstinnhold {
     oppsummeringTittel: LocaleRecordBlock;
+    oppsummeringGuide: LocaleRecordBlock;
     lesNoeye: LocaleRecordString;
     endreSvarLenkeTekst: LocaleRecordString;
 }

--- a/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
@@ -61,6 +61,7 @@ const VelgBarn: React.FC = () => {
     const teksterForSteg: IVelgBarnTekstinnhold = tekster()[ESanitySteg.VELG_BARN];
     const {
         velgBarnTittel,
+        velgBarnGuide,
         hvisOpplysningeneIkkeStemmer,
         leseMerOmRegleneKontantstoette,
         kanIkkeBestemmeRettUnder1Aar,
@@ -70,6 +71,7 @@ const VelgBarn: React.FC = () => {
         <>
             <Steg
                 tittel={<TekstBlock block={velgBarnTittel} typografi={Typografi.StegHeadingH1} />}
+                guide={<TekstBlock block={velgBarnGuide} />}
                 skjema={{
                     validerFelterOgVisFeilmelding,
                     valideringErOk,

--- a/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { Alert } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { Typografi } from '../../../typer/common';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import useModal from '../../Felleskomponenter/SkjemaModal/useModal';
@@ -52,6 +53,7 @@ const VelgBarn: React.FC = () => {
         barnSomSkalVæreMed,
         fjernBarn,
     } = useVelgBarn();
+    const { toggles } = useFeatureToggles();
 
     const barnFraRespons = søknad.søker.barn;
     const barnManueltLagtTil = søknad.barnRegistrertManuelt;
@@ -67,6 +69,8 @@ const VelgBarn: React.FC = () => {
         kanIkkeBestemmeRettUnder1Aar,
     } = teksterForSteg;
 
+    const visGammelInfo = !toggles.VIS_GUIDE_I_STEG || !velgBarnGuide;
+
     return (
         <>
             <Steg
@@ -81,12 +85,14 @@ const VelgBarn: React.FC = () => {
                     },
                 }}
             >
-                <Alert variant={'info'} inline>
-                    <TekstBlock
-                        block={hvisOpplysningeneIkkeStemmer}
-                        typografi={Typografi.BodyShort}
-                    />
-                </Alert>
+                {visGammelInfo && (
+                    <Alert variant={'info'} inline>
+                        <TekstBlock
+                            block={hvisOpplysningeneIkkeStemmer}
+                            typografi={Typografi.BodyShort}
+                        />
+                    </Alert>
+                )}
 
                 <BarnekortContainer
                     id={VelgBarnSpørsmålId.velgBarn}

--- a/src/frontend/components/SøknadsSteg/VelgBarn/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/innholdTyper.ts
@@ -2,6 +2,7 @@ import { LocaleRecordBlock } from '../../../typer/common';
 
 export interface IVelgBarnTekstinnhold {
     velgBarnTittel: LocaleRecordBlock;
+    velgBarnGuide: LocaleRecordBlock;
     hvisOpplysningeneIkkeStemmer: LocaleRecordBlock;
     leseMerOmRegleneKontantstoette: LocaleRecordBlock;
     soekeForUregistrerteBarn: LocaleRecordBlock;

--- a/src/frontend/typer/feature-toggles.ts
+++ b/src/frontend/typer/feature-toggles.ts
@@ -2,9 +2,13 @@ export enum EToggle {
     KONTANTSTOTTE = 'familie-ks-soknad.disable-soknad',
 }
 
-export enum EFeatureToggle {}
+export enum EFeatureToggle {
+    VIS_GUIDE_I_STEG = 'VIS_GUIDE_I_STEG',
+}
 
-export const ToggleKeys: Record<EFeatureToggle, string> = {};
+export const ToggleKeys: Record<EFeatureToggle, string> = {
+    [EFeatureToggle.VIS_GUIDE_I_STEG]: 'familie-ks-soknad.vis-guide-i-steg',
+};
 
 export type EAllFeatureToggles = Record<EFeatureToggle, boolean>;
 

--- a/src/frontend/utils/testing.tsx
+++ b/src/frontend/utils/testing.tsx
@@ -25,6 +25,7 @@ import { SanityProvider } from '../context/SanityContext';
 import { SpråkProvider } from '../context/SpråkContext';
 import { StegProvider } from '../context/StegContext';
 import { LocaleType } from '../typer/common';
+import { EFeatureToggle } from '../typer/feature-toggles';
 import { ESivilstand } from '../typer/kontrakt/generelle';
 import { IKvittering } from '../typer/kvittering';
 import { ISøker, ISøkerRespons } from '../typer/person';
@@ -146,7 +147,9 @@ export const mockFeatureToggle = () => {
         .spyOn(featureToggleContext, 'useFeatureToggles')
         .mockImplementation(
             jest.fn().mockReturnValue({
-                toggles: {},
+                toggles: {
+                    [EFeatureToggle.VIS_GUIDE_I_STEG]: false,
+                },
             })
         );
     return { useFeatureToggle };


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21827

### 💰 Hva forsøker du å løse i denne PR'en
- Legger til GuidePanel i steg for å gi brukere klarere og mer brukervennlige instruksjoner på hva steget går ut på.
- Legger til feature-toggle for å bytte mellom visning av gamle alerts med info og nye guide-paneler. https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ks-soknad.vis-guide-i-steg
- Endret rekkefølge og spacing for overskrift og guide-panel på forsiden slik at den følger samme utseende som i BA og resten av stegene i søknaden.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Jeg finner ingen grunner til å skrive tester for endringene som er gjort.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Gå gjennom alle stegene i søknaden både med feature toggle av og på for å se forskjellen mellom gamle alerts og nye guidepaneler.
- Merk at gamle alerts kun bruker på noen få steg, men nye guide-paneler skal brukes på nesten alle steg.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Forside
##### Før
![image](https://github.com/user-attachments/assets/75911363-8254-44f0-8588-83509d94592a)

##### Etter
![image](https://github.com/user-attachments/assets/e700372e-8492-43e6-acef-b64b1589e8ae)

#### Steg
##### Før (eller med feature-toggle av)
![image](https://github.com/user-attachments/assets/ad92ffc4-56d9-4d6b-b868-d583620ba6ac)

##### Etter (og med feature-toggle på)
![image](https://github.com/user-attachments/assets/df947918-7008-49bb-b7be-e479f47149f4)
