### PR TITLE
Fikser språk i FormProgress

### DIFF
--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -29,6 +29,7 @@ import useModal from '../SkjemaModal/useModal';
 import ModellVersjonModal from './ModellVersjonModal';
 import Navigeringspanel from './Navigeringspanel';
 import { ScrollHandler } from './ScrollHandler';
+import { useFormProgressSteg } from './useFormProgressSteg';
 
 interface ISteg {
     tittel: ReactNode;
@@ -65,6 +66,8 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
     const navigate = useNavigate();
     const { erÅpen: erModellVersjonModalÅpen, åpneModal: åpneModellVersjonModal } = useModal();
     const {
+        tekster,
+        plainTekst,
         settSisteUtfylteStegIndex,
         erStegUtfyltFrafør,
         gåTilbakeTilStart,
@@ -72,7 +75,6 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
         modellVersjonOppdatert,
     } = useApp();
     const {
-        formProgressSteps,
         hentNesteSteg,
         hentForrigeSteg,
         hentNåværendeSteg,
@@ -85,6 +87,7 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
     const nesteRoute = hentNesteSteg();
     const forrigeRoute = hentForrigeSteg();
     const nåværendeStegIndex = hentNåværendeStegIndex();
+    const formProgressSteg = useFormProgressSteg();
 
     const nyesteNåværendeRoute: RouteEnum = hentNåværendeSteg().route;
     useFørsteRender(() => logSidevisningKontantstøtte(nyesteNåværendeRoute));
@@ -144,9 +147,20 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
     };
 
     const håndterGåTilSteg = (stegIndex: number) => {
-        const steg = formProgressSteps[stegIndex];
+        const steg = formProgressSteg[stegIndex];
         navigate(steg.path);
     };
+
+    const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
+
+    const formProgressStegTekst =
+        plainTekst(frittståendeOrdTekster.steg) +
+        ' ' +
+        hentNåværendeStegIndex() +
+        ' ' +
+        plainTekst(frittståendeOrdTekster.av) +
+        ' ' +
+        formProgressSteg.length;
 
     return (
         <>
@@ -156,17 +170,22 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
                 {nyesteNåværendeRoute !== RouteEnum.Kvittering && (
                     <FormProgressContainer>
                         <FormProgress
-                            totalSteps={formProgressSteps.length}
+                            translations={{
+                                step: formProgressStegTekst,
+                                showAllSteps: plainTekst(frittståendeOrdTekster.visAlleSteg),
+                                hideAllSteps: plainTekst(frittståendeOrdTekster.skjulAlleSteg),
+                            }}
+                            totalSteps={formProgressSteg.length}
                             activeStep={hentNåværendeStegIndex()}
                             onStepChange={stegIndex => håndterGåTilSteg(stegIndex - 1)}
                         >
-                            {formProgressSteps.map((value, index) => (
+                            {formProgressSteg.map((value, index) => (
                                 <FormProgress.Step
                                     key={index}
                                     completed={index + 1 < hentNåværendeStegIndex()}
                                     interactive={index + 1 < hentNåværendeStegIndex()}
                                 >
-                                    {value.label}
+                                    {value.tittel}
                                 </FormProgress.Step>
                             ))}
                         </FormProgress>

--- a/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
@@ -1,0 +1,89 @@
+import { useApp } from '../../../context/AppContext';
+import { useSteg } from '../../../context/StegContext';
+import { LocaleRecordBlock } from '../../../typer/common';
+import { FlettefeltVerdier } from '../../../typer/kontrakt/generelle';
+import { ISteg, RouteEnum } from '../../../typer/routes';
+
+interface IStegMedTittel extends ISteg {
+    tittel: string;
+}
+
+export const useFormProgressSteg = (): IStegMedTittel[] => {
+    const { tekster, plainTekst } = useApp();
+    const { steg, barnForSteg } = useSteg();
+
+    const {
+        FORSIDE,
+        OM_DEG,
+        DIN_LIVSSITUASJON,
+        VELG_BARN,
+        OM_BARNA,
+        OM_BARNET,
+        OPPSUMMERING,
+        DOKUMENTASJON,
+        EØS_FOR_BARN,
+        EØS_FOR_SØKER,
+        KVITTERING,
+    } = tekster();
+
+    let antallBarnCounter = 0;
+    return steg
+        .map(steg => {
+            let tittelBlock: LocaleRecordBlock;
+            let tittelFlettefeltVerider: FlettefeltVerdier | undefined = undefined;
+
+            switch (steg.route) {
+                case RouteEnum.Forside:
+                    tittelBlock = FORSIDE.soeknadstittel;
+                    break;
+                case RouteEnum.OmDeg:
+                    tittelBlock = OM_DEG.omDegTittel;
+                    break;
+                case RouteEnum.DinLivssituasjon:
+                    tittelBlock = DIN_LIVSSITUASJON.dinLivssituasjonTittel;
+                    break;
+                case RouteEnum.VelgBarn:
+                    tittelBlock = VELG_BARN.velgBarnTittel;
+                    break;
+                case RouteEnum.OmBarna:
+                    tittelBlock = OM_BARNA.omBarnaTittel;
+                    break;
+                case RouteEnum.OmBarnet:
+                    if (barnForSteg.length === 0) {
+                        tittelBlock = OM_BARNET.omBarnetTittelUtenFlettefelt;
+                    } else {
+                        tittelBlock = OM_BARNET.omBarnetTittel;
+                        tittelFlettefeltVerider = {
+                            barnetsNavn: barnForSteg[antallBarnCounter].navn,
+                        };
+                        antallBarnCounter++;
+                    }
+                    break;
+                case RouteEnum.EøsForSøker:
+                    tittelBlock = EØS_FOR_SØKER.eoesForSoekerTittel;
+                    break;
+                case RouteEnum.EøsForBarn:
+                    tittelBlock = EØS_FOR_BARN.eoesForBarnTittel;
+                    break;
+                case RouteEnum.Oppsummering:
+                    tittelBlock = OPPSUMMERING.oppsummeringTittel;
+                    break;
+                case RouteEnum.Dokumentasjon:
+                    tittelBlock = DOKUMENTASJON.dokumentasjonTittel;
+                    break;
+                case RouteEnum.Kvittering:
+                    tittelBlock = KVITTERING.kvitteringTittel;
+                    break;
+                default:
+                    // Alle routes i RouteEnum må gjennomgås i switch(), ellers feiler _exhaustiveCheck
+                    const _exhaustiveCheck: never = steg.route;
+                    return _exhaustiveCheck;
+            }
+
+            return {
+                ...steg,
+                tittel: plainTekst(tittelBlock, tittelFlettefeltVerider),
+            };
+        })
+        .filter(steg => steg.route !== RouteEnum.Forside && steg.route !== RouteEnum.Kvittering);
+};

--- a/src/frontend/components/SøknadsSteg/OmBarnet/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/innholdTyper.ts
@@ -3,6 +3,7 @@ import { ISanitySpørsmålDokument } from '../../../typer/sanity/sanity';
 
 export interface IOmBarnetTekstinnhold {
     omBarnetTittel: LocaleRecordBlock;
+    omBarnetTittelUtenFlettefelt: LocaleRecordBlock;
     borBarnFastSammenMedDeg: ISanitySpørsmålDokument;
     paagaaendeSoeknadYtelse: ISanitySpørsmålDokument;
     hvilketLandYtelse: ISanitySpørsmålDokument;

--- a/src/frontend/context/Steg.test.tsx
+++ b/src/frontend/context/Steg.test.tsx
@@ -29,19 +29,6 @@ describe('Steg', () => {
         expect(result.current.steg.length).toEqual(9);
     });
 
-    test(`formProgressSteps skal returnere en liste uten forside og kvittering`, () => {
-        spyOnUseApp({
-            barnInkludertISøknaden: [],
-        });
-        const wrapper = ({ children }) => (
-            <RoutesProvider>
-                <StegProvider>{children}</StegProvider>
-            </RoutesProvider>
-        );
-        const { result } = renderHook(() => useSteg(), { wrapper });
-        expect(result.current.formProgressSteps.length).toEqual(7);
-    });
-
     test(`Kan hente neste steg fra forsiden`, () => {
         spyOnUseApp({
             barnInkludertISøknaden: [

--- a/src/frontend/context/StegContext.tsx
+++ b/src/frontend/context/StegContext.tsx
@@ -66,10 +66,6 @@ const [StegProvider, useSteg] = createUseContext(() => {
         })
         .flat();
 
-    const formProgressSteps: ISteg[] = steg.filter(
-        steg => steg.route !== RouteEnum.Forside && steg.route !== RouteEnum.Kvittering
-    );
-
     const hentSteg = (pathname: string): ISteg => {
         const index = steg.findIndex(steg => matchPath(steg.path, decodeURIComponent(pathname)));
         return steg[index] ?? steg[0];
@@ -121,7 +117,7 @@ const [StegProvider, useSteg] = createUseContext(() => {
 
     return {
         steg,
-        formProgressSteps,
+        barnForSteg,
         hentStegNummer,
         hentStegObjektForBarn,
         hentNesteSteg,

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -128,6 +128,9 @@ export interface IFrittståendeOrdTekstinnhold {
     barn: LocaleRecordString;
     soeker: LocaleRecordString;
     skjult: LocaleRecordString;
+    steg: LocaleRecordString;
+    visAlleSteg: LocaleRecordString;
+    skjulAlleSteg: LocaleRecordString;
 }
 
 export interface INavigasjonTekstinnhold {


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21887

### 💰 Hva forsøker du å løse i denne PR'en
- Legger til støtte for nynorsk og engelsk tekst i FormProgress.
- Bytter fra å bruke route.label i FormProgress.Step tekst, til å hente tekster fra Sanity.
- Legger til generisk tittel for "Om Barnet" steget som ikke krever flettefelt.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig.
- Fjernet en test relatert til formProgressSteps variabelen i StegContext.ts ettersom formProgressSteps er flyttet til Steg.tsx komponenten istedenfor.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Sjekk at steg registrerer riktig når barn velges, av-velges, legges til, fjernes og når man går frem og tilbake mot "Velg barn" steget.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Før
- Tittel vises bare på bokmål, selv om nynorsk eller engelsk er valgt.
- Tittel for "Om barnet" inkluderer ikke noe informasjon om hvilket barn det gjelder.
![image](https://github.com/user-attachments/assets/30d1f313-c39f-41cb-87c9-bcb6c5797c4b)

#### Etter
![image](https://github.com/user-attachments/assets/3ea26640-6110-46e5-88ac-d02bc9dfa707)