### PR TITLE
Forbedring av navigasjon-knapper iht Aksel

### DIFF
--- a/src/frontend/components/Felleskomponenter/Steg/Navigeringspanel.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Navigeringspanel.tsx
@@ -51,7 +51,6 @@ const Navigeringspanel: React.FC<{
                             onClick={onTilbakeCallback}
                             icon={<ArrowLeftIcon aria-hidden />}
                             iconPosition="left"
-                            data-testid="forrige-steg"
                         >
                             {plainTekst(tilbakeKnapp)}
                         </Button>

--- a/src/frontend/components/Felleskomponenter/Steg/Navigeringspanel.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Navigeringspanel.tsx
@@ -1,51 +1,21 @@
 import React from 'react';
 
-import styled from 'styled-components';
-
-import { Button } from '@navikt/ds-react';
+import {
+    ArrowLeftIcon,
+    ArrowRightIcon,
+    FloppydiskIcon,
+    PaperplaneIcon,
+    TrashIcon,
+} from '@navikt/aksel-icons';
+import { Box, Button, HGrid, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../context/AppContext';
 import { useSteg } from '../../../context/StegContext';
-import { device } from '../../../Theme';
 import { RouteEnum } from '../../../typer/routes';
+import { useBekreftelseOgStartSoknad } from '../../SøknadsSteg/Forside/useBekreftelseOgStartSoknad';
 
-const Container = styled.nav`
-    padding: 2rem;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-areas:
-        ' tilbake gåVidere '
-        ' avbryt avbryt';
-    grid-template-rows: auto;
-    gap: 0.5rem;
-    justify-content: center;
-
-    @media all and ${device.mobile} {
-        grid-template-columns: 1fr;
-        grid-template-areas:
-            ' gåVidere '
-            ' tilbake '
-            ' avbryt';
-        padding: 2rem 0;
-    }
-`;
-
-const StyledButton = styled(Button)<{
-    $placeself: 'end' | 'center' | 'start';
-    $gridarea: 'tilbake' | 'gåVidere' | 'avbryt';
-}>`
-    && {
-        grid-area: ${props => props.$gridarea};
-        min-width: 12.5rem;
-        place-self: ${props => props.$placeself};
-        @media all and ${device.mobile} {
-            place-self: center;
-        }
-    }
-`;
-
-type Knappetype = 'primary' | 'secondary';
+import { SlettSøknadenModal } from './SlettSøknadenModal';
 
 const Navigeringspanel: React.FC<{
     onAvbrytCallback: () => void;
@@ -55,53 +25,91 @@ const Navigeringspanel: React.FC<{
     const { hentNesteSteg } = useSteg();
     const nesteSteg = hentNesteSteg();
     const { innsendingStatus, tekster, plainTekst } = useApp();
+    const { visStartPåNyttModal, settVisStartPåNyttModal, startPåNytt } =
+        useBekreftelseOgStartSoknad();
 
-    const { avbrytSoeknad, tilbakeKnapp, gaaVidereKnapp, sendSoeknadKnapp } =
-        tekster().FELLES.navigasjon;
-
-    const hentKnappetype = (): Knappetype => {
-        if (valideringErOk) {
-            return valideringErOk() ? 'primary' : 'secondary';
-        } else {
-            return 'primary';
-        }
-    };
+    const {
+        sendSoeknadKnapp,
+        gaaVidereKnapp,
+        tilbakeKnapp,
+        fortsettSenereKnapp,
+        slettSoeknadKnapp,
+    } = tekster().FELLES.navigasjon;
 
     return (
-        <Container>
-            <StyledButton
-                variant={'secondary'}
-                type={'button'}
-                onClick={onTilbakeCallback}
-                $placeself={'end'}
-                $gridarea={'tilbake'}
-            >
-                {plainTekst(tilbakeKnapp)}
-            </StyledButton>
-            <StyledButton
-                type={'submit'}
-                variant={hentKnappetype()}
-                $placeself={'start'}
-                $gridarea={'gåVidere'}
-                loading={innsendingStatus.status === RessursStatus.HENTER}
-                data-testid={'gå-videre-knapp'}
-            >
-                {plainTekst(
-                    nesteSteg.route === RouteEnum.Kvittering ? sendSoeknadKnapp : gaaVidereKnapp
-                )}
-            </StyledButton>
+        <>
+            <Box marginBlock="12 0">
+                <VStack gap="4">
+                    <HGrid
+                        gap={{ xs: '4', sm: '8 4' }}
+                        columns={{ xs: 1, sm: 2 }}
+                        width={{ sm: 'fit-content' }}
+                    >
+                        <Button
+                            type={'button'}
+                            variant="secondary"
+                            onClick={onTilbakeCallback}
+                            icon={<ArrowLeftIcon aria-hidden />}
+                            iconPosition="left"
+                        >
+                            {plainTekst(tilbakeKnapp)}
+                        </Button>
+                        <Button
+                            type={'submit'}
+                            variant={
+                                valideringErOk
+                                    ? valideringErOk()
+                                        ? 'primary'
+                                        : 'secondary'
+                                    : 'primary'
+                            }
+                            icon={
+                                nesteSteg.route === RouteEnum.Kvittering ? (
+                                    <PaperplaneIcon aria-hidden />
+                                ) : (
+                                    <ArrowRightIcon aria-hidden />
+                                )
+                            }
+                            iconPosition="right"
+                            loading={innsendingStatus.status === RessursStatus.HENTER}
+                            data-testid="neste-steg"
+                        >
+                            {plainTekst(
+                                nesteSteg.route === RouteEnum.Kvittering
+                                    ? sendSoeknadKnapp
+                                    : gaaVidereKnapp
+                            )}
+                        </Button>
 
-            <StyledButton
-                variant={'tertiary'}
-                type={'button'}
-                onClick={onAvbrytCallback}
-                $gridarea={'avbryt'}
-                $placeself={'center'}
-                margintop={'0'}
-            >
-                {plainTekst(avbrytSoeknad)}
-            </StyledButton>
-        </Container>
+                        <Box asChild marginBlock={{ xs: '4 0', sm: '0' }}>
+                            <Button
+                                variant="tertiary"
+                                type={'button'}
+                                onClick={onAvbrytCallback}
+                                icon={<FloppydiskIcon aria-hidden />}
+                                iconPosition="left"
+                            >
+                                {plainTekst(fortsettSenereKnapp)}
+                            </Button>
+                        </Box>
+                        <Button
+                            variant="tertiary"
+                            type={'button'}
+                            icon={<TrashIcon aria-hidden />}
+                            iconPosition="left"
+                            onClick={() => settVisStartPåNyttModal(true)}
+                        >
+                            {plainTekst(slettSoeknadKnapp)}
+                        </Button>
+                    </HGrid>
+                </VStack>
+            </Box>
+            <SlettSøknadenModal
+                open={visStartPåNyttModal}
+                avbryt={() => settVisStartPåNyttModal(false)}
+                startPåNytt={() => startPåNytt()}
+            />
+        </>
     );
 };
 

--- a/src/frontend/components/Felleskomponenter/Steg/Navigeringspanel.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Navigeringspanel.tsx
@@ -51,6 +51,7 @@ const Navigeringspanel: React.FC<{
                             onClick={onTilbakeCallback}
                             icon={<ArrowLeftIcon aria-hidden />}
                             iconPosition="left"
+                            data-testid="forrige-steg"
                         >
                             {plainTekst(tilbakeKnapp)}
                         </Button>

--- a/src/frontend/components/Felleskomponenter/Steg/SlettSøknadenModal.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/SlettSøknadenModal.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Button, Heading, Modal } from '@navikt/ds-react';
+
+import { useApp } from '../../../context/AppContext';
+
+const StyledHeading = styled(Heading)`
+    && {
+        white-space: nowrap;
+        margin-right: var(--a-spacing-18);
+    }
+`;
+
+interface ISlettSøkadenModalProps {
+    open: boolean;
+    avbryt: () => void;
+    startPåNytt: () => void;
+}
+
+export const SlettSøknadenModal: React.FC<ISlettSøkadenModalProps> = ({
+    open,
+    avbryt,
+    startPåNytt,
+}) => {
+    const { tekster, plainTekst } = useApp();
+
+    const startPåNyttTekster = tekster().FELLES.modaler.startPåNytt;
+
+    return (
+        <Modal open={open} onClose={avbryt} aria-labelledby="modal-heading">
+            <Modal.Header>
+                <StyledHeading level="1" size="medium" id="modal-heading">
+                    {plainTekst(startPåNyttTekster.startPaaNyttTittel)}
+                </StyledHeading>
+            </Modal.Header>
+            <Modal.Footer>
+                <Button variant={'danger'} type="button" onClick={startPåNytt}>
+                    {plainTekst(startPåNyttTekster.startNySoeknadKnapp)}
+                </Button>
+                <Button variant={'secondary'} type="button" onClick={avbryt}>
+                    {plainTekst(startPåNyttTekster.startPaaNyttAvbryt)}
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+};

--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -3,7 +3,8 @@ import React, { ReactNode, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Box, GuidePanel, Heading, FormProgress } from '@navikt/ds-react';
+import { ArrowLeftIcon } from '@navikt/aksel-icons';
+import { Box, FormProgress, GuidePanel, Heading, Link, VStack } from '@navikt/ds-react';
 import { ISkjema } from '@navikt/familie-skjema';
 import { setAvailableLanguages } from '@navikt/nav-dekoratoren-moduler';
 
@@ -43,7 +44,7 @@ interface ISteg {
     children?: ReactNode;
 }
 
-const FormProgressContainer = styled.div`
+const TopNavigasjonContainer = styled.div`
     max-width: var(--innhold-bredde);
     margin: 0 auto;
 
@@ -70,6 +71,8 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
         gåTilbakeTilStart,
         settNåværendeRoute,
         modellVersjonOppdatert,
+        tekster,
+        plainTekst,
     } = useApp();
     const {
         formProgressSteps,
@@ -148,33 +151,50 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, children }: ISteg) {
         navigate(steg.path);
     };
 
+    const { tilbakeKnapp } = tekster().FELLES.navigasjon;
+
     return (
         <>
             <ScrollHandler />
             <header>
                 <Banner />
                 {nyesteNåværendeRoute !== RouteEnum.Kvittering && (
-                    <FormProgressContainer>
-                        <FormProgress
-                            totalSteps={formProgressSteps.length}
-                            activeStep={hentNåværendeStegIndex()}
-                            onStepChange={stegIndex => håndterGåTilSteg(stegIndex - 1)}
-                        >
-                            {formProgressSteps.map((value, index) => (
-                                <FormProgress.Step
-                                    key={index}
-                                    completed={index + 1 < hentNåværendeStegIndex()}
-                                    interactive={index + 1 < hentNåværendeStegIndex()}
+                    <TopNavigasjonContainer>
+                        <VStack gap="4">
+                            <div>
+                                <Link
+                                    href={forrigeRoute.path}
+                                    variant="action"
+                                    onClick={event => {
+                                        event.preventDefault();
+                                        håndterTilbake();
+                                    }}
                                 >
-                                    {value.label}
-                                </FormProgress.Step>
-                            ))}
-                        </FormProgress>
-                    </FormProgressContainer>
+                                    <ArrowLeftIcon aria-hidden />
+                                    {plainTekst(tilbakeKnapp)}
+                                </Link>
+                            </div>
+                            <FormProgress
+                                totalSteps={formProgressSteps.length}
+                                activeStep={hentNåværendeStegIndex()}
+                                onStepChange={stegIndex => håndterGåTilSteg(stegIndex - 1)}
+                            >
+                                {formProgressSteps.map((value, index) => (
+                                    <FormProgress.Step
+                                        key={index}
+                                        completed={index + 1 < hentNåværendeStegIndex()}
+                                        interactive={index + 1 < hentNåværendeStegIndex()}
+                                    >
+                                        {value.label}
+                                    </FormProgress.Step>
+                                ))}
+                            </FormProgress>
+                        </VStack>
+                    </TopNavigasjonContainer>
                 )}
             </header>
             <InnholdContainer>
-                <Box marginBlock="16 12" marginInline="auto" id={'stegHovedtittel'} tabIndex={-1}>
+                <Box marginBlock="16 12" marginInline="auto">
                     <Heading level="2" size={'large'} align="center">
                         {tittel}
                     </Heading>

--- a/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
@@ -61,8 +61,7 @@ const BekreftelseOgStartSoknad: React.FC = () => {
                         />
                     </ConfirmationPanel>
                 </Informasjonsbolk>
-
-                <div>
+                <VStack gap="8" width={{ sm: 'fit-content' }} marginInline={{ sm: 'auto' }}>
                     <Button
                         variant={
                             bekreftelseStatus === BekreftelseStatus.BEKREFTET
@@ -75,7 +74,7 @@ const BekreftelseOgStartSoknad: React.FC = () => {
                     >
                         {plainTekst(navigasjon.startKnapp)}
                     </Button>
-                </div>
+                </VStack>
             </VStack>
         </form>
     );

--- a/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import styled from 'styled-components';
-
-import { Button, ConfirmationPanel } from '@navikt/ds-react';
+import { ArrowRightIcon } from '@navikt/aksel-icons';
+import { Button, ConfirmationPanel, VStack } from '@navikt/ds-react';
 import { AGreen500, ANavRed, AOrange500 } from '@navikt/ds-tokens/dist/tokens';
 
 import { useApp } from '../../../context/AppContext';
@@ -11,17 +10,6 @@ import Informasjonsbolk from '../../Felleskomponenter/Informasjonsbolk/Informasj
 import TekstBlock from '../../Felleskomponenter/TekstBlock';
 
 import { BekreftelseStatus, useBekreftelseOgStartSoknad } from './useBekreftelseOgStartSoknad';
-
-const FormContainer = styled.form`
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledButton = styled(Button)`
-    && {
-        margin: 2.3rem auto 0 auto;
-    }
-`;
 
 export const bekreftelseBoksBorderFarge = (status: BekreftelseStatus) => {
     switch (status) {
@@ -49,35 +37,47 @@ const BekreftelseOgStartSoknad: React.FC = () => {
     } = tekster();
 
     return (
-        <FormContainer onSubmit={event => onStartSøknad(event)}>
-            <Informasjonsbolk
-                tittel={plainTekst(bekreftelsesboksTittel)}
-                data-testid={'bekreftelsesboks-container'}
-            >
-                <ConfirmationPanel
-                    label={plainTekst(bekreftelsesboksErklaering)}
-                    onChange={bekreftelseOnChange}
-                    checked={bekreftelseStatus === BekreftelseStatus.BEKREFTET}
-                    error={
-                        bekreftelseStatus === BekreftelseStatus.FEIL && (
-                            <span role={'alert'}>{plainTekst(bekreftelsesboksFeilmelding)}</span>
-                        )
-                    }
+        <form onSubmit={event => onStartSøknad(event)}>
+            <VStack gap="12">
+                <Informasjonsbolk
+                    tittel={plainTekst(bekreftelsesboksTittel)}
+                    data-testid={'bekreftelsesboks-container'}
                 >
-                    <TekstBlock block={bekreftelsesboksBroedtekst} typografi={Typografi.BodyLong} />
-                </ConfirmationPanel>
-            </Informasjonsbolk>
+                    <ConfirmationPanel
+                        label={plainTekst(bekreftelsesboksErklaering)}
+                        onChange={bekreftelseOnChange}
+                        checked={bekreftelseStatus === BekreftelseStatus.BEKREFTET}
+                        error={
+                            bekreftelseStatus === BekreftelseStatus.FEIL && (
+                                <span role={'alert'}>
+                                    {plainTekst(bekreftelsesboksFeilmelding)}
+                                </span>
+                            )
+                        }
+                    >
+                        <TekstBlock
+                            block={bekreftelsesboksBroedtekst}
+                            typografi={Typografi.BodyLong}
+                        />
+                    </ConfirmationPanel>
+                </Informasjonsbolk>
 
-            <StyledButton
-                variant={
-                    bekreftelseStatus === BekreftelseStatus.BEKREFTET ? 'primary' : 'secondary'
-                }
-                type={'submit'}
-                data-testid={'start-søknad-knapp'}
-            >
-                {plainTekst(navigasjon.startKnapp)}
-            </StyledButton>
-        </FormContainer>
+                <div>
+                    <Button
+                        variant={
+                            bekreftelseStatus === BekreftelseStatus.BEKREFTET
+                                ? 'primary'
+                                : 'secondary'
+                        }
+                        type={'submit'}
+                        icon={<ArrowRightIcon aria-hidden />}
+                        iconPosition="right"
+                    >
+                        {plainTekst(navigasjon.startKnapp)}
+                    </Button>
+                </div>
+            </VStack>
+        </form>
     );
 };
 

--- a/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
@@ -15,7 +15,7 @@ import InnholdContainer from '../../Felleskomponenter/InnholdContainer/InnholdCo
 import TekstBlock from '../../Felleskomponenter/TekstBlock';
 
 import BekreftelseOgStartSoknad from './BekreftelseOgStartSoknad';
-import FortsettPåSøknad from './FortsettPåSøknad';
+import { FortsettPåSøknad } from './FortsettPåSøknad';
 
 const Forside: React.FC = () => {
     const { mellomlagretVerdi, settNåværendeRoute, tekster } = useApp();

--- a/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
@@ -1,86 +1,45 @@
 import React, { FC } from 'react';
 
-import styled from 'styled-components';
-
-import { Alert, Button, Modal } from '@navikt/ds-react';
+import { Alert, Button, VStack } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
 import { Typografi } from '../../../typer/common';
-import KomponentGruppe from '../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
-import ModalContent from '../../Felleskomponenter/ModalContent';
+import { SlettSøknadenModal } from '../../Felleskomponenter/Steg/SlettSøknadenModal';
 import TekstBlock from '../../Felleskomponenter/TekstBlock';
 
 import { useBekreftelseOgStartSoknad } from './useBekreftelseOgStartSoknad';
 
-const StyledButton = styled(Button)`
-    && {
-        margin: 0 auto 2rem auto;
-        padding: 1rem 3rem 1rem 3rem;
-    }
-`;
-
-const StyledFortsettPåSøknad = styled.div`
-    margin-top: 2rem;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    width: 100%;
-`;
-
-const FortsettPåSøknad: FC = () => {
+export const FortsettPåSøknad: FC = () => {
     const { tekster, plainTekst } = useApp();
-    const { fortsettPåSøknaden, startPåNytt, visStartPåNyttModal, settVisStartPåNyttModal } =
+    const { fortsettPåSøknaden, visStartPåNyttModal, settVisStartPåNyttModal, startPåNytt } =
         useBekreftelseOgStartSoknad();
 
-    const {
-        FORSIDE: { mellomlagretAlert },
-        FELLES: {
-            navigasjon: { fortsettKnapp, startPaaNyttKnapp },
-            modaler: {
-                startPåNytt: {
-                    startNySoeknadKnapp,
-                    startPaaNyttInfo,
-                    startPaaNyttTittel,
-                    startPaaNyttAvbryt,
-                },
-            },
-        },
-    } = tekster();
+    const forsideTekster = tekster().FORSIDE;
+    const navigasjonTekster = tekster().FELLES.navigasjon;
 
     return (
-        <StyledFortsettPåSøknad role={'navigation'}>
-            <KomponentGruppe>
+        <>
+            <VStack role={'navigation'} gap="8">
                 <Alert variant={'info'}>
-                    <TekstBlock block={mellomlagretAlert} typografi={Typografi.BodyShort} />
+                    <TekstBlock
+                        block={forsideTekster.mellomlagretAlert}
+                        typografi={Typografi.BodyLong}
+                    />
                 </Alert>
-            </KomponentGruppe>
-            <StyledButton onClick={fortsettPåSøknaden}>{plainTekst(fortsettKnapp)}</StyledButton>
-            <StyledButton variant={'secondary'} onClick={() => settVisStartPåNyttModal(true)}>
-                {plainTekst(startPaaNyttKnapp)}
-            </StyledButton>
-            <Modal
+                <VStack gap="8" width={{ sm: 'fit-content' }}>
+                    <Button onClick={fortsettPåSøknaden}>
+                        {plainTekst(navigasjonTekster.fortsettKnapp)}
+                    </Button>
+                    <Button variant={'secondary'} onClick={() => settVisStartPåNyttModal(true)}>
+                        {plainTekst(navigasjonTekster.startPaaNyttKnapp)}
+                    </Button>
+                </VStack>
+            </VStack>
+            <SlettSøknadenModal
                 open={visStartPåNyttModal}
-                onClose={() => {
-                    settVisStartPåNyttModal(false);
-                }}
-                header={{
-                    heading: plainTekst(startPaaNyttTittel),
-                    size: 'medium',
-                }}
-            >
-                <ModalContent>
-                    <TekstBlock block={startPaaNyttInfo} typografi={Typografi.BodyShort} />
-                </ModalContent>
-                <Modal.Footer>
-                    <Button variant={'primary'} onClick={startPåNytt}>
-                        <TekstBlock block={startNySoeknadKnapp} />
-                    </Button>
-                    <Button variant={'secondary'} onClick={() => settVisStartPåNyttModal(false)}>
-                        <TekstBlock block={startPaaNyttAvbryt} />
-                    </Button>
-                </Modal.Footer>
-            </Modal>
-        </StyledFortsettPåSøknad>
+                avbryt={() => settVisStartPåNyttModal(false)}
+                startPåNytt={() => startPåNytt()}
+            />
+        </>
     );
 };
-export default FortsettPåSøknad;

--- a/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
@@ -19,7 +19,7 @@ export const FortsettPåSøknad: FC = () => {
 
     return (
         <>
-            <VStack role={'navigation'} gap="8">
+            <VStack role={'navigation'} gap="8" marginBlock="8 0">
                 <Alert variant={'info'}>
                     <TekstBlock
                         block={forsideTekster.mellomlagretAlert}

--- a/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
@@ -26,7 +26,7 @@ export const FortsettPåSøknad: FC = () => {
                         typografi={Typografi.BodyLong}
                     />
                 </Alert>
-                <VStack gap="8" width={{ sm: 'fit-content' }}>
+                <VStack gap="8" width={{ sm: 'fit-content' }} marginInline={{ sm: 'auto' }}>
                     <Button onClick={fortsettPåSøknaden}>
                         {plainTekst(navigasjonTekster.fortsettKnapp)}
                     </Button>

--- a/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.test.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.test.tsx
@@ -92,7 +92,7 @@ describe('VelgBarn', () => {
 
         act(() => fjernBarnKnapp?.click());
 
-        const gåVidere = queryByTestId('gå-videre-knapp');
+        const gåVidere = queryByTestId('neste-steg');
         act(() => gåVidere?.click());
 
         // Først blir barnet fjernet fra manuelt registrerte barn
@@ -119,6 +119,7 @@ describe('VelgBarn', () => {
             erEøs: false,
         });
     });
+
     test('Rendrer ikke navn eller fnr på barnekort dersom det har adressebeskyttelse', () => {
         const søknad = mockDeep<ISøknad>({
             søker: {

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -139,6 +139,8 @@ export interface INavigasjonTekstinnhold {
     tilbakeKnapp: LocaleRecordString;
     gaaVidereKnapp: LocaleRecordString;
     sendSoeknadKnapp: LocaleRecordString;
+    slettSoeknadKnapp: LocaleRecordString;
+    fortsettSenereKnapp: LocaleRecordString;
 }
 
 export interface IFormateringsfeilmeldingerTekstinnhold {


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21973

### 💰 Hva forsøker du å løse i denne PR'en
- Endre layout for navigasjonsknapper iht Aksel. (Se på bunnen av eksempel i oppsummering-malen: https://aksel.nav.no/monster-maler/soknadsdialog/oppsummeringsside-for-soknadsdialoger)
- Flytter SlettSøknadenModal i en egen komponent som brukes både på forsiden (det gjorde den fra før) og på steg når man trykker "Slett søknaden"
- Legger til "Forrige steg" lenke i toppen av steg.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
- Koden for denne oppgaven er nå ferdig, men enkelte tekster som hentes fra Sanity må endres slik at de har samme innhold som i BA og malen fra Aksel.
- Dette gjelder følgende Sanity tekster:
  - Modaler --> Start på nytt --> Tittel _(Skal byttes ut med "Dette sletter søknaden")_
  - Modaler --> Start på nytt --> Andre tekster --> Start ny søknad-knapp _(Skal byttes ut med "Slett søknaden")_
  - Navigasjon --> Gå videre-knapp _(Skal byttes ut med "Neste steg")_
  - Navigasjon --> Tilbake-knapp _(Skal byttes ut med "Forrige steg")_
- På forhånd vil disse tekstene være klare til å publiseres slik at de går live samtidig som koden deployes til prod. I værstefall vil brukeren få gamle/eksisterende tekster med nye navgiasjonsknapper i ca. 1 min etter deploy er ferdig. For eksempel vil det isåfall stå "Gå tilbake" og "Gå videre" fremfor de nye tekstene "Forrige steg" og "Neste steg", men dette er ikke noe stort problem. 

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ingen nye tester er skrevet, men en del tester er endret ettersom de brukte "Gå videre" tekst for å finne knapper. Nå som tekstene er endret har jeg byttet testene til å heller se etter testId'er slik at tekstendringer ikke skaper problemer dersom de endres i Sanity.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Sjekk at funksjonalitet følgende funksjonalitet fungerer som forventet:
  - Gå til forrige steg både ved lenken på toppen av steg og ved bruk av knappen nederst på siden.
  - Gå til neste steg.
  - Fortsett senere.
  - Slett søknaden (underveis i steg)
  - Start på nytt (på forsiden) (dette skal gi samme resultat som å slette søknaden underveis i steg)
  - Fortsett på søknad (på forsiden)

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Forside uten påbegynt søknad
##### Før
![image](https://github.com/user-attachments/assets/0ec4988d-ca6b-4a24-8cba-03156d3345ad)

##### Etter
![image](https://github.com/user-attachments/assets/95977147-058c-49fd-93a0-55ace2fddde7)

#### Forside med påbegynt søknad
##### Før
![image](https://github.com/user-attachments/assets/fb825372-73fd-4faf-92f8-2c892169d26b)

##### Etter
![image](https://github.com/user-attachments/assets/687d635a-0e0e-49b0-947c-39e5023c1b9d)

#### I steg
##### Før
![image](https://github.com/user-attachments/assets/0d676f90-7ccb-45ff-8948-49f0af63e7e3)

##### Etter
![image](https://github.com/user-attachments/assets/730da3b7-c8de-4943-80f7-23bb1a428bd9)

#### Modal for å starte på nytt / slette søknad
##### Før 
![image](https://github.com/user-attachments/assets/96747a7d-990f-4105-b546-d41a64fd1a83)

##### Etter
![image](https://github.com/user-attachments/assets/3d6143e2-1663-48ed-8f2f-122ee59bce9f)

Når nye tekster publiseres i Sanity vil det se slikt ut

![image](https://github.com/user-attachments/assets/e68318d8-9b80-49a8-86c4-1b890d351892)

