### PR TITLE
Bytter forside tekster vekk fra midlertidige tekster

### DIFF
--- a/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
@@ -14,7 +14,7 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
     const { steg, barnForSteg } = useSteg();
 
     const {
-        // FORSIDE,
+        FORSIDE,
         OM_DEG,
         DIN_LIVSSITUASJON,
         VELG_BARN,
@@ -27,7 +27,7 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
         KVITTERING,
     } = tekster();
 
-    const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
+    // const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
 
     let antallBarnTellerOmBarnet = 0;
     let antallBarnTellerEøsForBarnet = 0;
@@ -39,8 +39,8 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
 
             switch (steg.route) {
                 case RouteEnum.Forside:
-                    // tittelBlock = FORSIDE.soeknadstittel;
-                    tittelBlock = midlertidigeTekster.forsideSoeknadstittel;
+                    tittelBlock = FORSIDE.soeknadstittel;
+                    // tittelBlock = midlertidigeTekster.forsideSoeknadstittel;
                     break;
                 case RouteEnum.OmDeg:
                     tittelBlock = OM_DEG.omDegTittel;

--- a/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/useFormProgressSteg.tsx
@@ -27,8 +27,6 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
         KVITTERING,
     } = tekster();
 
-    // const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
-
     let antallBarnTellerOmBarnet = 0;
     let antallBarnTellerEøsForBarnet = 0;
 
