### PR TITLE
Forbedring av forsiden iht Aksel

### DIFF
--- a/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
@@ -14,7 +14,7 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
     const { steg, barnForSteg } = useSteg();
 
     const {
-        FORSIDE,
+        // FORSIDE,
         OM_DEG,
         DIN_LIVSSITUASJON,
         VELG_BARN,
@@ -27,6 +27,8 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
         KVITTERING,
     } = tekster();
 
+    const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
+
     let antallBarnTellerOmBarnet = 0;
     let antallBarnTellerEøsForBarnet = 0;
 
@@ -37,7 +39,8 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
 
             switch (steg.route) {
                 case RouteEnum.Forside:
-                    tittelBlock = FORSIDE.soeknadstittel;
+                    // tittelBlock = FORSIDE.soeknadstittel;
+                    tittelBlock = midlertidigeTekster.forsideSoeknadstittel;
                     break;
                 case RouteEnum.OmDeg:
                     tittelBlock = OM_DEG.omDegTittel;

--- a/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
@@ -25,6 +25,12 @@ const BekreftelseOgStartSoknad: React.FC = () => {
     const { onStartSøknad, bekreftelseOnChange, bekreftelseStatus } = useBekreftelseOgStartSoknad();
     const { plainTekst, tekster } = useApp();
 
+    /* 
+    Vi oppretter midlertidige tekster som inneholder nye forside-tekster. 
+    Når dette er ute i prod vil vi endre de eksisterende forsideteksene i Sanity (de som nå er utkommentert) slik at de blir likt det som ligger i de midlertidige tekstene. 
+    Når dette er gjort lages en ny PR for å bytte koden tilbake til å bruke forsidetekstene. 
+    */
+
     // const forsidetekster = tekster().FORSIDE;
     const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
     const navigasjonTekster = tekster().FELLES.navigasjon;

--- a/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
@@ -25,33 +25,31 @@ const BekreftelseOgStartSoknad: React.FC = () => {
     const { onStartSøknad, bekreftelseOnChange, bekreftelseStatus } = useBekreftelseOgStartSoknad();
     const { plainTekst, tekster } = useApp();
 
-    const {
-        FORSIDE: {
-            bekreftelsesboksFeilmelding,
-            bekreftelsesboksBroedtekst,
-            bekreftelsesboksErklaering,
-            bekreftelsesboksTittel,
-        },
-        FELLES: { navigasjon },
-    } = tekster();
+    const forsidetekster = tekster().FORSIDE;
+    const fellestekster = tekster().FELLES;
 
     return (
         <form onSubmit={event => onStartSøknad(event)}>
             <VStack gap="12">
                 <ConfirmationPanel
-                    label={plainTekst(bekreftelsesboksErklaering)}
+                    label={plainTekst(forsidetekster.bekreftelsesboksErklaering)}
                     onChange={bekreftelseOnChange}
                     checked={bekreftelseStatus === BekreftelseStatus.BEKREFTET}
                     error={
                         bekreftelseStatus === BekreftelseStatus.FEIL && (
-                            <span role={'alert'}>{plainTekst(bekreftelsesboksFeilmelding)}</span>
+                            <span role={'alert'}>
+                                {plainTekst(forsidetekster.bekreftelsesboksFeilmelding)}
+                            </span>
                         )
                     }
                 >
                     <Heading level="2" size="xsmall" spacing>
-                        {plainTekst(bekreftelsesboksTittel)}
+                        {plainTekst(forsidetekster.bekreftelsesboksTittel)}
                     </Heading>
-                    <TekstBlock block={bekreftelsesboksBroedtekst} typografi={Typografi.BodyLong} />
+                    <TekstBlock
+                        block={forsidetekster.bekreftelsesboksBroedtekst}
+                        typografi={Typografi.BodyLong}
+                    />
                 </ConfirmationPanel>
 
                 <Box marginInline="auto">
@@ -66,7 +64,7 @@ const BekreftelseOgStartSoknad: React.FC = () => {
                         iconPosition="right"
                         data-testid={'start-søknad-knapp'}
                     >
-                        {plainTekst(navigasjon.startKnapp)}
+                        {plainTekst(fellestekster.navigasjon.startKnapp)}
                     </Button>
                 </Box>
             </VStack>

--- a/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
@@ -1,27 +1,14 @@
 import React from 'react';
 
-import styled from 'styled-components';
-
-import { Button, ConfirmationPanel } from '@navikt/ds-react';
+import { ArrowRightIcon } from '@navikt/aksel-icons';
+import { Box, Button, ConfirmationPanel, Heading, VStack } from '@navikt/ds-react';
 import { AGreen500, ANavRed, AOrange500 } from '@navikt/ds-tokens/dist/tokens';
 
 import { useApp } from '../../../context/AppContext';
 import { Typografi } from '../../../typer/common';
-import Informasjonsbolk from '../../Felleskomponenter/Informasjonsbolk/Informasjonsbolk';
 import TekstBlock from '../../Felleskomponenter/TekstBlock';
 
 import { BekreftelseStatus, useBekreftelseOgStartSoknad } from './useBekreftelseOgStartSoknad';
-
-const FormContainer = styled.form`
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledButton = styled(Button)`
-    && {
-        margin: 2.3rem auto 0 auto;
-    }
-`;
 
 export const bekreftelseBoksBorderFarge = (status: BekreftelseStatus) => {
     switch (status) {
@@ -49,11 +36,8 @@ const BekreftelseOgStartSoknad: React.FC = () => {
     } = tekster();
 
     return (
-        <FormContainer onSubmit={event => onStartSøknad(event)}>
-            <Informasjonsbolk
-                tittel={plainTekst(bekreftelsesboksTittel)}
-                data-testid={'bekreftelsesboks-container'}
-            >
+        <form onSubmit={event => onStartSøknad(event)}>
+            <VStack gap="12">
                 <ConfirmationPanel
                     label={plainTekst(bekreftelsesboksErklaering)}
                     onChange={bekreftelseOnChange}
@@ -64,20 +48,29 @@ const BekreftelseOgStartSoknad: React.FC = () => {
                         )
                     }
                 >
+                    <Heading level="2" size="xsmall" spacing>
+                        {plainTekst(bekreftelsesboksTittel)}
+                    </Heading>
                     <TekstBlock block={bekreftelsesboksBroedtekst} typografi={Typografi.BodyLong} />
                 </ConfirmationPanel>
-            </Informasjonsbolk>
 
-            <StyledButton
-                variant={
-                    bekreftelseStatus === BekreftelseStatus.BEKREFTET ? 'primary' : 'secondary'
-                }
-                type={'submit'}
-                data-testid={'start-søknad-knapp'}
-            >
-                {plainTekst(navigasjon.startKnapp)}
-            </StyledButton>
-        </FormContainer>
+                <Box marginInline="auto">
+                    <Button
+                        variant={
+                            bekreftelseStatus === BekreftelseStatus.BEKREFTET
+                                ? 'primary'
+                                : 'secondary'
+                        }
+                        type={'submit'}
+                        icon={<ArrowRightIcon aria-hidden />}
+                        iconPosition="right"
+                        data-testid={'start-søknad-knapp'}
+                    >
+                        {plainTekst(navigasjon.startKnapp)}
+                    </Button>
+                </Box>
+            </VStack>
+        </form>
     );
 };
 

--- a/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
@@ -25,29 +25,34 @@ const BekreftelseOgStartSoknad: React.FC = () => {
     const { onStartSøknad, bekreftelseOnChange, bekreftelseStatus } = useBekreftelseOgStartSoknad();
     const { plainTekst, tekster } = useApp();
 
-    const forsidetekster = tekster().FORSIDE;
+    // const forsidetekster = tekster().FORSIDE;
+    const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
     const navigasjonTekster = tekster().FELLES.navigasjon;
 
     return (
         <form onSubmit={event => onStartSøknad(event)}>
             <VStack gap="12">
                 <ConfirmationPanel
-                    label={plainTekst(forsidetekster.bekreftelsesboksErklaering)}
+                    // label={plainTekst(forsidetekster.bekreftelsesboksErklaering)}
+                    label={plainTekst(midlertidigeTekster.forsideBekreftelsesboksErklaering)}
                     onChange={bekreftelseOnChange}
                     checked={bekreftelseStatus === BekreftelseStatus.BEKREFTET}
                     error={
                         bekreftelseStatus === BekreftelseStatus.FEIL && (
                             <span role={'alert'}>
-                                {plainTekst(forsidetekster.bekreftelsesboksFeilmelding)}
+                                {/* {plainTekst(forsidetekster.bekreftelsesboksFeilmelding)} */}
+                                {plainTekst(midlertidigeTekster.forsideBekreftelsesboksFeilmelding)}
                             </span>
                         )
                     }
                 >
                     <Heading level="2" size="xsmall" spacing>
-                        {plainTekst(forsidetekster.bekreftelsesboksTittel)}
+                        {/* {plainTekst(forsidetekster.bekreftelsesboksTittel)} */}
+                        {plainTekst(midlertidigeTekster.forsideBekreftelsesboksTittel)}
                     </Heading>
                     <TekstBlock
-                        block={forsidetekster.bekreftelsesboksBroedtekst}
+                        // block={forsidetekster.bekreftelsesboksBroedtekst}
+                        block={midlertidigeTekster.forsideBekreftelsesboksBroedtekst}
                         typografi={Typografi.BodyLong}
                     />
                 </ConfirmationPanel>

--- a/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
@@ -26,7 +26,7 @@ const BekreftelseOgStartSoknad: React.FC = () => {
     const { plainTekst, tekster } = useApp();
 
     const forsidetekster = tekster().FORSIDE;
-    const fellestekster = tekster().FELLES;
+    const navigasjonTekster = tekster().FELLES.navigasjon;
 
     return (
         <form onSubmit={event => onStartSøknad(event)}>
@@ -64,7 +64,7 @@ const BekreftelseOgStartSoknad: React.FC = () => {
                         iconPosition="right"
                         data-testid={'start-søknad-knapp'}
                     >
-                        {plainTekst(fellestekster.navigasjon.startKnapp)}
+                        {plainTekst(navigasjonTekster.startKnapp)}
                     </Button>
                 </Box>
             </VStack>

--- a/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
@@ -11,7 +11,6 @@ import useFørsteRender from '../../../hooks/useFørsteRender';
 import { device } from '../../../Theme';
 import { Typografi } from '../../../typer/common';
 import { RouteEnum } from '../../../typer/routes';
-import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { logSidevisningKontantstøtte } from '../../../utils/amplitude';
 import TekstBlock from '../../Felleskomponenter/TekstBlock';
 
@@ -31,19 +30,7 @@ const Layout = styled.div`
 const Forside: React.FC = () => {
     const { mellomlagretVerdi, settNåværendeRoute, tekster, plainTekst } = useApp();
 
-    const {
-        [ESanitySteg.FORSIDE]: {
-            veilederHei,
-            veilederhilsen,
-            soeknadstittel,
-            foerDuSoekerTittel,
-            foerDuSoeker,
-            informasjonOmPlikterTittel,
-            informasjonOmPlikter,
-            informasjonOmPersonopplysningerTittel,
-            informasjonOmPersonopplysninger,
-        },
-    } = tekster();
+    const forsidetekster = tekster().FORSIDE;
 
     useFørsteRender(() => logSidevisningKontantstøtte(`${RouteEnum.Forside}`));
 
@@ -67,44 +54,50 @@ const Forside: React.FC = () => {
         <Layout>
             <VStack gap="12">
                 <Heading level="1" size="large" align="center">
-                    {plainTekst(soeknadstittel)}
+                    {plainTekst(forsidetekster.soeknadstittel)}
                 </Heading>
                 <GuidePanel poster>
                     <Heading level="2" size="medium" spacing>
-                        {plainTekst(veilederHei)}
+                        {plainTekst(forsidetekster.veilederHei)}
                     </Heading>
-                    <TekstBlock block={veilederhilsen} typografi={Typografi.BodyLong} />
+                    <TekstBlock
+                        block={forsidetekster.veilederhilsen}
+                        typografi={Typografi.BodyLong}
+                    />
                 </GuidePanel>
                 <div>
                     <Heading level="2" size="large" spacing>
-                        {plainTekst(foerDuSoekerTittel)}
+                        {plainTekst(forsidetekster.foerDuSoekerTittel)}
                     </Heading>
-                    <TekstBlock block={foerDuSoeker} typografi={Typografi.BodyLong} />
+                    <TekstBlock
+                        block={forsidetekster.foerDuSoeker}
+                        typografi={Typografi.BodyLong}
+                    />
                 </div>
                 <Accordion>
                     <Accordion.Item>
                         <Accordion.Header>
-                            {plainTekst(informasjonOmPlikterTittel)}
+                            {plainTekst(forsidetekster.informasjonOmPlikterTittel)}
                         </Accordion.Header>
                         <Accordion.Content>
-                            <TekstBlock block={informasjonOmPlikter} />
+                            <TekstBlock block={forsidetekster.informasjonOmPlikter} />
                         </Accordion.Content>
                     </Accordion.Item>
                     <Accordion.Item>
                         <Accordion.Header>
-                            {plainTekst(informasjonOmPersonopplysningerTittel)}
+                            {plainTekst(forsidetekster.informasjonOmPersonopplysningerTittel)}
                         </Accordion.Header>
                         <Accordion.Content>
-                            <TekstBlock block={informasjonOmPersonopplysninger} />
+                            <TekstBlock block={forsidetekster.informasjonOmPersonopplysninger} />
                         </Accordion.Content>
                     </Accordion.Item>
                     <Accordion.Item>
                         <Accordion.Header>
-                            {/* {plainTekst(informasjonOmLagringAvSvarTittel)} */}
+                            {/* {plainTekst(forsidetekster.informasjonOmLagringAvSvarTittel)} */}
                             informasjonOmLagringAvSvarTittel
                         </Accordion.Header>
                         <Accordion.Content>
-                            {/* <TekstBlock block={informasjonOmLagringAvSvar} /> */}
+                            {/* <TekstBlock block={forsidetekster.informasjonOmLagringAvSvar} /> */}
                             informasjonOmLagringAvSvar
                         </Accordion.Content>
                     </Accordion.Item>

--- a/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
@@ -1,31 +1,19 @@
 import React, { useEffect } from 'react';
 
-import styled from 'styled-components';
-
 import { Accordion, GuidePanel, Heading, VStack } from '@navikt/ds-react';
 import { setAvailableLanguages } from '@navikt/nav-dekoratoren-moduler';
 
 import Miljø from '../../../../shared-utils/Miljø';
 import { useApp } from '../../../context/AppContext';
 import useFørsteRender from '../../../hooks/useFørsteRender';
-import { device } from '../../../Theme';
 import { Typografi } from '../../../typer/common';
 import { RouteEnum } from '../../../typer/routes';
 import { logSidevisningKontantstøtte } from '../../../utils/amplitude';
+import InnholdContainer from '../../Felleskomponenter/InnholdContainer/InnholdContainer';
 import TekstBlock from '../../Felleskomponenter/TekstBlock';
 
 import BekreftelseOgStartSoknad from './BekreftelseOgStartSoknad';
 import { FortsettPåSøknad } from './FortsettPåSøknad';
-
-const Layout = styled.div`
-    max-width: var(--innhold-bredde);
-    margin: 2rem auto 4rem auto;
-
-    @media all and ${device.tablet} {
-        max-width: 100%;
-        margin: 2rem 2rem 4rem 2rem;
-    }
-`;
 
 const Forside: React.FC = () => {
     const { mellomlagretVerdi, settNåværendeRoute, tekster, plainTekst } = useApp();
@@ -52,7 +40,7 @@ const Forside: React.FC = () => {
         mellomlagretVerdi && mellomlagretVerdi.modellVersjon === Miljø().modellVersjon;
 
     return (
-        <Layout>
+        <InnholdContainer>
             <VStack gap="12">
                 <Heading level="1" size="large" align="center">
                     {/* {plainTekst(forsidetekster.soeknadstittel)} */}
@@ -128,7 +116,7 @@ const Forside: React.FC = () => {
 
                 {kanFortsettePåSøknad ? <FortsettPåSøknad /> : <BekreftelseOgStartSoknad />}
             </VStack>
-        </Layout>
+        </InnholdContainer>
     );
 };
 

--- a/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
@@ -2,13 +2,14 @@ import React, { useEffect } from 'react';
 
 import styled from 'styled-components';
 
-import { Accordion, BodyLong, GuidePanel, Heading, VStack } from '@navikt/ds-react';
+import { Accordion, GuidePanel, Heading, VStack } from '@navikt/ds-react';
 import { setAvailableLanguages } from '@navikt/nav-dekoratoren-moduler';
 
 import Miljø from '../../../../shared-utils/Miljø';
 import { useApp } from '../../../context/AppContext';
 import useFørsteRender from '../../../hooks/useFørsteRender';
 import { device } from '../../../Theme';
+import { Typografi } from '../../../typer/common';
 import { RouteEnum } from '../../../typer/routes';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { logSidevisningKontantstøtte } from '../../../utils/amplitude';
@@ -66,25 +67,20 @@ const Forside: React.FC = () => {
         <Layout>
             <VStack gap="12">
                 <Heading level="1" size="large" align="center">
-                    <TekstBlock block={soeknadstittel} />
+                    {plainTekst(soeknadstittel)}
                 </Heading>
-
                 <GuidePanel poster>
                     <Heading level="2" size="medium" spacing>
                         {plainTekst(veilederHei)}
                     </Heading>
-                    <BodyLong>{plainTekst(veilederhilsen)}</BodyLong>
+                    <TekstBlock block={veilederhilsen} typografi={Typografi.BodyLong} />
                 </GuidePanel>
-
                 <div>
                     <Heading level="2" size="large" spacing>
                         {plainTekst(foerDuSoekerTittel)}
                     </Heading>
-                    <BodyLong>
-                        <TekstBlock block={foerDuSoeker} />
-                    </BodyLong>
+                    <TekstBlock block={foerDuSoeker} typografi={Typografi.BodyLong} />
                 </div>
-
                 <Accordion>
                     <Accordion.Item>
                         <Accordion.Header>
@@ -100,6 +96,16 @@ const Forside: React.FC = () => {
                         </Accordion.Header>
                         <Accordion.Content>
                             <TekstBlock block={informasjonOmPersonopplysninger} />
+                        </Accordion.Content>
+                    </Accordion.Item>
+                    <Accordion.Item>
+                        <Accordion.Header>
+                            {/* {plainTekst(informasjonOmLagringAvSvarTittel)} */}
+                            informasjonOmLagringAvSvarTittel
+                        </Accordion.Header>
+                        <Accordion.Content>
+                            {/* <TekstBlock block={informasjonOmLagringAvSvar} /> */}
+                            informasjonOmLagringAvSvar
                         </Accordion.Content>
                     </Accordion.Item>
                 </Accordion>

--- a/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
@@ -18,6 +18,12 @@ import { FortsettPåSøknad } from './FortsettPåSøknad';
 const Forside: React.FC = () => {
     const { mellomlagretVerdi, settNåværendeRoute, tekster, plainTekst } = useApp();
 
+    /* 
+    Vi oppretter midlertidige tekster som inneholder nye forside-tekster. 
+    Når dette er ute i prod vil vi endre de eksisterende forsideteksene i Sanity (de som nå er utkommentert) slik at de blir likt det som ligger i de midlertidige tekstene. 
+    Når dette er gjort lages en ny PR for å bytte koden tilbake til å bruke forsidetekstene. 
+    */
+
     // const forsidetekster = tekster().FORSIDE;
     const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
 

--- a/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
@@ -30,7 +30,8 @@ const Layout = styled.div`
 const Forside: React.FC = () => {
     const { mellomlagretVerdi, settNåværendeRoute, tekster, plainTekst } = useApp();
 
-    const forsidetekster = tekster().FORSIDE;
+    // const forsidetekster = tekster().FORSIDE;
+    const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
 
     useFørsteRender(() => logSidevisningKontantstøtte(`${RouteEnum.Forside}`));
 
@@ -54,51 +55,73 @@ const Forside: React.FC = () => {
         <Layout>
             <VStack gap="12">
                 <Heading level="1" size="large" align="center">
-                    {plainTekst(forsidetekster.soeknadstittel)}
+                    {/* {plainTekst(forsidetekster.soeknadstittel)} */}
+                    {plainTekst(midlertidigeTekster.forsideSoeknadstittel)}
                 </Heading>
                 <GuidePanel poster>
                     <Heading level="2" size="medium" spacing>
-                        {plainTekst(forsidetekster.veilederHei)}
+                        {/* {plainTekst(forsidetekster.veilederHei)} */}
+                        {plainTekst(midlertidigeTekster.forsideVeilederHei)}
                     </Heading>
                     <TekstBlock
-                        block={forsidetekster.veilederhilsen}
+                        // block={forsidetekster.veilederIntro}
+                        block={midlertidigeTekster.forsideVeilederIntro}
                         typografi={Typografi.BodyLong}
                     />
                 </GuidePanel>
                 <div>
                     <Heading level="2" size="large" spacing>
-                        {plainTekst(forsidetekster.foerDuSoekerTittel)}
+                        {/* {plainTekst(forsidetekster.foerDuSoekerTittel)} */}
+                        {plainTekst(midlertidigeTekster.forsideFoerDuSoekerTittel)}
                     </Heading>
                     <TekstBlock
-                        block={forsidetekster.foerDuSoeker}
+                        // block={forsidetekster.foerDuSoeker}
+                        block={midlertidigeTekster.forsideFoerDuSoeker}
                         typografi={Typografi.BodyLong}
                     />
                 </div>
                 <Accordion>
                     <Accordion.Item>
                         <Accordion.Header>
-                            {plainTekst(forsidetekster.informasjonOmPlikterTittel)}
+                            {/* {plainTekst(forsidetekster.informasjonOmPlikterTittel)} */}
+                            {plainTekst(midlertidigeTekster.forsideInformasjonOmPlikterTittel)}
                         </Accordion.Header>
                         <Accordion.Content>
-                            <TekstBlock block={forsidetekster.informasjonOmPlikter} />
+                            {/* <TekstBlock block={forsidetekster.informasjonOmPlikter} /> */}
+                            <TekstBlock
+                                block={midlertidigeTekster.forsideInformasjonOmPlikter}
+                                typografi={Typografi.BodyLong}
+                            />
                         </Accordion.Content>
                     </Accordion.Item>
                     <Accordion.Item>
                         <Accordion.Header>
-                            {plainTekst(forsidetekster.informasjonOmPersonopplysningerTittel)}
+                            {/* {plainTekst(forsidetekster.informasjonOmPersonopplysningerTittel)} */}
+                            {plainTekst(
+                                midlertidigeTekster.forsideInformasjonOmPersonopplysningerTittel
+                            )}
                         </Accordion.Header>
                         <Accordion.Content>
-                            <TekstBlock block={forsidetekster.informasjonOmPersonopplysninger} />
+                            {/* <TekstBlock block={forsidetekster.informasjonOmPersonopplysninger} /> */}
+                            <TekstBlock
+                                block={midlertidigeTekster.forsideInformasjonOmPersonopplysninger}
+                                typografi={Typografi.BodyLong}
+                            />
                         </Accordion.Content>
                     </Accordion.Item>
                     <Accordion.Item>
                         <Accordion.Header>
                             {/* {plainTekst(forsidetekster.informasjonOmLagringAvSvarTittel)} */}
-                            informasjonOmLagringAvSvarTittel
+                            {plainTekst(
+                                midlertidigeTekster.forsideInformasjonOmLagringAvSvarTittel
+                            )}
                         </Accordion.Header>
                         <Accordion.Content>
                             {/* <TekstBlock block={forsidetekster.informasjonOmLagringAvSvar} /> */}
-                            informasjonOmLagringAvSvar
+                            <TekstBlock
+                                block={midlertidigeTekster.forsideInformasjonOmLagringAvSvar}
+                                typografi={Typografi.BodyLong}
+                            />
                         </Accordion.Content>
                     </Accordion.Item>
                 </Accordion>

--- a/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
@@ -1,31 +1,46 @@
 import React, { useEffect } from 'react';
 
-import { Box, GuidePanel, Heading } from '@navikt/ds-react';
+import styled from 'styled-components';
+
+import { Accordion, BodyLong, GuidePanel, Heading, VStack } from '@navikt/ds-react';
 import { setAvailableLanguages } from '@navikt/nav-dekoratoren-moduler';
 
 import Miljø from '../../../../shared-utils/Miljø';
 import { useApp } from '../../../context/AppContext';
 import useFørsteRender from '../../../hooks/useFørsteRender';
-import { Typografi } from '../../../typer/common';
+import { device } from '../../../Theme';
 import { RouteEnum } from '../../../typer/routes';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { logSidevisningKontantstøtte } from '../../../utils/amplitude';
-import Informasjonsbolk from '../../Felleskomponenter/Informasjonsbolk/Informasjonsbolk';
-import InnholdContainer from '../../Felleskomponenter/InnholdContainer/InnholdContainer';
 import TekstBlock from '../../Felleskomponenter/TekstBlock';
 
 import BekreftelseOgStartSoknad from './BekreftelseOgStartSoknad';
 import FortsettPåSøknad from './FortsettPåSøknad';
 
+const Layout = styled.div`
+    max-width: var(--innhold-bredde);
+    margin: 2rem auto 4rem auto;
+
+    @media all and ${device.tablet} {
+        max-width: 100%;
+        margin: 2rem 2rem 4rem 2rem;
+    }
+`;
+
 const Forside: React.FC = () => {
-    const { mellomlagretVerdi, settNåværendeRoute, tekster } = useApp();
+    const { mellomlagretVerdi, settNåværendeRoute, tekster, plainTekst } = useApp();
 
     const {
         [ESanitySteg.FORSIDE]: {
-            punktliste,
+            veilederHei,
             veilederhilsen,
             soeknadstittel,
-            personopplysningslenke,
+            foerDuSoekerTittel,
+            foerDuSoeker,
+            informasjonOmPlikterTittel,
+            informasjonOmPlikter,
+            informasjonOmPersonopplysningerTittel,
+            informasjonOmPersonopplysninger,
         },
     } = tekster();
 
@@ -48,27 +63,50 @@ const Forside: React.FC = () => {
         mellomlagretVerdi && mellomlagretVerdi.modellVersjon === Miljø().modellVersjon;
 
     return (
-        <InnholdContainer>
-            <Box marginBlock="0 12">
-                <Heading size="xlarge" align="center">
+        <Layout>
+            <VStack gap="12">
+                <Heading level="1" size="large" align="center">
                     <TekstBlock block={soeknadstittel} />
                 </Heading>
-            </Box>
 
-            <GuidePanel poster>
-                <TekstBlock block={veilederhilsen} typografi={Typografi.BodyShort} />
-            </GuidePanel>
+                <GuidePanel poster>
+                    <Heading level="2" size="medium" spacing>
+                        {plainTekst(veilederHei)}
+                    </Heading>
+                    <BodyLong>{plainTekst(veilederhilsen)}</BodyLong>
+                </GuidePanel>
 
-            <Informasjonsbolk>
-                <TekstBlock block={punktliste} />
-            </Informasjonsbolk>
+                <div>
+                    <Heading level="2" size="large" spacing>
+                        {plainTekst(foerDuSoekerTittel)}
+                    </Heading>
+                    <BodyLong>
+                        <TekstBlock block={foerDuSoeker} />
+                    </BodyLong>
+                </div>
 
-            {kanFortsettePåSøknad ? <FortsettPåSøknad /> : <BekreftelseOgStartSoknad />}
+                <Accordion>
+                    <Accordion.Item>
+                        <Accordion.Header>
+                            {plainTekst(informasjonOmPlikterTittel)}
+                        </Accordion.Header>
+                        <Accordion.Content>
+                            <TekstBlock block={informasjonOmPlikter} />
+                        </Accordion.Content>
+                    </Accordion.Item>
+                    <Accordion.Item>
+                        <Accordion.Header>
+                            {plainTekst(informasjonOmPersonopplysningerTittel)}
+                        </Accordion.Header>
+                        <Accordion.Content>
+                            <TekstBlock block={informasjonOmPersonopplysninger} />
+                        </Accordion.Content>
+                    </Accordion.Item>
+                </Accordion>
 
-            <Informasjonsbolk>
-                <TekstBlock block={personopplysningslenke} />
-            </Informasjonsbolk>
-        </InnholdContainer>
+                {kanFortsettePåSøknad ? <FortsettPåSøknad /> : <BekreftelseOgStartSoknad />}
+            </VStack>
+        </Layout>
     );
 };
 

--- a/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/FortsettPåSøknad.tsx
@@ -1,31 +1,13 @@
 import React, { FC } from 'react';
 
-import styled from 'styled-components';
-
-import { Alert, Button, Modal } from '@navikt/ds-react';
+import { Alert, Box, Button, Modal, VStack } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
 import { Typografi } from '../../../typer/common';
-import KomponentGruppe from '../../Felleskomponenter/KomponentGruppe/KomponentGruppe';
 import ModalContent from '../../Felleskomponenter/ModalContent';
 import TekstBlock from '../../Felleskomponenter/TekstBlock';
 
 import { useBekreftelseOgStartSoknad } from './useBekreftelseOgStartSoknad';
-
-const StyledButton = styled(Button)`
-    && {
-        margin: 0 auto 2rem auto;
-        padding: 1rem 3rem 1rem 3rem;
-    }
-`;
-
-const StyledFortsettPåSøknad = styled.div`
-    margin-top: 2rem;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    width: 100%;
-`;
 
 const FortsettPåSøknad: FC = () => {
     const { tekster, plainTekst } = useApp();
@@ -48,16 +30,18 @@ const FortsettPåSøknad: FC = () => {
     } = tekster();
 
     return (
-        <StyledFortsettPåSøknad role={'navigation'}>
-            <KomponentGruppe>
-                <Alert variant={'info'}>
-                    <TekstBlock block={mellomlagretAlert} typografi={Typografi.BodyShort} />
-                </Alert>
-            </KomponentGruppe>
-            <StyledButton onClick={fortsettPåSøknaden}>{plainTekst(fortsettKnapp)}</StyledButton>
-            <StyledButton variant={'secondary'} onClick={() => settVisStartPåNyttModal(true)}>
-                {plainTekst(startPaaNyttKnapp)}
-            </StyledButton>
+        <VStack role={'navigation'} gap="6">
+            <Alert variant={'info'}>
+                <TekstBlock block={mellomlagretAlert} typografi={Typografi.BodyShort} />
+            </Alert>
+            <Box marginInline="auto">
+                <Button onClick={fortsettPåSøknaden}>{plainTekst(fortsettKnapp)}</Button>
+            </Box>
+            <Box marginInline="auto">
+                <Button variant={'secondary'} onClick={() => settVisStartPåNyttModal(true)}>
+                    {plainTekst(startPaaNyttKnapp)}
+                </Button>
+            </Box>
             <Modal
                 open={visStartPåNyttModal}
                 onClose={() => {
@@ -80,7 +64,7 @@ const FortsettPåSøknad: FC = () => {
                     </Button>
                 </Modal.Footer>
             </Modal>
-        </StyledFortsettPåSøknad>
+        </VStack>
     );
 };
 export default FortsettPåSøknad;

--- a/src/frontend/components/SøknadsSteg/Forside/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Forside/innholdTyper.ts
@@ -6,8 +6,15 @@ export interface IForsideTekstinnhold {
     bekreftelsesboksErklaering: LocaleRecordString;
     bekreftelsesboksFeilmelding: LocaleRecordString;
     punktliste: LocaleRecordBlock;
+    veilederHei: LocaleRecordBlock;
     veilederhilsen: LocaleRecordBlock;
     soeknadstittel: LocaleRecordBlock;
     personopplysningslenke: LocaleRecordBlock;
     mellomlagretAlert: LocaleRecordBlock;
+    foerDuSoekerTittel: LocaleRecordBlock;
+    foerDuSoeker: LocaleRecordBlock;
+    informasjonOmPlikterTittel: LocaleRecordBlock;
+    informasjonOmPlikter: LocaleRecordBlock;
+    informasjonOmPersonopplysningerTittel: LocaleRecordBlock;
+    informasjonOmPersonopplysninger: LocaleRecordBlock;
 }

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringFelt.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringFelt.tsx
@@ -14,13 +14,19 @@ const StyledOppsummeringsFelt = styled.div`
 `;
 
 interface IOppsummeringsFeltProps {
-    spørsmålstekst: LocaleRecordBlock | LocaleRecordString;
+    /*
+    Tittel brukes istedenfor spørsmålstekst dersom man ønsker å vise tittel/spørsmål på en annen måte enn ved bruk av plainTekst, for eksempel ved å passere inn en <TekstBlock> komponent.
+    I oppgaven om Oppsummering iht Aksel (lenke) så skal OppsummeringsFelt endres, da vil også problemet med å ha to props (spørsmålstekst og tittel) løses slik at vil fungere likt som det nå er i BA.
+    */
+    tittel?: ReactNode;
+    spørsmålstekst?: LocaleRecordBlock | LocaleRecordString;
     søknadsvar?: ReactNode | null;
     flettefelter?: FlettefeltVerdier;
     children?: ReactNode;
 }
 
 export function OppsummeringFelt({
+    tittel,
     søknadsvar,
     spørsmålstekst,
     flettefelter,
@@ -30,7 +36,11 @@ export function OppsummeringFelt({
 
     return (
         <StyledOppsummeringsFelt>
-            {spørsmålstekst && <Label>{plainTekst(spørsmålstekst, flettefelter)}</Label>}
+            {tittel ? (
+                <Label>{tittel}</Label>
+            ) : (
+                spørsmålstekst && <Label>{plainTekst(spørsmålstekst, flettefelter)}</Label>
+            )}
             {søknadsvar ? (
                 <BodyLong>
                     {formaterSøknadsvar(søknadsvar, plainTekst, tekster().FELLES.frittståendeOrd)}

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
@@ -27,6 +27,12 @@ const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
     const { hentRouteObjektForRouteEnum } = useRoutes();
     const omDegHook = useOmdeg();
 
+    /* 
+    Vi oppretter midlertidige tekster som inneholder nye forside-tekster. 
+    Når dette er ute i prod vil vi endre de eksisterende forsideteksene i Sanity (de som nå er utkommentert) slik at de blir likt det som ligger i de midlertidige tekstene. 
+    Når dette er gjort lages en ny PR for å bytte koden tilbake til å bruke forsidetekstene. 
+    */
+
     return (
         <Oppsummeringsbolk
             steg={hentRouteObjektForRouteEnum(RouteEnum.OmDeg)}
@@ -39,7 +45,8 @@ const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
                     spørsmålstekst={forsideTekster.bekreftelsesboksBroedtekst}
                     søknadsvar={plainTekst(
                         søknad.lestOgForståttBekreftelse
-                            ? tekster().FORSIDE.bekreftelsesboksErklaering
+                            ? // ? tekster().FORSIDE.bekreftelsesboksErklaering
+                              tekster().FELLES.midlertidigeTekster.forsideBekreftelsesboksErklaering
                             : jaNeiSvarTilSpråkId(ESvar.NEI, tekster().FELLES.frittståendeOrd)
                     )}
                 />

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
@@ -11,6 +11,7 @@ import { RouteEnum } from '../../../../typer/routes';
 import { genererAdresseVisning } from '../../../../utils/adresse';
 import { landkodeTilSpråk, sivilstandTilSanitySivilstandApiKey } from '../../../../utils/språk';
 import { jaNeiSvarTilSpråkId } from '../../../../utils/spørsmål';
+import TekstBlock from '../../../Felleskomponenter/TekstBlock';
 import { useOmdeg } from '../../OmDeg/useOmdeg';
 import { OppsummeringFelt } from '../OppsummeringFelt';
 import Oppsummeringsbolk from '../Oppsummeringsbolk';
@@ -22,7 +23,11 @@ interface Props {
 
 const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
     const { søknad, tekster, plainTekst } = useApp();
-    const { OM_DEG: omDegTekster, FORSIDE: forsideTekster, FELLES: fellesTekster } = tekster();
+    const {
+        OM_DEG: omDegTekster,
+        // FORSIDE: forsideTekster,
+        FELLES: fellesTekster,
+    } = tekster();
     const { valgtLocale } = useSpråk();
     const { hentRouteObjektForRouteEnum } = useRoutes();
     const omDegHook = useOmdeg();
@@ -42,11 +47,18 @@ const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
         >
             <StyledOppsummeringsFeltGruppe>
                 <OppsummeringFelt
-                    spørsmålstekst={forsideTekster.bekreftelsesboksBroedtekst}
+                    // spørsmålstekst={forsideTekster.bekreftelsesboksBroedtekst}
+                    tittel={
+                        <TekstBlock
+                            block={
+                                fellesTekster.midlertidigeTekster.forsideBekreftelsesboksBroedtekst
+                            }
+                        />
+                    }
                     søknadsvar={plainTekst(
                         søknad.lestOgForståttBekreftelse
                             ? // ? tekster().FORSIDE.bekreftelsesboksErklaering
-                              tekster().FELLES.midlertidigeTekster.forsideBekreftelsesboksErklaering
+                              fellesTekster.midlertidigeTekster.forsideBekreftelsesboksErklaering
                             : jaNeiSvarTilSpråkId(ESvar.NEI, tekster().FELLES.frittståendeOrd)
                     )}
                 />

--- a/src/frontend/typer/sanity/sanity.ts
+++ b/src/frontend/typer/sanity/sanity.ts
@@ -45,6 +45,7 @@ export const bannerPrefix = 'BANNER';
 export const vedlikeholdsarbeidPrefix = 'VEDLIKEHOLDSARBEID';
 export const kanIkkeBrukeSoeknadPrefix = 'KAN_IKKE_BRUKE_SOKNAD';
 export const hjelpeteksterForInputPrefix = 'HJELPETEKSTER_FOR_INPUT';
+export const midlertidigeTeksterPrefix = 'MIDLERTIDIGE_TEKSTER';
 export const alternativeTeksterPrefix = 'ALTERNATIVE_TEKSTER';
 
 export enum ESanityFlettefeltverdi {

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -68,6 +68,7 @@ export interface IFellesTekstInnhold {
     kanIkkeBrukeSoeknad: IKanIkkeBrukeSoeknadTekstinnhold;
     hjelpeteksterForInput: IHjelpeteksterForInputTekstInnhold;
     alternativeTekster: IAlternativeTeksterTekstinnhold;
+    midlertidigeTekster: IMidlertidigeTeksterTekstInnhold;
 }
 
 export interface IModalerTekstinnhold {
@@ -177,3 +178,5 @@ export interface IHjelpeteksterForInputTekstInnhold {
 export interface IAlternativeTeksterTekstinnhold {
     barneillustrajonAltTekst: LocaleRecordBlock;
 }
+
+export interface IMidlertidigeTeksterTekstInnhold {}

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -191,4 +191,8 @@ export interface IMidlertidigeTeksterTekstInnhold {
     forsideInformasjonOmPersonopplysninger: LocaleRecordBlock;
     forsideInformasjonOmLagringAvSvarTittel: LocaleRecordBlock;
     forsideInformasjonOmLagringAvSvar: LocaleRecordBlock;
+    forsideBekreftelsesboksErklaering: LocaleRecordBlock;
+    forsideBekreftelsesboksFeilmelding: LocaleRecordBlock;
+    forsideBekreftelsesboksTittel: LocaleRecordBlock;
+    forsideBekreftelsesboksBroedtekst: LocaleRecordBlock;
 }

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -179,4 +179,16 @@ export interface IAlternativeTeksterTekstinnhold {
     barneillustrajonAltTekst: LocaleRecordBlock;
 }
 
-export interface IMidlertidigeTeksterTekstInnhold {}
+export interface IMidlertidigeTeksterTekstInnhold {
+    forsideSoeknadstittel: LocaleRecordBlock;
+    forsideVeilederHei: LocaleRecordBlock;
+    forsideVeilederIntro: LocaleRecordBlock;
+    forsideFoerDuSoekerTittel: LocaleRecordBlock;
+    forsideFoerDuSoeker: LocaleRecordBlock;
+    forsideInformasjonOmPlikterTittel: LocaleRecordBlock;
+    forsideInformasjonOmPlikter: LocaleRecordBlock;
+    forsideInformasjonOmPersonopplysningerTittel: LocaleRecordBlock;
+    forsideInformasjonOmPersonopplysninger: LocaleRecordBlock;
+    forsideInformasjonOmLagringAvSvarTittel: LocaleRecordBlock;
+    forsideInformasjonOmLagringAvSvar: LocaleRecordBlock;
+}

--- a/src/frontend/utils/sanity.ts
+++ b/src/frontend/utils/sanity.ts
@@ -27,6 +27,7 @@ import {
     formateringsfeilmeldingerPrefix,
     frittståendeOrdPrefix,
     hjelpeteksterForInputPrefix,
+    midlertidigeTeksterPrefix,
     kanIkkeBrukeSoeknadPrefix,
     modalPrefix,
     navigasjonPrefix,
@@ -40,6 +41,7 @@ import {
     IFrittståendeOrdTekstinnhold,
     IHjelpeteksterForInputTekstInnhold,
     IKanIkkeBrukeSoeknadTekstinnhold,
+    IMidlertidigeTeksterTekstInnhold,
     IModalerTekstinnhold,
     INavigasjonTekstinnhold,
     ITekstinnhold,
@@ -192,6 +194,9 @@ export const transformerTilTekstinnhold = (alleDokumenter: SanityDokument[]): IT
         alternativeTekster: struktrerInnholdForFelles(
             dokumenterFiltrertPåPrefix(fellesDokumenter, alternativeTeksterPrefix)
         ) as IAlternativeTeksterTekstinnhold,
+        midlertidigeTekster: struktrerInnholdForFelles(
+            dokumenterFiltrertPåPrefix(fellesDokumenter, midlertidigeTeksterPrefix)
+        ) as IMidlertidigeTeksterTekstInnhold,
     };
     return tekstInnhold as ITekstinnhold;
 };

--- a/src/shared-utils/Miljø.ts
+++ b/src/shared-utils/Miljø.ts
@@ -35,7 +35,7 @@ export const erLokalt = () => !erProd() && !erDev();
 const Miljø = (): MiljøProps => {
     if (erDev()) {
         return {
-            sanityDataset: 'production-v2', // TODO: Trenger vi å bruke dette datasettet? Kan det byttes ut med "production" slik som det gjøres i BA?
+            sanityDataset: 'production',
             soknadApiProxyUrl: `https://familie-ks-soknad.ekstern.dev.nav.no${basePath}api`,
             soknadApiUrl: `http://familie-baks-soknad-api/api`,
             dokumentProxyUrl: `https://familie-ks-soknad.ekstern.dev.nav.no${basePath}dokument`,

--- a/src/shared-utils/Miljø.ts
+++ b/src/shared-utils/Miljø.ts
@@ -61,7 +61,7 @@ const Miljø = (): MiljøProps => {
         };
     } else {
         return {
-            sanityDataset: 'test',
+            sanityDataset: 'production',
             soknadApiProxyUrl: `http://localhost:3000${basePath}api`,
             soknadApiUrl: 'http://localhost:8080/api',
             dokumentProxyUrl: `http://localhost:3000${basePath}dokument`,

--- a/src/shared-utils/Miljø.ts
+++ b/src/shared-utils/Miljø.ts
@@ -35,7 +35,7 @@ export const erLokalt = () => !erProd() && !erDev();
 const Miljø = (): MiljøProps => {
     if (erDev()) {
         return {
-            sanityDataset: 'production-v2',
+            sanityDataset: 'production-v2', // TODO: Trenger vi å bruke dette datasettet? Kan det byttes ut med "production" slik som det gjøres i BA?
             soknadApiProxyUrl: `https://familie-ks-soknad.ekstern.dev.nav.no${basePath}api`,
             soknadApiUrl: `http://familie-baks-soknad-api/api`,
             dokumentProxyUrl: `https://familie-ks-soknad.ekstern.dev.nav.no${basePath}dokument`,


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21846

### 💰 Hva forsøker du å løse i denne PR'en
- Endrer tekster på forsiden slik at den blir mer like Aksel sin mal: https://aksel.nav.no/monster-maler/soknadsdialog/introside-for-soknadsdialoger
- Legger til midlertidige tekster som skal brukes for å vise nye Sanity tekster uten å endre de "vanlige" tekstene. 
- Dersom vi skulle endret de vanlige tekstene måtte vi også pushet koden til prod samtidig for å unngå en mismatch mellom koden og tekstene, noe som er vanskelig å unngå ettersom det er et delay mellom når tekster i Sanity publiseres. Dette ville ført til at noen brukere hadde fått feil tekstinnhold når de besøker nettsiden.
- Når vi har sjekket at alt fungerer som det skal vil tekstene flyttes vekk fra midlertidige tekster og inn i de vanlige. Da oppdaterer vi også hvilke tekster som skal brukes i koden.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig

### 🤷‍♀ ️Hvor er det lurt å starte?
- Gjerne gå gjennom hele applikasjonen, men det skal bare være endringer på forsiden og i komponenter som brukes på forsiden.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Før
![image](https://github.com/user-attachments/assets/e5c7d2bf-5802-46c8-9059-9e7182e09f35)

##### Etter
![image](https://github.com/user-attachments/assets/4319d172-5afa-4a10-91f3-427f9b132c8a)
