### PR TITLE
Fikser språk i FormProgress

### DIFF
--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -153,14 +153,7 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
 
     const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
 
-    const formProgressStegTekst =
-        plainTekst(frittståendeOrdTekster.steg) +
-        ' ' +
-        hentNåværendeStegIndex() +
-        ' ' +
-        plainTekst(frittståendeOrdTekster.av) +
-        ' ' +
-        formProgressSteg.length;
+    const formProgressStegOppsummeringTekst = `${plainTekst(frittståendeOrdTekster.steg)} ${hentNåværendeStegIndex()} ${plainTekst(frittståendeOrdTekster.av)} ${formProgressSteg.length}`;
 
     return (
         <>
@@ -171,7 +164,7 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
                     <FormProgressContainer>
                         <FormProgress
                             translations={{
-                                step: formProgressStegTekst,
+                                step: formProgressStegOppsummeringTekst,
                                 showAllSteps: plainTekst(frittståendeOrdTekster.visAlleSteg),
                                 hideAllSteps: plainTekst(frittståendeOrdTekster.skjulAlleSteg),
                             }}

--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -29,6 +29,7 @@ import useModal from '../SkjemaModal/useModal';
 import ModellVersjonModal from './ModellVersjonModal';
 import Navigeringspanel from './Navigeringspanel';
 import { ScrollHandler } from './ScrollHandler';
+import { useFormProgressSteg } from './useFormProgressSteg';
 
 interface ISteg {
     tittel: ReactNode;
@@ -65,6 +66,8 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
     const navigate = useNavigate();
     const { erÅpen: erModellVersjonModalÅpen, åpneModal: åpneModellVersjonModal } = useModal();
     const {
+        tekster,
+        plainTekst,
         settSisteUtfylteStegIndex,
         erStegUtfyltFrafør,
         gåTilbakeTilStart,
@@ -72,7 +75,6 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
         modellVersjonOppdatert,
     } = useApp();
     const {
-        formProgressSteps,
         hentNesteSteg,
         hentForrigeSteg,
         hentNåværendeSteg,
@@ -85,6 +87,7 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
     const nesteRoute = hentNesteSteg();
     const forrigeRoute = hentForrigeSteg();
     const nåværendeStegIndex = hentNåværendeStegIndex();
+    const formProgressSteg = useFormProgressSteg();
 
     const nyesteNåværendeRoute: RouteEnum = hentNåværendeSteg().route;
     useFørsteRender(() => logSidevisningKontantstøtte(nyesteNåværendeRoute));
@@ -144,9 +147,20 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
     };
 
     const håndterGåTilSteg = (stegIndex: number) => {
-        const steg = formProgressSteps[stegIndex];
+        const steg = formProgressSteg[stegIndex];
         navigate(steg.path);
     };
+
+    const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
+
+    const formProgressStegTekst =
+        plainTekst(frittståendeOrdTekster.steg) +
+        ' ' +
+        hentNåværendeStegIndex() +
+        ' ' +
+        plainTekst(frittståendeOrdTekster.av) +
+        ' ' +
+        formProgressSteg.length;
 
     return (
         <>
@@ -156,17 +170,22 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
                 {nyesteNåværendeRoute !== RouteEnum.Kvittering && (
                     <FormProgressContainer>
                         <FormProgress
-                            totalSteps={formProgressSteps.length}
+                            translations={{
+                                step: formProgressStegTekst,
+                                showAllSteps: plainTekst(frittståendeOrdTekster.visAlleSteg),
+                                hideAllSteps: plainTekst(frittståendeOrdTekster.skjulAlleSteg),
+                            }}
+                            totalSteps={formProgressSteg.length}
                             activeStep={hentNåværendeStegIndex()}
                             onStepChange={stegIndex => håndterGåTilSteg(stegIndex - 1)}
                         >
-                            {formProgressSteps.map((value, index) => (
+                            {formProgressSteg.map((value, index) => (
                                 <FormProgress.Step
                                     key={index}
                                     completed={index + 1 < hentNåværendeStegIndex()}
                                     interactive={index + 1 < hentNåværendeStegIndex()}
                                 >
-                                    {value.label}
+                                    {value.tittel}
                                 </FormProgress.Step>
                             ))}
                         </FormProgress>

--- a/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
@@ -3,6 +3,7 @@ import { useSteg } from '../../../context/StegContext';
 import { LocaleRecordBlock } from '../../../typer/common';
 import { FlettefeltVerdier } from '../../../typer/kontrakt/generelle';
 import { ISteg, RouteEnum } from '../../../typer/routes';
+import { uppercaseFørsteBokstav } from '../../../utils/visning';
 
 interface IStegMedTittel extends ISteg {
     tittel: string;
@@ -92,7 +93,7 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
 
             return {
                 ...steg,
-                tittel: plainTekst(tittelBlock, tittelFlettefeltVerider),
+                tittel: uppercaseFørsteBokstav(plainTekst(tittelBlock, tittelFlettefeltVerider)),
             };
         })
         .filter(steg => steg.route !== RouteEnum.Forside && steg.route !== RouteEnum.Kvittering);

--- a/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
@@ -86,9 +86,14 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
                     tittelBlock = KVITTERING.kvitteringTittel;
                     break;
                 default:
-                    // Alle routes i RouteEnum må gjennomgås i switch(), ellers feiler _exhaustiveCheck
-                    const _exhaustiveCheck: never = steg.route;
-                    return _exhaustiveCheck;
+                    /*
+                     * Det er viktig at alle enum-medlemmer i RouteEnum blir håndtert i switch-setningen.
+                     * Hvis et medlem utelates, vil koden under feile fordi den forutsetter at hver route har en tilhørende tittel fra Sanity.
+                     * Eslint vil fange opp en ubehandlet enum-verdi og kaste en feil, men dersom dette ikke korrigeres, kan det resultere i runtime-feil eller manglende tittel for enkelte steg.
+                     * Dette bidrar til å sikre at alle routes har en tilhørende titteltekst og at applikasjonen oppfører seg som forventet.
+                     */
+                    const alleRouteEnumMedlemmerGjennomgås: never = steg.route;
+                    return alleRouteEnumMedlemmerGjennomgås;
             }
 
             return {

--- a/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
@@ -26,7 +26,9 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
         KVITTERING,
     } = tekster();
 
-    let antallBarnCounter = 0;
+    let antallBarnCounterOmBarnet = 0;
+    let antallBarnCounterEøsForBarnet = 0;
+
     return steg
         .map(steg => {
             let tittelBlock: LocaleRecordBlock;
@@ -54,16 +56,24 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
                     } else {
                         tittelBlock = OM_BARNET.omBarnetTittel;
                         tittelFlettefeltVerider = {
-                            barnetsNavn: barnForSteg[antallBarnCounter].navn,
+                            barnetsNavn: barnForSteg[antallBarnCounterOmBarnet].navn,
                         };
-                        antallBarnCounter++;
+                        antallBarnCounterOmBarnet++;
                     }
                     break;
                 case RouteEnum.EøsForSøker:
                     tittelBlock = EØS_FOR_SØKER.eoesForSoekerTittel;
                     break;
                 case RouteEnum.EøsForBarn:
-                    tittelBlock = EØS_FOR_BARN.eoesForBarnTittel;
+                    if (barnForSteg.length === 0) {
+                        tittelBlock = EØS_FOR_BARN.eoesForBarnTittelUtenFlettefelt;
+                    } else {
+                        tittelBlock = EØS_FOR_BARN.eoesForBarnTittel;
+                        tittelFlettefeltVerider = {
+                            barnetsNavn: barnForSteg[antallBarnCounterEøsForBarnet].navn,
+                        };
+                        antallBarnCounterEøsForBarnet++;
+                    }
                     break;
                 case RouteEnum.Oppsummering:
                     tittelBlock = OPPSUMMERING.oppsummeringTittel;

--- a/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
@@ -26,10 +26,8 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
         KVITTERING,
     } = tekster();
 
-    const antallBarnTellere = {
-        omBarnet: 0,
-        EøsForBarnet: 0,
-    };
+    let antallBarnTellerOmBarnet = 0;
+    let antallBarnTellerEøsForBarnet = 0;
 
     return steg
         .map(steg => {
@@ -58,9 +56,9 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
                     } else {
                         tittelBlock = OM_BARNET.omBarnetTittel;
                         tittelFlettefeltVerider = {
-                            barnetsNavn: barnForSteg[antallBarnTellere.omBarnet].navn,
+                            barnetsNavn: barnForSteg[antallBarnTellerOmBarnet].navn,
                         };
-                        antallBarnTellere.omBarnet++;
+                        antallBarnTellerOmBarnet++;
                     }
                     break;
                 case RouteEnum.EøsForSøker:
@@ -72,9 +70,9 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
                     } else {
                         tittelBlock = EØS_FOR_BARN.eoesForBarnTittel;
                         tittelFlettefeltVerider = {
-                            barnetsNavn: barnForSteg[antallBarnTellere.EøsForBarnet].navn,
+                            barnetsNavn: barnForSteg[antallBarnTellerEøsForBarnet].navn,
                         };
-                        antallBarnTellere.EøsForBarnet++;
+                        antallBarnTellerEøsForBarnet++;
                     }
                     break;
                 case RouteEnum.Oppsummering:

--- a/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
@@ -1,0 +1,89 @@
+import { useApp } from '../../../context/AppContext';
+import { useSteg } from '../../../context/StegContext';
+import { LocaleRecordBlock } from '../../../typer/common';
+import { FlettefeltVerdier } from '../../../typer/kontrakt/generelle';
+import { ISteg, RouteEnum } from '../../../typer/routes';
+
+interface IStegMedTittel extends ISteg {
+    tittel: string;
+}
+
+export const useFormProgressSteg = (): IStegMedTittel[] => {
+    const { tekster, plainTekst } = useApp();
+    const { steg, barnForSteg } = useSteg();
+
+    const {
+        FORSIDE,
+        OM_DEG,
+        DIN_LIVSSITUASJON,
+        VELG_BARN,
+        OM_BARNA,
+        OM_BARNET,
+        OPPSUMMERING,
+        DOKUMENTASJON,
+        EØS_FOR_BARN,
+        EØS_FOR_SØKER,
+        KVITTERING,
+    } = tekster();
+
+    let antallBarnCounter = 0;
+    return steg
+        .map(steg => {
+            let tittelBlock: LocaleRecordBlock;
+            let tittelFlettefeltVerider: FlettefeltVerdier | undefined = undefined;
+
+            switch (steg.route) {
+                case RouteEnum.Forside:
+                    tittelBlock = FORSIDE.soeknadstittel;
+                    break;
+                case RouteEnum.OmDeg:
+                    tittelBlock = OM_DEG.omDegTittel;
+                    break;
+                case RouteEnum.DinLivssituasjon:
+                    tittelBlock = DIN_LIVSSITUASJON.dinLivssituasjonTittel;
+                    break;
+                case RouteEnum.VelgBarn:
+                    tittelBlock = VELG_BARN.velgBarnTittel;
+                    break;
+                case RouteEnum.OmBarna:
+                    tittelBlock = OM_BARNA.omBarnaTittel;
+                    break;
+                case RouteEnum.OmBarnet:
+                    if (barnForSteg.length === 0) {
+                        tittelBlock = OM_BARNET.omBarnetTittelUtenFlettefelt;
+                    } else {
+                        tittelBlock = OM_BARNET.omBarnetTittel;
+                        tittelFlettefeltVerider = {
+                            barnetsNavn: barnForSteg[antallBarnCounter].navn,
+                        };
+                        antallBarnCounter++;
+                    }
+                    break;
+                case RouteEnum.EøsForSøker:
+                    tittelBlock = EØS_FOR_SØKER.eoesForSoekerTittel;
+                    break;
+                case RouteEnum.EøsForBarn:
+                    tittelBlock = EØS_FOR_BARN.eoesForBarnTittel;
+                    break;
+                case RouteEnum.Oppsummering:
+                    tittelBlock = OPPSUMMERING.oppsummeringTittel;
+                    break;
+                case RouteEnum.Dokumentasjon:
+                    tittelBlock = DOKUMENTASJON.dokumentasjonTittel;
+                    break;
+                case RouteEnum.Kvittering:
+                    tittelBlock = KVITTERING.kvitteringTittel;
+                    break;
+                default:
+                    // Alle routes i RouteEnum må gjennomgås i switch(), ellers feiler _exhaustiveCheck
+                    const _exhaustiveCheck: never = steg.route;
+                    return _exhaustiveCheck;
+            }
+
+            return {
+                ...steg,
+                tittel: plainTekst(tittelBlock, tittelFlettefeltVerider),
+            };
+        })
+        .filter(steg => steg.route !== RouteEnum.Forside && steg.route !== RouteEnum.Kvittering);
+};

--- a/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
@@ -26,8 +26,10 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
         KVITTERING,
     } = tekster();
 
-    let antallBarnCounterOmBarnet = 0;
-    let antallBarnCounterEøsForBarnet = 0;
+    const antallBarnTellere = {
+        omBarnet: 0,
+        EøsForBarnet: 0,
+    };
 
     return steg
         .map(steg => {
@@ -56,9 +58,9 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
                     } else {
                         tittelBlock = OM_BARNET.omBarnetTittel;
                         tittelFlettefeltVerider = {
-                            barnetsNavn: barnForSteg[antallBarnCounterOmBarnet].navn,
+                            barnetsNavn: barnForSteg[antallBarnTellere.omBarnet].navn,
                         };
-                        antallBarnCounterOmBarnet++;
+                        antallBarnTellere.omBarnet++;
                     }
                     break;
                 case RouteEnum.EøsForSøker:
@@ -70,9 +72,9 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
                     } else {
                         tittelBlock = EØS_FOR_BARN.eoesForBarnTittel;
                         tittelFlettefeltVerider = {
-                            barnetsNavn: barnForSteg[antallBarnCounterEøsForBarnet].navn,
+                            barnetsNavn: barnForSteg[antallBarnTellere.EøsForBarnet].navn,
                         };
-                        antallBarnCounterEøsForBarnet++;
+                        antallBarnTellere.EøsForBarnet++;
                     }
                     break;
                 case RouteEnum.Oppsummering:

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/innholdTyper.ts
@@ -3,6 +3,7 @@ import { ISanitySpørsmålDokument } from '../../../../typer/sanity/sanity';
 
 export interface IEøsForBarnTekstinnhold {
     eoesForBarnTittel: LocaleRecordBlock;
+    eoesForBarnTittelUtenFlettefelt: LocaleRecordBlock;
     eosForBarnGuide: LocaleRecordBlock;
     idNummerBarn: ISanitySpørsmålDokument;
     slektsforhold: ISanitySpørsmålDokument;

--- a/src/frontend/components/SøknadsSteg/OmBarnet/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/innholdTyper.ts
@@ -3,6 +3,7 @@ import { ISanitySpørsmålDokument } from '../../../typer/sanity/sanity';
 
 export interface IOmBarnetTekstinnhold {
     omBarnetTittel: LocaleRecordBlock;
+    omBarnetTittelUtenFlettefelt: LocaleRecordBlock;
     borBarnFastSammenMedDeg: ISanitySpørsmålDokument;
     paagaaendeSoeknadYtelse: ISanitySpørsmålDokument;
     hvilketLandYtelse: ISanitySpørsmålDokument;

--- a/src/frontend/context/Steg.test.tsx
+++ b/src/frontend/context/Steg.test.tsx
@@ -29,19 +29,6 @@ describe('Steg', () => {
         expect(result.current.steg.length).toEqual(9);
     });
 
-    test(`formProgressSteps skal returnere en liste uten forside og kvittering`, () => {
-        spyOnUseApp({
-            barnInkludertISøknaden: [],
-        });
-        const wrapper = ({ children }) => (
-            <RoutesProvider>
-                <StegProvider>{children}</StegProvider>
-            </RoutesProvider>
-        );
-        const { result } = renderHook(() => useSteg(), { wrapper });
-        expect(result.current.formProgressSteps.length).toEqual(7);
-    });
-
     test(`Kan hente neste steg fra forsiden`, () => {
         spyOnUseApp({
             barnInkludertISøknaden: [

--- a/src/frontend/context/StegContext.tsx
+++ b/src/frontend/context/StegContext.tsx
@@ -66,10 +66,6 @@ const [StegProvider, useSteg] = createUseContext(() => {
         })
         .flat();
 
-    const formProgressSteps: ISteg[] = steg.filter(
-        steg => steg.route !== RouteEnum.Forside && steg.route !== RouteEnum.Kvittering
-    );
-
     const hentSteg = (pathname: string): ISteg => {
         const index = steg.findIndex(steg => matchPath(steg.path, decodeURIComponent(pathname)));
         return steg[index] ?? steg[0];
@@ -121,7 +117,7 @@ const [StegProvider, useSteg] = createUseContext(() => {
 
     return {
         steg,
-        formProgressSteps,
+        barnForSteg,
         hentStegNummer,
         hentStegObjektForBarn,
         hentNesteSteg,

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -128,6 +128,9 @@ export interface IFrittståendeOrdTekstinnhold {
     barn: LocaleRecordString;
     soeker: LocaleRecordString;
     skjult: LocaleRecordString;
+    steg: LocaleRecordString;
+    visAlleSteg: LocaleRecordString;
+    skjulAlleSteg: LocaleRecordString;
 }
 
 export interface INavigasjonTekstinnhold {


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21887

### 💰 Hva forsøker du å løse i denne PR'en
- Legger til støtte for nynorsk og engelsk tekst i FormProgress.
- Bytter fra å bruke route.label i FormProgress.Step tekst, til å hente tekster fra Sanity.
- Legger til generisk tittel for "Om barnet" og "EØS om barnet" stegene som ikke krever flettefelt.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig.
- Fjernet en test relatert til formProgressSteps variabelen i StegContext.ts ettersom formProgressSteps er flyttet til Steg.tsx komponenten istedenfor.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Gå gjennom søknaden og sjekk at stegene som vises i FormProgress (øverst på siden) inneholder riktige titler.
- Sjekk også at når barn legges til og fjernes, så oppdateres disse riktig i FormProgress.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Før
- Tittel vises bare på bokmål, selv om nynorsk eller engelsk er valgt.
- Tittel for "Om barnet" og "EØS om barnet" inkluderer ikke noe informasjon om hvilket barn det gjelder.

![image](https://github.com/user-attachments/assets/c48a379b-9115-4ed3-a680-c17edaa0eb61)

#### Etter
![image](https://github.com/user-attachments/assets/142e8833-4717-4e74-ab73-05d2efab36ce)