@@ -40,7 +38,6 @@ export const useFormProgressSteg = (): IStegMedTittel[] => {
             switch (steg.route) {
                 case RouteEnum.Forside:
                     tittelBlock = FORSIDE.soeknadstittel;
-                    // tittelBlock = midlertidigeTekster.forsideSoeknadstittel;
                     break;
                 case RouteEnum.OmDeg:
                     tittelBlock = OM_DEG.omDegTittel;

--- a/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
@@ -25,14 +25,7 @@ const BekreftelseOgStartSoknad: React.FC = () => {
     const { onStartSøknad, bekreftelseOnChange, bekreftelseStatus } = useBekreftelseOgStartSoknad();
     const { plainTekst, tekster } = useApp();
 
-    /* 
-    Vi oppretter midlertidige tekster som inneholder nye forside-tekster. 
-    Når dette er ute i prod vil vi endre de eksisterende forsideteksene i Sanity (de som nå er utkommentert) slik at de blir likt det som ligger i de midlertidige tekstene. 
-    Når dette er gjort lages en ny PR for å bytte koden tilbake til å bruke forsidetekstene. 
-    */
-
     const forsidetekster = tekster().FORSIDE;
-    // const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
     const navigasjonTekster = tekster().FELLES.navigasjon;
 
     return (
@@ -40,25 +33,21 @@ const BekreftelseOgStartSoknad: React.FC = () => {
             <VStack gap="12">
                 <ConfirmationPanel
                     label={plainTekst(forsidetekster.bekreftelsesboksErklaering)}
-                    // label={plainTekst(midlertidigeTekster.forsideBekreftelsesboksErklaering)}
                     onChange={bekreftelseOnChange}
                     checked={bekreftelseStatus === BekreftelseStatus.BEKREFTET}
                     error={
                         bekreftelseStatus === BekreftelseStatus.FEIL && (
                             <span role={'alert'}>
                                 {plainTekst(forsidetekster.bekreftelsesboksFeilmelding)}
-                                {/* {plainTekst(midlertidigeTekster.forsideBekreftelsesboksFeilmelding)} */}
                             </span>
                         )
                     }
                 >
                     <Heading level="2" size="xsmall" spacing>
                         {plainTekst(forsidetekster.bekreftelsesboksTittel)}
-                        {/* {plainTekst(midlertidigeTekster.forsideBekreftelsesboksTittel)} */}
                     </Heading>
                     <TekstBlock
                         block={forsidetekster.bekreftelsesboksBroedtekst}
-                        // block={midlertidigeTekster.forsideBekreftelsesboksBroedtekst}
                         typografi={Typografi.BodyLong}
                     />
                 </ConfirmationPanel>

--- a/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/BekreftelseOgStartSoknad.tsx
@@ -31,34 +31,34 @@ const BekreftelseOgStartSoknad: React.FC = () => {
     Når dette er gjort lages en ny PR for å bytte koden tilbake til å bruke forsidetekstene. 
     */
 
-    // const forsidetekster = tekster().FORSIDE;
-    const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
+    const forsidetekster = tekster().FORSIDE;
+    // const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
     const navigasjonTekster = tekster().FELLES.navigasjon;
 
     return (
         <form onSubmit={event => onStartSøknad(event)}>
             <VStack gap="12">
                 <ConfirmationPanel
-                    // label={plainTekst(forsidetekster.bekreftelsesboksErklaering)}
-                    label={plainTekst(midlertidigeTekster.forsideBekreftelsesboksErklaering)}
+                    label={plainTekst(forsidetekster.bekreftelsesboksErklaering)}
+                    // label={plainTekst(midlertidigeTekster.forsideBekreftelsesboksErklaering)}
                     onChange={bekreftelseOnChange}
                     checked={bekreftelseStatus === BekreftelseStatus.BEKREFTET}
                     error={
                         bekreftelseStatus === BekreftelseStatus.FEIL && (
                             <span role={'alert'}>
-                                {/* {plainTekst(forsidetekster.bekreftelsesboksFeilmelding)} */}
-                                {plainTekst(midlertidigeTekster.forsideBekreftelsesboksFeilmelding)}
+                                {plainTekst(forsidetekster.bekreftelsesboksFeilmelding)}
+                                {/* {plainTekst(midlertidigeTekster.forsideBekreftelsesboksFeilmelding)} */}
                             </span>
                         )
                     }
                 >
                     <Heading level="2" size="xsmall" spacing>
-                        {/* {plainTekst(forsidetekster.bekreftelsesboksTittel)} */}
-                        {plainTekst(midlertidigeTekster.forsideBekreftelsesboksTittel)}
+                        {plainTekst(forsidetekster.bekreftelsesboksTittel)}
+                        {/* {plainTekst(midlertidigeTekster.forsideBekreftelsesboksTittel)} */}
                     </Heading>
                     <TekstBlock
-                        // block={forsidetekster.bekreftelsesboksBroedtekst}
-                        block={midlertidigeTekster.forsideBekreftelsesboksBroedtekst}
+                        block={forsidetekster.bekreftelsesboksBroedtekst}
+                        // block={midlertidigeTekster.forsideBekreftelsesboksBroedtekst}
                         typografi={Typografi.BodyLong}
                     />
                 </ConfirmationPanel>

--- a/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
@@ -18,14 +18,7 @@ import { FortsettPåSøknad } from './FortsettPåSøknad';
 const Forside: React.FC = () => {
     const { mellomlagretVerdi, settNåværendeRoute, tekster, plainTekst } = useApp();
 
-    /* 
-    Vi oppretter midlertidige tekster som inneholder nye forside-tekster. 
-    Når dette er ute i prod vil vi endre de eksisterende forsideteksene i Sanity (de som nå er utkommentert) slik at de blir likt det som ligger i de midlertidige tekstene. 
-    Når dette er gjort lages en ny PR for å bytte koden tilbake til å bruke forsidetekstene. 
-    */
-
     const forsidetekster = tekster().FORSIDE;
-    // const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
 
     useFørsteRender(() => logSidevisningKontantstøtte(`${RouteEnum.Forside}`));
 
@@ -50,27 +43,22 @@ const Forside: React.FC = () => {
             <VStack gap="12">
                 <Heading level="1" size="large" align="center">
                     {plainTekst(forsidetekster.soeknadstittel)}
-                    {/* {plainTekst(midlertidigeTekster.forsideSoeknadstittel)} */}
                 </Heading>
                 <GuidePanel poster>
                     <Heading level="2" size="medium" spacing>
                         {plainTekst(forsidetekster.veilederHei)}
-                        {/* {plainTekst(midlertidigeTekster.forsideVeilederHei)}*/}
                     </Heading>
                     <TekstBlock
                         block={forsidetekster.veilederIntro}
-                        // block={midlertidigeTekster.forsideVeilederIntro}
                         typografi={Typografi.BodyLong}
                     />
                 </GuidePanel>
                 <div>
                     <Heading level="2" size="large" spacing>
                         {plainTekst(forsidetekster.foerDuSoekerTittel)}
-                        {/* {plainTekst(midlertidigeTekster.forsideFoerDuSoekerTittel)} */}
                     </Heading>
                     <TekstBlock
                         block={forsidetekster.foerDuSoeker}
-                        // block={midlertidigeTekster.forsideFoerDuSoeker}
                         typografi={Typografi.BodyLong}
                     />
                 </div>
@@ -78,12 +66,10 @@ const Forside: React.FC = () => {
                     <Accordion.Item>
                         <Accordion.Header>
                             {plainTekst(forsidetekster.informasjonOmPlikterTittel)}
-                            {/* {plainTekst(midlertidigeTekster.forsideInformasjonOmPlikterTittel)} */}
                         </Accordion.Header>
                         <Accordion.Content>
                             <TekstBlock
                                 block={forsidetekster.informasjonOmPlikter}
-                                // block={midlertidigeTekster.forsideInformasjonOmPlikter}
                                 typografi={Typografi.BodyLong}
                             />
                         </Accordion.Content>
@@ -91,14 +77,10 @@ const Forside: React.FC = () => {
                     <Accordion.Item>
                         <Accordion.Header>
                             {plainTekst(forsidetekster.informasjonOmPersonopplysningerTittel)}
-                            {/* {plainTekst(
-                                midlertidigeTekster.forsideInformasjonOmPersonopplysningerTittel
-                            )} */}
                         </Accordion.Header>
                         <Accordion.Content>
                             <TekstBlock
                                 block={forsidetekster.informasjonOmPersonopplysninger}
-                                // block={midlertidigeTekster.forsideInformasjonOmPersonopplysninger}
                                 typografi={Typografi.BodyLong}
                             />
                         </Accordion.Content>
@@ -106,14 +88,10 @@ const Forside: React.FC = () => {
                     <Accordion.Item>
                         <Accordion.Header>
                             {plainTekst(forsidetekster.informasjonOmLagringAvSvarTittel)}
-                            {/* {plainTekst(
-                                midlertidigeTekster.forsideInformasjonOmLagringAvSvarTittel
-                            )} */}
                         </Accordion.Header>
                         <Accordion.Content>
                             <TekstBlock
                                 block={forsidetekster.informasjonOmLagringAvSvar}
-                                // block={midlertidigeTekster.forsideInformasjonOmLagringAvSvar}
                                 typografi={Typografi.BodyLong}
                             />
                         </Accordion.Content>

--- a/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
+++ b/src/frontend/components/SøknadsSteg/Forside/Forside.tsx
@@ -24,8 +24,8 @@ const Forside: React.FC = () => {
     Når dette er gjort lages en ny PR for å bytte koden tilbake til å bruke forsidetekstene. 
     */
 
-    // const forsidetekster = tekster().FORSIDE;
-    const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
+    const forsidetekster = tekster().FORSIDE;
+    // const midlertidigeTekster = tekster().FELLES.midlertidigeTekster;
 
     useFørsteRender(() => logSidevisningKontantstøtte(`${RouteEnum.Forside}`));
 
@@ -49,71 +49,71 @@ const Forside: React.FC = () => {
         <InnholdContainer>
             <VStack gap="12">
                 <Heading level="1" size="large" align="center">
-                    {/* {plainTekst(forsidetekster.soeknadstittel)} */}
-                    {plainTekst(midlertidigeTekster.forsideSoeknadstittel)}
+                    {plainTekst(forsidetekster.soeknadstittel)}
+                    {/* {plainTekst(midlertidigeTekster.forsideSoeknadstittel)} */}
                 </Heading>
                 <GuidePanel poster>
                     <Heading level="2" size="medium" spacing>
-                        {/* {plainTekst(forsidetekster.veilederHei)} */}
-                        {plainTekst(midlertidigeTekster.forsideVeilederHei)}
+                        {plainTekst(forsidetekster.veilederHei)}
+                        {/* {plainTekst(midlertidigeTekster.forsideVeilederHei)}*/}
                     </Heading>
                     <TekstBlock
-                        // block={forsidetekster.veilederIntro}
-                        block={midlertidigeTekster.forsideVeilederIntro}
+                        block={forsidetekster.veilederIntro}
+                        // block={midlertidigeTekster.forsideVeilederIntro}
                         typografi={Typografi.BodyLong}
                     />
                 </GuidePanel>
                 <div>
                     <Heading level="2" size="large" spacing>
-                        {/* {plainTekst(forsidetekster.foerDuSoekerTittel)} */}
-                        {plainTekst(midlertidigeTekster.forsideFoerDuSoekerTittel)}
+                        {plainTekst(forsidetekster.foerDuSoekerTittel)}
+                        {/* {plainTekst(midlertidigeTekster.forsideFoerDuSoekerTittel)} */}
                     </Heading>
                     <TekstBlock
-                        // block={forsidetekster.foerDuSoeker}
-                        block={midlertidigeTekster.forsideFoerDuSoeker}
+                        block={forsidetekster.foerDuSoeker}
+                        // block={midlertidigeTekster.forsideFoerDuSoeker}
                         typografi={Typografi.BodyLong}
                     />
                 </div>
                 <Accordion>
                     <Accordion.Item>
                         <Accordion.Header>
-                            {/* {plainTekst(forsidetekster.informasjonOmPlikterTittel)} */}
-                            {plainTekst(midlertidigeTekster.forsideInformasjonOmPlikterTittel)}
+                            {plainTekst(forsidetekster.informasjonOmPlikterTittel)}
+                            {/* {plainTekst(midlertidigeTekster.forsideInformasjonOmPlikterTittel)} */}
                         </Accordion.Header>
                         <Accordion.Content>
-                            {/* <TekstBlock block={forsidetekster.informasjonOmPlikter} /> */}
                             <TekstBlock
-                                block={midlertidigeTekster.forsideInformasjonOmPlikter}
+                                block={forsidetekster.informasjonOmPlikter}
+                                // block={midlertidigeTekster.forsideInformasjonOmPlikter}
                                 typografi={Typografi.BodyLong}
                             />
                         </Accordion.Content>
                     </Accordion.Item>
                     <Accordion.Item>
                         <Accordion.Header>
-                            {/* {plainTekst(forsidetekster.informasjonOmPersonopplysningerTittel)} */}
-                            {plainTekst(
+                            {plainTekst(forsidetekster.informasjonOmPersonopplysningerTittel)}
+                            {/* {plainTekst(
                                 midlertidigeTekster.forsideInformasjonOmPersonopplysningerTittel
-                            )}
+                            )} */}
                         </Accordion.Header>
                         <Accordion.Content>
-                            {/* <TekstBlock block={forsidetekster.informasjonOmPersonopplysninger} /> */}
                             <TekstBlock
-                                block={midlertidigeTekster.forsideInformasjonOmPersonopplysninger}
+                                block={forsidetekster.informasjonOmPersonopplysninger}
+                                // block={midlertidigeTekster.forsideInformasjonOmPersonopplysninger}
                                 typografi={Typografi.BodyLong}
                             />
                         </Accordion.Content>
                     </Accordion.Item>
                     <Accordion.Item>
                         <Accordion.Header>
-                            {/* {plainTekst(forsidetekster.informasjonOmLagringAvSvarTittel)} */}
-                            {plainTekst(
+                            {plainTekst(forsidetekster.informasjonOmLagringAvSvarTittel)}
+                            {/* {plainTekst(
                                 midlertidigeTekster.forsideInformasjonOmLagringAvSvarTittel
-                            )}
+                            )} */}
                         </Accordion.Header>
                         <Accordion.Content>
-                            {/* <TekstBlock block={forsidetekster.informasjonOmLagringAvSvar} /> */}
                             <TekstBlock
-                                block={midlertidigeTekster.forsideInformasjonOmLagringAvSvar}
+                                block={forsidetekster.informasjonOmLagringAvSvar}
+                                // block={midlertidigeTekster.forsideInformasjonOmLagringAvSvar}
                                 typografi={Typografi.BodyLong}
                             />
                         </Accordion.Content>

--- a/src/frontend/components/SøknadsSteg/Forside/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Forside/innholdTyper.ts
@@ -7,6 +7,7 @@ export interface IForsideTekstinnhold {
     bekreftelsesboksFeilmelding: LocaleRecordString;
     punktliste: LocaleRecordBlock;
     veilederHei: LocaleRecordBlock;
+    veilederIntro: LocaleRecordBlock;
     veilederhilsen: LocaleRecordBlock;
     soeknadstittel: LocaleRecordBlock;
     personopplysningslenke: LocaleRecordBlock;
@@ -17,4 +18,6 @@ export interface IForsideTekstinnhold {
     informasjonOmPlikter: LocaleRecordBlock;
     informasjonOmPersonopplysningerTittel: LocaleRecordBlock;
     informasjonOmPersonopplysninger: LocaleRecordBlock;
+    informasjonOmLagringAvSvarTittel: LocaleRecordBlock;
+    informasjonOmLagringAvSvar: LocaleRecordBlock;
 }

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
@@ -28,12 +28,6 @@ const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
     const { hentRouteObjektForRouteEnum } = useRoutes();
     const omDegHook = useOmdeg();
 
-    /* 
-    Vi oppretter midlertidige tekster som inneholder nye forside-tekster. 
-    Når dette er ute i prod vil vi endre de eksisterende forsideteksene i Sanity (de som nå er utkommentert) slik at de blir likt det som ligger i de midlertidige tekstene. 
-    Når dette er gjort lages en ny PR for å bytte koden tilbake til å bruke forsidetekstene. 
-    */
-
     return (
         <Oppsummeringsbolk
             steg={hentRouteObjektForRouteEnum(RouteEnum.OmDeg)}
@@ -43,19 +37,11 @@ const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
         >
             <StyledOppsummeringsFeltGruppe>
                 <OppsummeringFelt
-                    tittel={
-                        <TekstBlock
-                            block={
-                                forsideTekster.bekreftelsesboksBroedtekst
-                                // fellesTekster.midlertidigeTekster.forsideBekreftelsesboksBroedtekst
-                            }
-                        />
-                    }
+                    tittel={<TekstBlock block={forsideTekster.bekreftelsesboksBroedtekst} />}
                     søknadsvar={plainTekst(
                         søknad.lestOgForståttBekreftelse
                             ? forsideTekster.bekreftelsesboksErklaering
-                            : // fellesTekster.midlertidigeTekster.forsideBekreftelsesboksErklaering
-                              jaNeiSvarTilSpråkId(ESvar.NEI, fellesTekster.frittståendeOrd)
+                            : jaNeiSvarTilSpråkId(ESvar.NEI, fellesTekster.frittståendeOrd)
                     )}
                 />
             </StyledOppsummeringsFeltGruppe>

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
@@ -23,11 +23,7 @@ interface Props {
 
 const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
     const { søknad, tekster, plainTekst } = useApp();
-    const {
-        OM_DEG: omDegTekster,
-        // FORSIDE: forsideTekster,
-        FELLES: fellesTekster,
-    } = tekster();
+    const { OM_DEG: omDegTekster, FORSIDE: forsideTekster, FELLES: fellesTekster } = tekster();
     const { valgtLocale } = useSpråk();
     const { hentRouteObjektForRouteEnum } = useRoutes();
     const omDegHook = useOmdeg();
@@ -47,19 +43,19 @@ const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
         >
             <StyledOppsummeringsFeltGruppe>
                 <OppsummeringFelt
-                    // spørsmålstekst={forsideTekster.bekreftelsesboksBroedtekst}
                     tittel={
                         <TekstBlock
                             block={
-                                fellesTekster.midlertidigeTekster.forsideBekreftelsesboksBroedtekst
+                                forsideTekster.bekreftelsesboksBroedtekst
+                                // fellesTekster.midlertidigeTekster.forsideBekreftelsesboksBroedtekst
                             }
                         />
                     }
                     søknadsvar={plainTekst(
                         søknad.lestOgForståttBekreftelse
-                            ? // ? tekster().FORSIDE.bekreftelsesboksErklaering
-                              fellesTekster.midlertidigeTekster.forsideBekreftelsesboksErklaering
-                            : jaNeiSvarTilSpråkId(ESvar.NEI, tekster().FELLES.frittståendeOrd)
+                            ? forsideTekster.bekreftelsesboksErklaering
+                            : // fellesTekster.midlertidigeTekster.forsideBekreftelsesboksErklaering
+                              jaNeiSvarTilSpråkId(ESvar.NEI, fellesTekster.frittståendeOrd)
                     )}
                 />
             </StyledOppsummeringsFeltGruppe>

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -181,20 +181,4 @@ export interface IAlternativeTeksterTekstinnhold {
     barneillustrajonAltTekst: LocaleRecordBlock;
 }
 
-export interface IMidlertidigeTeksterTekstInnhold {
-    forsideSoeknadstittel: LocaleRecordBlock;
-    forsideVeilederHei: LocaleRecordBlock;
-    forsideVeilederIntro: LocaleRecordBlock;
-    forsideFoerDuSoekerTittel: LocaleRecordBlock;
-    forsideFoerDuSoeker: LocaleRecordBlock;
-    forsideInformasjonOmPlikterTittel: LocaleRecordBlock;
-    forsideInformasjonOmPlikter: LocaleRecordBlock;
-    forsideInformasjonOmPersonopplysningerTittel: LocaleRecordBlock;
-    forsideInformasjonOmPersonopplysninger: LocaleRecordBlock;
-    forsideInformasjonOmLagringAvSvarTittel: LocaleRecordBlock;
-    forsideInformasjonOmLagringAvSvar: LocaleRecordBlock;
-    forsideBekreftelsesboksErklaering: LocaleRecordBlock;
-    forsideBekreftelsesboksFeilmelding: LocaleRecordBlock;
-    forsideBekreftelsesboksTittel: LocaleRecordBlock;
-    forsideBekreftelsesboksBroedtekst: LocaleRecordBlock;
-}
+export interface IMidlertidigeTeksterTekstInnhold {}


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22084

### 💰 Hva forsøker du å løse i denne PR'en
- Midlertidige tekster ble lagt til i [en annen oppgave](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21846) for å passe på at nye tekster kunne bli lagt til samtidig som ny kode for forsiden gikk live.
- Disse midlertidige tekstene blir nå fjernet og byttes ut med de vanlige tekstene igjen.

### ✅ Checklist
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig

### 🤷‍♀ ️Hvor er det lurt å starte?
- Sjekk at alle tekstene på forsiden ser bra ut.
- Sjekk også på nynorsk og engelsk.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
- Ingen visuelle endringer, det er kun kode som endres for å bestemme hvordan tekster hentes fra Sanity.