### PR TITLE
Fjerner forklaring over LeggTilKnapp

### DIFF
--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/Arbeidsperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/Arbeidsperiode.tsx
@@ -4,7 +4,6 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { Felt, ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
-import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { IArbeidsperiode } from '../../../typer/perioder';
 import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { IArbeidsperiodeTekstinnhold } from '../../../typer/sanity/modaler/arbeidsperiode';
@@ -53,7 +52,6 @@ export const Arbeidsperiode: React.FC<Props> = ({
     barn,
 }) => {
     const { tekster, plainTekst } = useApp();
-    const { toggles } = useFeatureToggles();
     const {
         erÅpen: arbeidsmodalErÅpen,
         lukkModal: lukkArbeidsmodal,
@@ -94,16 +92,12 @@ export const Arbeidsperiode: React.FC<Props> = ({
                     <LeggTilKnapp
                         onClick={åpneArbeidsmodal}
                         id={registrerteArbeidsperioder.id}
-                        forklaring={
-                            registrerteArbeidsperioder.verdi.length > 0
-                                ? plainTekst(flerePerioder, {
-                                      gjelderUtland: gjelderUtlandet,
-                                      barnetsNavn: barn?.navn,
-                                  })
-                                : toggles.FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP &&
-                                    leggTilPeriodeForklaring
-                                  ? plainTekst(leggTilPeriodeForklaring)
-                                  : undefined
+                        leggTilFlereTekst={
+                            registrerteArbeidsperioder.verdi.length > 0 &&
+                            plainTekst(flerePerioder, {
+                                gjelderUtland: gjelderUtlandet,
+                                barnetsNavn: barn?.navn,
+                            })
                         }
                         feilmelding={
                             registrerteArbeidsperioder.erSynlig &&

--- a/src/frontend/components/Felleskomponenter/Barnehagemodal/BarnehageplassPeriode.tsx
+++ b/src/frontend/components/Felleskomponenter/Barnehagemodal/BarnehageplassPeriode.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Felt, ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
-import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { Typografi } from '../../../typer/common';
 import { IBarnehageplassPeriode } from '../../../typer/perioder';
@@ -40,7 +39,6 @@ export const BarnehageplassPeriode: React.FC<BarnehageplassPeriodeProps> = ({
         åpneModal: åpneBarnehageplassModal,
     } = useModal();
     const { tekster, plainTekst } = useApp();
-    const { toggles } = useFeatureToggles();
     const barnehageplassTekster: IBarnehageplassTekstinnhold =
         tekster()[ESanitySteg.FELLES].modaler.barnehageplass;
     const teksterForOmBarnetSteg: IOmBarnetTekstinnhold = tekster()[ESanitySteg.OM_BARNET];
@@ -66,13 +64,9 @@ export const BarnehageplassPeriode: React.FC<BarnehageplassPeriodeProps> = ({
             <LeggTilKnapp
                 onClick={åpneBarnehageplassModal}
                 id={registrerteBarnehageplassPerioder.id}
-                forklaring={
-                    registrerteBarnehageplassPerioder.verdi.length > 0
-                        ? plainTekst(barnehageplassTekster.flerePerioder)
-                        : toggles.FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP &&
-                            barnehageplassTekster.leggTilPeriodeForklaring
-                          ? plainTekst(barnehageplassTekster.leggTilPeriodeForklaring)
-                          : undefined
+                leggTilFlereTekst={
+                    registrerteBarnehageplassPerioder.verdi.length > 0 &&
+                    plainTekst(barnehageplassTekster.flerePerioder)
                 }
                 feilmelding={
                     registrerteBarnehageplassPerioder.erSynlig &&

--- a/src/frontend/components/Felleskomponenter/KontantstøttePeriode/KontantstøttePeriode.tsx
+++ b/src/frontend/components/Felleskomponenter/KontantstøttePeriode/KontantstøttePeriode.tsx
@@ -4,7 +4,6 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { Felt, ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
-import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { IEøsKontantstøttePeriode } from '../../../typer/perioder';
 import { PeriodePersonTypeProps, PersonType } from '../../../typer/personType';
@@ -47,7 +46,6 @@ export const KontantstøttePeriode: React.FC<KontantstøttePeriodeProps> = ({
         lukkModal: lukkKontantstøtteModal,
         åpneModal: åpneKontantstøtteModal,
     } = useModal();
-    const { toggles } = useFeatureToggles();
 
     const teksterForPersonType: IEøsYtelseTekstinnhold =
         tekster().FELLES.modaler.eøsYtelse[personType];
@@ -77,15 +75,11 @@ export const KontantstøttePeriode: React.FC<KontantstøttePeriodeProps> = ({
                     <LeggTilKnapp
                         onClick={åpneKontantstøtteModal}
                         id={registrerteEøsKontantstøttePerioder.id}
-                        forklaring={
-                            registrerteEøsKontantstøttePerioder.verdi.length > 0
-                                ? plainTekst(teksterForPersonType.flerePerioder, {
-                                      barnetsNavn: barn?.navn,
-                                  })
-                                : toggles.FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP &&
-                                    teksterForPersonType.leggTilPeriodeForklaring
-                                  ? plainTekst(teksterForPersonType.leggTilPeriodeForklaring)
-                                  : undefined
+                        leggTilFlereTekst={
+                            registrerteEøsKontantstøttePerioder.verdi.length > 0 &&
+                            plainTekst(teksterForPersonType.flerePerioder, {
+                                barnetsNavn: barn?.navn,
+                            })
                         }
                         feilmelding={
                             registrerteEøsKontantstøttePerioder.erSynlig &&

--- a/src/frontend/components/Felleskomponenter/LeggTilKnapp/LeggTilKnapp.tsx
+++ b/src/frontend/components/Felleskomponenter/LeggTilKnapp/LeggTilKnapp.tsx
@@ -8,7 +8,7 @@ import { ARed500 } from '@navikt/ds-tokens/dist/tokens';
 
 interface Props {
     onClick: () => void | Promise<void>;
-    forklaring?: ReactNode;
+    leggTilFlereTekst?: ReactNode;
     feilmelding: ReactNode;
     id?: string;
     children?: ReactNode;
@@ -22,14 +22,14 @@ const StyledButton = styled(Button)`
 
 export function LeggTilKnapp({
     onClick,
-    forklaring = undefined,
+    leggTilFlereTekst = undefined,
     feilmelding,
     id,
     children,
 }: Props) {
     return (
         <>
-            {forklaring && <BodyShort spacing>{forklaring}</BodyShort>}
+            {leggTilFlereTekst && <BodyShort spacing>{leggTilFlereTekst}</BodyShort>}
             <StyledButton
                 id={id}
                 variant={'tertiary'}

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/Pensjonsperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/Pensjonsperiode.tsx
@@ -4,7 +4,6 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { Felt, ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
-import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { IPensjonsperiode } from '../../../typer/perioder';
 import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import {
@@ -59,7 +58,6 @@ export const Pensjonsperiode: React.FC<Props> = ({
         lukkModal: lukkPensjonsmodal,
         åpneModal: åpnePensjonsmodal,
     } = useModal();
-    const { toggles } = useFeatureToggles();
 
     return (
         <>
@@ -92,16 +90,12 @@ export const Pensjonsperiode: React.FC<Props> = ({
                     <LeggTilKnapp
                         onClick={åpnePensjonsmodal}
                         id={registrertePensjonsperioder.id}
-                        forklaring={
-                            registrertePensjonsperioder.verdi.length > 0
-                                ? plainTekst(teksterForModal.flerePerioder, {
-                                      barnetsNavn: barn?.navn,
-                                      gjelderUtland: gjelderUtlandet,
-                                  })
-                                : toggles.FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP &&
-                                    teksterForModal.leggTilPeriodeForklaring
-                                  ? plainTekst(teksterForModal.leggTilPeriodeForklaring)
-                                  : undefined
+                        leggTilFlereTekst={
+                            registrertePensjonsperioder.verdi.length > 0 &&
+                            plainTekst(teksterForModal.flerePerioder, {
+                                barnetsNavn: barn?.navn,
+                                gjelderUtland: gjelderUtlandet,
+                            })
                         }
                         feilmelding={
                             registrertePensjonsperioder.erSynlig &&

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/Utbetalingsperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/Utbetalingsperiode.tsx
@@ -4,7 +4,6 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { Felt, ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
-import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { IUtbetalingsperiode } from '../../../typer/perioder';
 import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { IEøsForBarnFeltTyper, IEøsForSøkerFeltTyper } from '../../../typer/skjema';
@@ -45,7 +44,6 @@ export const Utbetalingsperiode: React.FC<Props> = ({
         lukkModal: lukkUtbetalingsmodal,
         åpneModal: åpneUtbetalingsmodal,
     } = useModal();
-    const { toggles } = useFeatureToggles();
 
     const teksterForPersontype = tekster().FELLES.modaler.andreUtbetalinger[personType];
 
@@ -76,15 +74,11 @@ export const Utbetalingsperiode: React.FC<Props> = ({
                     <LeggTilKnapp
                         onClick={åpneUtbetalingsmodal}
                         id={registrerteUtbetalingsperioder.id}
-                        forklaring={
-                            registrerteUtbetalingsperioder.verdi.length > 0
-                                ? plainTekst(teksterForPersontype.flerePerioder, {
-                                      barnetsNavn: barn?.navn,
-                                  })
-                                : toggles.FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP &&
-                                    teksterForPersontype.leggTilPeriodeForklaring
-                                  ? plainTekst(teksterForPersontype.leggTilPeriodeForklaring)
-                                  : undefined
+                        leggTilFlereTekst={
+                            registrerteUtbetalingsperioder.verdi.length > 0 &&
+                            plainTekst(teksterForPersontype.flerePerioder, {
+                                barnetsNavn: barn?.navn,
+                            })
                         }
                         feilmelding={
                             registrerteUtbetalingsperioder.erSynlig &&

--- a/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/Utenlandsperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/Utenlandsperiode.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Felt, ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
-import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { IUtenlandsperiode } from '../../../typer/perioder';
 import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
@@ -37,7 +36,6 @@ export const Utenlandsperiode: React.FC<Props> = ({
         lukkModal: lukkUtenlandsoppholdModal,
         åpneModal: åpneUtenlandsoppholdModal,
     } = useModal();
-    const { toggles } = useFeatureToggles();
 
     const {
         [ESanitySteg.FELLES]: {
@@ -73,13 +71,8 @@ export const Utenlandsperiode: React.FC<Props> = ({
             <LeggTilKnapp
                 id={registrerteUtenlandsperioder.id}
                 onClick={åpneUtenlandsoppholdModal}
-                forklaring={
-                    registrerteUtenlandsperioder.verdi.length > 0
-                        ? plainTekst(flerePerioder)
-                        : toggles.FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP &&
-                            leggTilPeriodeForklaring
-                          ? plainTekst(leggTilPeriodeForklaring)
-                          : undefined
+                leggTilFlereTekst={
+                    registrerteUtenlandsperioder.verdi.length > 0 && plainTekst(flerePerioder)
                 }
                 feilmelding={
                     registrerteUtenlandsperioder.erSynlig &&


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21806

### 💰 Hva forsøker du å løse i denne PR'en
- Fjerner forklaring over LeggTilKnapp slik at forklaring kun vises inne i modalen.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig ut fra det jeg kan se.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Gå gjennom søknaden og fokuser på forklaringstekster i modaler for perioder.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Før - Forklaring ligger både over LeggTilKnapp og inne i modal
![image](https://github.com/user-attachments/assets/621d1c6c-c838-4d4d-86e6-d85e3731e428)
![image](https://github.com/user-attachments/assets/e233792c-96bd-4852-b12e-e65f68376577)


#### Etter - Forklaring ligger bare inne i modal
![image](https://github.com/user-attachments/assets/af70a389-1b18-4d47-aa77-0c66e962c0f3)
![image](https://github.com/user-attachments/assets/ce0ad18d-b3a2-48d2-bf69-43b3e4bfd0d1)