### PR TITLE
Forbedring av oppsummering iht Aksel

### DIFF
--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/Arbeidsperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/Arbeidsperiode.tsx
@@ -13,6 +13,7 @@ import {
     IEøsForSøkerFeltTyper,
     IOmBarnetFeltTyper,
 } from '../../../typer/skjema';
+import { uppercaseFørsteBokstav } from '../../../utils/visning';
 import JaNeiSpm from '../JaNeiSpm/JaNeiSpm';
 import { LeggTilKnapp } from '../LeggTilKnapp/LeggTilKnapp';
 import PerioderContainer from '../PerioderContainer';
@@ -61,6 +62,13 @@ export const Arbeidsperiode: React.FC<Props> = ({
         tekster().FELLES.modaler.arbeidsperiode[personType];
     const { flerePerioder, leggTilKnapp, leggTilPeriodeForklaring } = teksterForModal;
 
+    const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
+    const { arbeidsperioder, utenfor, i, norge } = frittståendeOrdTekster;
+
+    const perioderContainerTittel = uppercaseFørsteBokstav(
+        `${plainTekst(arbeidsperioder)} ${plainTekst(gjelderUtlandet ? utenfor : i)} ${plainTekst(norge)}`
+    );
+
     return (
         <>
             <JaNeiSpm
@@ -76,7 +84,7 @@ export const Arbeidsperiode: React.FC<Props> = ({
                 flettefelter={{ barnetsNavn: barn?.navn }}
             />
             {arbeiderEllerArbeidetFelt.verdi === ESvar.JA && (
-                <PerioderContainer>
+                <PerioderContainer tittel={perioderContainerTittel}>
                     {registrerteArbeidsperioder.verdi.map((periode, index) => (
                         <ArbeidsperiodeOppsummering
                             key={`arbeidsperiode-${index}`}

--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering.tsx
@@ -70,34 +70,44 @@ export const ArbeidsperiodeOppsummering: React.FC<ArbeidsperiodeOppsummeringProp
         >
             {arbeidsperiodeAvsluttet.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={teksterForModal.arbeidsperiodenAvsluttet.sporsmal}
+                    tittel={
+                        <TekstBlock block={teksterForModal.arbeidsperiodenAvsluttet.sporsmal} />
+                    }
                     søknadsvar={arbeidsperiodeAvsluttet.svar}
                 />
             )}
             {arbeidsperiodeland.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={
-                        periodenErAvsluttet
-                            ? teksterForModal.hvilketLandFortid.sporsmal
-                            : teksterForModal.hvilketLandNaatid.sporsmal
+                    tittel={
+                        <TekstBlock
+                            block={
+                                periodenErAvsluttet
+                                    ? teksterForModal.hvilketLandFortid.sporsmal
+                                    : teksterForModal.hvilketLandNaatid.sporsmal
+                            }
+                            flettefelter={{ barnetsNavn: barn?.navn }}
+                        />
                     }
-                    flettefelter={{ barnetsNavn: barn?.navn }}
                     søknadsvar={landkodeTilSpråk(arbeidsperiodeland.svar, valgtLocale)}
                 />
             )}
             <OppsummeringFelt
-                spørsmålstekst={teksterForModal.arbeidsgiver.sporsmal}
+                tittel={<TekstBlock block={teksterForModal.arbeidsgiver.sporsmal} />}
                 søknadsvar={arbeidsgiver.svar}
             />
             <OppsummeringFelt
-                spørsmålstekst={teksterForModal.startdato.sporsmal}
+                tittel={<TekstBlock block={teksterForModal.startdato.sporsmal} />}
                 søknadsvar={formaterDato(fraDatoArbeidsperiode.svar)}
             />
             <OppsummeringFelt
-                spørsmålstekst={
-                    periodenErAvsluttet
-                        ? teksterForModal.sluttdatoFortid.sporsmal
-                        : teksterForModal.sluttdatoFremtid.sporsmal
+                tittel={
+                    <TekstBlock
+                        block={
+                            periodenErAvsluttet
+                                ? teksterForModal.sluttdatoFortid.sporsmal
+                                : teksterForModal.sluttdatoFremtid.sporsmal
+                        }
+                    />
                 }
                 søknadsvar={formaterDatoMedUkjent(
                     tilDatoArbeidsperiode.svar,
@@ -106,7 +116,7 @@ export const ArbeidsperiodeOppsummering: React.FC<ArbeidsperiodeOppsummeringProp
             />
             {adresse.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={adresseTekst.sporsmal}
+                    tittel={<TekstBlock block={adresseTekst.sporsmal} />}
                     søknadsvar={
                         adresse.svar === AlternativtSvarForInput.UKJENT
                             ? plainTekst(adresseTekst.checkboxLabel)

--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering.tsx
@@ -4,7 +4,7 @@ import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { AlternativtSvarForInput, Typografi } from '../../../typer/common';
+import { AlternativtSvarForInput } from '../../../typer/common';
 import { IArbeidsperiode } from '../../../typer/perioder';
 import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { IArbeidsperiodeTekstinnhold } from '../../../typer/sanity/modaler/arbeidsperiode';
@@ -64,7 +64,6 @@ export const ArbeidsperiodeOppsummering: React.FC<ArbeidsperiodeOppsummeringProp
                 <TekstBlock
                     block={teksterForModal.oppsummeringstittel}
                     flettefelter={{ antall: nummer.toString(), gjelderUtland: gjelderUtlandet }}
-                    typografi={Typografi.HeadingH3}
                 />
             }
         >

--- a/src/frontend/components/Felleskomponenter/Barnehagemodal/BarnehageplassPeriode.tsx
+++ b/src/frontend/components/Felleskomponenter/Barnehagemodal/BarnehageplassPeriode.tsx
@@ -9,6 +9,7 @@ import { IBarnehageplassPeriode } from '../../../typer/perioder';
 import { IBarnehageplassTekstinnhold } from '../../../typer/sanity/modaler/barnehageplass';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { IOmBarnetFeltTyper } from '../../../typer/skjema';
+import { uppercaseFørsteBokstav } from '../../../utils/visning';
 import { IOmBarnetTekstinnhold } from '../../SøknadsSteg/OmBarnet/innholdTyper';
 import { LeggTilKnapp } from '../LeggTilKnapp/LeggTilKnapp';
 import PerioderContainer from '../PerioderContainer';
@@ -44,8 +45,14 @@ export const BarnehageplassPeriode: React.FC<BarnehageplassPeriodeProps> = ({
     const teksterForOmBarnetSteg: IOmBarnetTekstinnhold = tekster()[ESanitySteg.OM_BARNET];
     const barnetsNavn = barn.navn;
 
+    const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
+
     return (
-        <PerioderContainer>
+        <PerioderContainer
+            tittel={uppercaseFørsteBokstav(
+                plainTekst(frittståendeOrdTekster.barnehageplassperioder)
+            )}
+        >
             <TekstBlock
                 block={teksterForOmBarnetSteg.opplystBarnehageplass}
                 flettefelter={{ barnetsNavn }}

--- a/src/frontend/components/Felleskomponenter/Barnehagemodal/BarnehageplassPeriodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Barnehagemodal/BarnehageplassPeriodeOppsummering.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { useApp } from '../../../context/AppContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { Typografi } from '../../../typer/common';
 import { IBarnehageplassPeriode } from '../../../typer/perioder';
 import { IBarnehageplassTekstinnhold } from '../../../typer/sanity/modaler/barnehageplass';
 import { formaterDato, formaterDatoMedUkjent } from '../../../utils/dato';
@@ -49,7 +48,6 @@ export const BarnehageplassPeriodeOppsummering: React.FC<BarnehageplassPeriodePr
                 <TekstBlock
                     block={barnehageplassTekster.oppsummeringstittel}
                     flettefelter={{ antall: nummer.toString() }}
-                    typografi={Typografi.HeadingH3}
                 />
             }
         >

--- a/src/frontend/components/Felleskomponenter/Barnehagemodal/BarnehageplassPeriodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Barnehagemodal/BarnehageplassPeriodeOppsummering.tsx
@@ -54,7 +54,7 @@ export const BarnehageplassPeriodeOppsummering: React.FC<BarnehageplassPeriodePr
             }
         >
             <OppsummeringFelt
-                spørsmålstekst={barnehageplassTekster.periodebeskrivelse.sporsmal}
+                tittel={<TekstBlock block={barnehageplassTekster.periodebeskrivelse.sporsmal} />}
                 søknadsvar={plainTekst(
                     hentBarnehageplassBeskrivelse(
                         barnehageplassPeriodeBeskrivelse.svar,
@@ -64,41 +64,49 @@ export const BarnehageplassPeriodeOppsummering: React.FC<BarnehageplassPeriodePr
             />
 
             <OppsummeringFelt
-                spørsmålstekst={barnehageplassTekster.utland.sporsmal}
+                tittel={<TekstBlock block={barnehageplassTekster.utland.sporsmal} />}
                 søknadsvar={barnehageplassUtlandet.svar}
             />
             {barnehageplassLand.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={barnehageplassTekster.hvilketLand.sporsmal}
+                    tittel={<TekstBlock block={barnehageplassTekster.hvilketLand.sporsmal} />}
                     søknadsvar={landkodeTilSpråk(barnehageplassLand.svar, valgtLocale)}
                 />
             )}
             {offentligStøtte.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={barnehageplassTekster.offentligStoette.sporsmal}
+                    tittel={<TekstBlock block={barnehageplassTekster.offentligStoette.sporsmal} />}
                     søknadsvar={offentligStøtte.svar}
                 />
             )}
             <OppsummeringFelt
-                spørsmålstekst={barnehageplassTekster.antallTimer.sporsmal}
+                tittel={<TekstBlock block={barnehageplassTekster.antallTimer.sporsmal} />}
                 søknadsvar={antallTimer.svar}
             />
 
             <OppsummeringFelt
-                spørsmålstekst={
-                    barnehageplassPeriodeBeskrivelse.svar ===
-                    EBarnehageplassPeriodeBeskrivelse.TILDELT_BARNEHAGEPLASS_I_FREMTIDEN
-                        ? barnehageplassTekster.startdatoFremtid.sporsmal
-                        : barnehageplassTekster.startdatoFortid.sporsmal
+                tittel={
+                    <TekstBlock
+                        block={
+                            barnehageplassPeriodeBeskrivelse.svar ===
+                            EBarnehageplassPeriodeBeskrivelse.TILDELT_BARNEHAGEPLASS_I_FREMTIDEN
+                                ? barnehageplassTekster.startdatoFremtid.sporsmal
+                                : barnehageplassTekster.startdatoFortid.sporsmal
+                        }
+                    />
                 }
                 søknadsvar={formaterDato(startetIBarnehagen.svar)}
             />
             <OppsummeringFelt
-                spørsmålstekst={
-                    barnehageplassPeriodeBeskrivelse.svar ===
-                    EBarnehageplassPeriodeBeskrivelse.HATT_BARNEHAGEPLASS_TIDLIGERE
-                        ? barnehageplassTekster.sluttdatoFortid.sporsmal
-                        : barnehageplassTekster.sluttdatoFremtid.sporsmal
+                tittel={
+                    <TekstBlock
+                        block={
+                            barnehageplassPeriodeBeskrivelse.svar ===
+                            EBarnehageplassPeriodeBeskrivelse.HATT_BARNEHAGEPLASS_TIDLIGERE
+                                ? barnehageplassTekster.sluttdatoFortid.sporsmal
+                                : barnehageplassTekster.sluttdatoFremtid.sporsmal
+                        }
+                    />
                 }
                 søknadsvar={formaterDatoMedUkjent(
                     slutterIBarnehagen.svar,

--- a/src/frontend/components/Felleskomponenter/KontantstøttePeriode/KontantstøttePeriode.tsx
+++ b/src/frontend/components/Felleskomponenter/KontantstøttePeriode/KontantstøttePeriode.tsx
@@ -9,6 +9,7 @@ import { IEøsKontantstøttePeriode } from '../../../typer/perioder';
 import { PeriodePersonTypeProps, PersonType } from '../../../typer/personType';
 import { IEøsYtelseTekstinnhold } from '../../../typer/sanity/modaler/eøsYtelse';
 import { IEøsForBarnFeltTyper, IOmBarnetFeltTyper } from '../../../typer/skjema';
+import { uppercaseFørsteBokstav } from '../../../utils/visning';
 import JaNeiSpm from '../JaNeiSpm/JaNeiSpm';
 import { LeggTilKnapp } from '../LeggTilKnapp/LeggTilKnapp';
 import PerioderContainer from '../PerioderContainer';
@@ -50,6 +51,8 @@ export const KontantstøttePeriode: React.FC<KontantstøttePeriodeProps> = ({
     const teksterForPersonType: IEøsYtelseTekstinnhold =
         tekster().FELLES.modaler.eøsYtelse[personType];
 
+    const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
+
     return (
         <>
             <JaNeiSpm
@@ -60,7 +63,11 @@ export const KontantstøttePeriode: React.FC<KontantstøttePeriodeProps> = ({
                 flettefelter={{ barnetsNavn: barn?.navn }}
             />
             {tilhørendeJaNeiSpmFelt.verdi === ESvar.JA && (
-                <PerioderContainer>
+                <PerioderContainer
+                    tittel={uppercaseFørsteBokstav(
+                        plainTekst(frittståendeOrdTekster.kontantstoetteperioder)
+                    )}
+                >
                     {registrerteEøsKontantstøttePerioder.verdi.map((periode, index) => (
                         <KontantstøttePeriodeOppsummering
                             key={`eøs-kontantstøtte-periode-${index}`}

--- a/src/frontend/components/Felleskomponenter/KontantstøttePeriode/KontantstøttePeriodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/KontantstøttePeriode/KontantstøttePeriodeOppsummering.tsx
@@ -4,7 +4,6 @@ import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { Typografi } from '../../../typer/common';
 import { IEøsKontantstøttePeriode } from '../../../typer/perioder';
 import { PersonType } from '../../../typer/personType';
 import { IEøsYtelseTekstinnhold } from '../../../typer/sanity/modaler/eøsYtelse';
@@ -64,7 +63,6 @@ export const KontantstøttePeriodeOppsummering: React.FC<Props> = ({
                 <TekstBlock
                     block={teksterForPersonType.oppsummeringstittelKontantstoette}
                     flettefelter={{ antall: nummer.toString() }}
-                    typografi={Typografi.HeadingH3}
                 />
             }
         >

--- a/src/frontend/components/Felleskomponenter/KontantstøttePeriode/KontantstøttePeriodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/KontantstøttePeriode/KontantstøttePeriodeOppsummering.tsx
@@ -70,33 +70,45 @@ export const KontantstøttePeriodeOppsummering: React.FC<Props> = ({
         >
             {mottarEøsKontantstøtteNå.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={teksterForPersonType.faarYtelserNaa.sporsmal}
-                    flettefelter={{ barnetsNavn }}
+                    tittel={
+                        <TekstBlock
+                            block={teksterForPersonType.faarYtelserNaa.sporsmal}
+                            flettefelter={{ barnetsNavn }}
+                        />
+                    }
                     søknadsvar={mottarEøsKontantstøtteNå.svar}
                 />
             )}
             <OppsummeringFelt
-                spørsmålstekst={
-                    periodenErAvsluttet
-                        ? teksterForPersonType.ytelseLandFortid.sporsmal
-                        : teksterForPersonType.ytelseLandNaatid.sporsmal
+                tittel={
+                    <TekstBlock
+                        block={
+                            periodenErAvsluttet
+                                ? teksterForPersonType.ytelseLandFortid.sporsmal
+                                : teksterForPersonType.ytelseLandNaatid.sporsmal
+                        }
+                        flettefelter={{ barnetsNavn }}
+                    />
                 }
-                flettefelter={{ barnetsNavn }}
                 søknadsvar={landkodeTilSpråk(kontantstøtteLand.svar, valgtLocale)}
             />
             <OppsummeringFelt
-                spørsmålstekst={teksterForPersonType.startdato.sporsmal}
+                tittel={<TekstBlock block={teksterForPersonType.startdato.sporsmal} />}
                 søknadsvar={formaterDato(fraDatoKontantstøttePeriode.svar)}
             />
             {tilDatoKontantstøttePeriode.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={teksterForPersonType.sluttdato.sporsmal}
+                    tittel={<TekstBlock block={teksterForPersonType.sluttdato.sporsmal} />}
                     søknadsvar={formaterDato(tilDatoKontantstøttePeriode.svar)}
                 />
             )}
             <OppsummeringFelt
-                spørsmålstekst={teksterForPersonType.beloepPerMaaned.sporsmal}
-                flettefelter={{ barnetsNavn }}
+                tittel={
+                    <TekstBlock
+                        block={teksterForPersonType.beloepPerMaaned.sporsmal}
+                        flettefelter={{ barnetsNavn }}
+                    />
+                }
                 søknadsvar={månedligBeløp.svar}
             />
         </PeriodeOppsummering>

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/Pensjonsperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/Pensjonsperiode.tsx
@@ -12,6 +12,7 @@ import {
     IEøsForSøkerFeltTyper,
     IOmBarnetFeltTyper,
 } from '../../../typer/skjema';
+import { uppercaseFørsteBokstav } from '../../../utils/visning';
 import JaNeiSpm from '../JaNeiSpm/JaNeiSpm';
 import { LeggTilKnapp } from '../LeggTilKnapp/LeggTilKnapp';
 import PerioderContainer from '../PerioderContainer';
@@ -51,13 +52,21 @@ export const Pensjonsperiode: React.FC<Props> = ({
     barn,
 }) => {
     const { tekster, plainTekst } = useApp();
-    const teksterForModal = tekster().FELLES.modaler.pensjonsperiode[personType];
 
     const {
         erÅpen: pensjonsmodalErÅpen,
         lukkModal: lukkPensjonsmodal,
         åpneModal: åpnePensjonsmodal,
     } = useModal();
+
+    const teksterForModal = tekster().FELLES.modaler.pensjonsperiode[personType];
+
+    const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
+    const { pensjonsperioder, fra, utlandet, norge } = frittståendeOrdTekster;
+
+    const perioderContainerTittel = uppercaseFørsteBokstav(
+        `${plainTekst(pensjonsperioder)} ${plainTekst(fra)} ${plainTekst(gjelderUtlandet ? utlandet : norge)}`
+    );
 
     return (
         <>
@@ -74,7 +83,7 @@ export const Pensjonsperiode: React.FC<Props> = ({
                 flettefelter={{ barnetsNavn: barn?.navn }}
             />
             {mottarEllerMottattPensjonFelt.verdi === ESvar.JA && (
-                <PerioderContainer>
+                <PerioderContainer tittel={perioderContainerTittel}>
                     {registrertePensjonsperioder.verdi.map((pensjonsperiode, index) => (
                         <PensjonsperiodeOppsummering
                             key={`pensjonsperiode-${index}`}

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering.tsx
@@ -56,31 +56,39 @@ export const PensjonsperiodeOppsummering: React.FC<PensjonsperiodeOppsummeringPr
         >
             {mottarPensjonNå.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={teksterForModal.faarPensjonNaa.sporsmal}
+                    tittel={
+                        <TekstBlock
+                            block={teksterForModal.faarPensjonNaa.sporsmal}
+                            flettefelter={{ barnetsNavn: barn?.navn }}
+                        />
+                    }
                     søknadsvar={mottarPensjonNå.svar}
-                    flettefelter={{ barnetsNavn: barn?.navn }}
                 />
             )}
             {pensjonsland.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={
-                        periodenErAvsluttet
-                            ? teksterForModal.pensjonLandFortid.sporsmal
-                            : teksterForModal.pensjonLandNaatid.sporsmal
+                    tittel={
+                        <TekstBlock
+                            block={
+                                periodenErAvsluttet
+                                    ? teksterForModal.pensjonLandFortid.sporsmal
+                                    : teksterForModal.pensjonLandNaatid.sporsmal
+                            }
+                            flettefelter={{ barnetsNavn: barn?.navn }}
+                        />
                     }
                     søknadsvar={landkodeTilSpråk(pensjonsland.svar, valgtLocale)}
-                    flettefelter={{ barnetsNavn: barn?.navn }}
                 />
             )}
             {pensjonFra.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={teksterForModal.startdato.sporsmal}
+                    tittel={<TekstBlock block={teksterForModal.startdato.sporsmal} />}
                     søknadsvar={formaterDato(pensjonFra.svar)}
                 />
             )}
             {pensjonTil.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={teksterForModal.sluttdato.sporsmal}
+                    tittel={<TekstBlock block={teksterForModal.sluttdato.sporsmal} />}
                     søknadsvar={formaterDato(pensjonTil.svar)}
                 />
             )}

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering.tsx
@@ -4,7 +4,6 @@ import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { Typografi } from '../../../typer/common';
 import { IPensjonsperiode } from '../../../typer/perioder';
 import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { formaterDato } from '../../../utils/dato';
@@ -50,7 +49,6 @@ export const PensjonsperiodeOppsummering: React.FC<PensjonsperiodeOppsummeringPr
                 <TekstBlock
                     block={teksterForModal.oppsummeringstittel}
                     flettefelter={{ antall: nummer.toString(), gjelderUtland: gjelderUtlandet }}
-                    typografi={Typografi.HeadingH3}
                 />
             }
         >

--- a/src/frontend/components/Felleskomponenter/PeriodeOppsummering/PeriodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/PeriodeOppsummering/PeriodeOppsummering.tsx
@@ -1,10 +1,7 @@
 import React, { ReactNode } from 'react';
 
-import styled from 'styled-components';
-
 import { TrashFillIcon } from '@navikt/aksel-icons';
-import { Button } from '@navikt/ds-react';
-import { ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
+import { Button, FormSummary } from '@navikt/ds-react';
 
 import { LocaleRecordBlock } from '../../../typer/common';
 import TekstBlock from '../TekstBlock';
@@ -17,17 +14,6 @@ interface Props {
     children?: ReactNode;
 }
 
-const PeriodeContainer = styled.div<{ $bottomBorder: boolean }>`
-    margin-bottom: 2rem;
-    border-bottom: ${props => (props.$bottomBorder ? `1px solid ${ABorderDefault}` : 'none')};
-`;
-
-const StyledButton = styled(Button)`
-    && {
-        margin-bottom: 1.5rem;
-    }
-`;
-
 function PeriodeOppsummering({
     fjernPeriodeCallback = undefined,
     fjernKnappTekst,
@@ -35,24 +21,26 @@ function PeriodeOppsummering({
     vedleggNotis,
     children,
 }: Props) {
-    const skalHaBottomBorder = !!fjernPeriodeCallback;
-
     return (
-        <PeriodeContainer $bottomBorder={skalHaBottomBorder}>
-            {tittel}
-            {children}
-            {fjernPeriodeCallback !== undefined && (
-                <StyledButton
-                    type={'button'}
-                    variant={'tertiary'}
-                    onClick={() => fjernPeriodeCallback()}
-                    icon={<TrashFillIcon aria-hidden />}
-                >
-                    {<TekstBlock block={fjernKnappTekst} />}
-                </StyledButton>
-            )}
+        <FormSummary.Answer>
+            <FormSummary.Label>{tittel}</FormSummary.Label>
+            <FormSummary.Value>
+                <FormSummary.Answers>
+                    {children}
+                    {fjernPeriodeCallback !== undefined && (
+                        <Button
+                            type={'button'}
+                            variant={'tertiary'}
+                            onClick={() => fjernPeriodeCallback()}
+                            icon={<TrashFillIcon aria-hidden />}
+                        >
+                            {<TekstBlock block={fjernKnappTekst} />}
+                        </Button>
+                    )}
+                </FormSummary.Answers>
+            </FormSummary.Value>
             {vedleggNotis}
-        </PeriodeContainer>
+        </FormSummary.Answer>
     );
 }
 

--- a/src/frontend/components/Felleskomponenter/PerioderContainer.tsx
+++ b/src/frontend/components/Felleskomponenter/PerioderContainer.tsx
@@ -1,11 +1,22 @@
 import React, { ReactNode } from 'react';
 
-import { Box } from '@navikt/ds-react';
+import { Box, FormSummary } from '@navikt/ds-react';
 
-const PerioderContainer: React.FC<{ children?: ReactNode }> = ({ children }) => {
+interface IPerioderContainer {
+    // tittel: ReactNode;
+    children?: ReactNode;
+}
+
+const PerioderContainer: React.FC<IPerioderContainer> = ({
+    // tittel,
+    children,
+}) => {
     return (
-        <Box padding="4" marginBlock="2 0" background="surface-subtle" borderRadius="medium">
-            {children}
+        <Box marginBlock="4 0">
+            <FormSummary>
+                {/* <FormSummary.Header>{tittel}</FormSummary.Header> */}
+                <FormSummary.Answers>{children}</FormSummary.Answers>
+            </FormSummary>
         </Box>
     );
 };

--- a/src/frontend/components/Felleskomponenter/PerioderContainer.tsx
+++ b/src/frontend/components/Felleskomponenter/PerioderContainer.tsx
@@ -3,18 +3,15 @@ import React, { ReactNode } from 'react';
 import { Box, FormSummary } from '@navikt/ds-react';
 
 interface IPerioderContainer {
-    // tittel: ReactNode;
+    tittel: ReactNode;
     children?: ReactNode;
 }
 
-const PerioderContainer: React.FC<IPerioderContainer> = ({
-    // tittel,
-    children,
-}) => {
+const PerioderContainer: React.FC<IPerioderContainer> = ({ tittel, children }) => {
     return (
         <Box marginBlock="4 0">
             <FormSummary>
-                {/* <FormSummary.Header>{tittel}</FormSummary.Header> */}
+                <FormSummary.Header>{tittel}</FormSummary.Header>
                 <FormSummary.Answers>{children}</FormSummary.Answers>
             </FormSummary>
         </Box>

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/Utbetalingsperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/Utbetalingsperiode.tsx
@@ -7,6 +7,7 @@ import { useApp } from '../../../context/AppContext';
 import { IUtbetalingsperiode } from '../../../typer/perioder';
 import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { IEøsForBarnFeltTyper, IEøsForSøkerFeltTyper } from '../../../typer/skjema';
+import { uppercaseFørsteBokstav } from '../../../utils/visning';
 import JaNeiSpm from '../JaNeiSpm/JaNeiSpm';
 import { LeggTilKnapp } from '../LeggTilKnapp/LeggTilKnapp';
 import PerioderContainer from '../PerioderContainer';
@@ -46,6 +47,7 @@ export const Utbetalingsperiode: React.FC<Props> = ({
     } = useModal();
 
     const teksterForPersontype = tekster().FELLES.modaler.andreUtbetalinger[personType];
+    const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
 
     const barnetsNavn = barn && barn.navn;
 
@@ -59,7 +61,11 @@ export const Utbetalingsperiode: React.FC<Props> = ({
                 flettefelter={{ barnetsNavn: barnetsNavn }}
             />
             {tilhørendeJaNeiSpmFelt.verdi === ESvar.JA && (
-                <PerioderContainer>
+                <PerioderContainer
+                    tittel={uppercaseFørsteBokstav(
+                        plainTekst(frittståendeOrdTekster.utbetalingsperioder)
+                    )}
+                >
                     {registrerteUtbetalingsperioder.verdi.map((utbetalingsperiode, index) => (
                         <UtbetalingsperiodeOppsummering
                             key={`utbetalingsperiode-${index}`}
@@ -88,7 +94,6 @@ export const Utbetalingsperiode: React.FC<Props> = ({
                     >
                         <TekstBlock block={teksterForPersontype.leggTilKnapp} />
                     </LeggTilKnapp>
-
                     {utbetalingermodalErÅpen && (
                         <UtbetalingerModal
                             erÅpen={utbetalingermodalErÅpen}

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering.tsx
@@ -4,7 +4,6 @@ import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { Typografi } from '../../../typer/common';
 import { IUtbetalingsperiode } from '../../../typer/perioder';
 import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { IAndreUtbetalingerTekstinnhold } from '../../../typer/sanity/modaler/andreUtbetalinger';
@@ -51,7 +50,6 @@ export const UtbetalingsperiodeOppsummering: React.FC<UtbetalingsperiodeOppsumme
                 <TekstBlock
                     block={teksterForPersontype.oppsummeringstittel}
                     flettefelter={{ antall: nummer.toString() }}
-                    typografi={Typografi.HeadingH3}
                 />
             }
         >

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering.tsx
@@ -57,29 +57,41 @@ export const UtbetalingsperiodeOppsummering: React.FC<UtbetalingsperiodeOppsumme
         >
             {fårUtbetalingNå.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={teksterForPersontype.faarUtbetalingerNaa.sporsmal}
+                    tittel={
+                        <TekstBlock
+                            block={teksterForPersontype.faarUtbetalingerNaa.sporsmal}
+                            flettefelter={{ barnetsNavn: barn?.navn }}
+                        />
+                    }
                     søknadsvar={fårUtbetalingNå.svar}
-                    flettefelter={{ barnetsNavn: barn?.navn }}
                 />
             )}
             <OppsummeringFelt
-                spørsmålstekst={
-                    periodenErAvsluttet
-                        ? teksterForPersontype.utbetalingLandFortid.sporsmal
-                        : teksterForPersontype.utbetalingLandNaatid.sporsmal
+                tittel={
+                    <TekstBlock
+                        block={
+                            periodenErAvsluttet
+                                ? teksterForPersontype.utbetalingLandFortid.sporsmal
+                                : teksterForPersontype.utbetalingLandNaatid.sporsmal
+                        }
+                        flettefelter={{ barnetsNavn: barn?.navn }}
+                    />
                 }
-                flettefelter={{ barnetsNavn: barn?.navn }}
                 søknadsvar={landkodeTilSpråk(utbetalingLand.svar, valgtLocale)}
             />
             <OppsummeringFelt
-                spørsmålstekst={teksterForPersontype.startdato.sporsmal}
+                tittel={<TekstBlock block={teksterForPersontype.startdato.sporsmal} />}
                 søknadsvar={formaterDato(utbetalingFraDato.svar)}
             />
             <OppsummeringFelt
-                spørsmålstekst={
-                    periodenErAvsluttet
-                        ? teksterForPersontype.sluttdatoFortid.sporsmal
-                        : teksterForPersontype.sluttdatoFremtid.sporsmal
+                tittel={
+                    <TekstBlock
+                        block={
+                            periodenErAvsluttet
+                                ? teksterForPersontype.sluttdatoFortid.sporsmal
+                                : teksterForPersontype.sluttdatoFremtid.sporsmal
+                        }
+                    />
                 }
                 søknadsvar={formaterDatoMedUkjent(
                     utbetalingTilDato.svar,

--- a/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/Utenlandsperiode.tsx
+++ b/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/Utenlandsperiode.tsx
@@ -7,6 +7,7 @@ import { IUtenlandsperiode } from '../../../typer/perioder';
 import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { IDinLivssituasjonFeltTyper, IOmBarnetFeltTyper } from '../../../typer/skjema';
+import { uppercaseFørsteBokstav } from '../../../utils/visning';
 import { LeggTilKnapp } from '../LeggTilKnapp/LeggTilKnapp';
 import PerioderContainer from '../PerioderContainer';
 import useModal from '../SkjemaModal/useModal';
@@ -45,8 +46,12 @@ export const Utenlandsperiode: React.FC<Props> = ({
 
     const { flerePerioder, leggTilKnapp, leggTilPeriodeForklaring } = utenlandsopphold[personType];
 
+    const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
+
     return (
-        <PerioderContainer>
+        <PerioderContainer
+            tittel={uppercaseFørsteBokstav(plainTekst(frittståendeOrdTekster.utenlandsopphold))}
+        >
             {erUtenlandsoppholdModalÅpen && (
                 <UtenlandsoppholdModal
                     erÅpen={erUtenlandsoppholdModalÅpen}
@@ -67,7 +72,6 @@ export const Utenlandsperiode: React.FC<Props> = ({
                     barn={personType !== PersonType.søker ? barn : undefined}
                 />
             ))}
-
             <LeggTilKnapp
                 id={registrerteUtenlandsperioder.id}
                 onClick={åpneUtenlandsoppholdModal}

--- a/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/UtenlandsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/UtenlandsperiodeOppsummering.tsx
@@ -69,26 +69,34 @@ export const UtenlandsperiodeOppsummering: React.FC<UtenlandsperiodeOppsummering
                 fjernPeriodeCallback={fjernPeriodeCallback && (() => fjernPeriodeCallback(periode))}
             >
                 <OppsummeringFelt
-                    spørsmålstekst={teksterForPersonType.periodeBeskrivelse.sporsmal}
+                    tittel={<TekstBlock block={teksterForPersonType.periodeBeskrivelse.sporsmal} />}
                     søknadsvar={plainTekst(hentUtenlandsoppholdÅrsak(årsak, teksterForPersonType))}
                 />
 
                 <OppsummeringFelt
-                    spørsmålstekst={hentLandSpørsmål(årsak, teksterForPersonType)}
+                    tittel={
+                        <TekstBlock
+                            block={hentLandSpørsmål(årsak, teksterForPersonType)}
+                            flettefelter={{ barnetsNavn: barn?.navn }}
+                        />
+                    }
                     søknadsvar={landkodeTilSpråk(oppholdsland.svar, valgtLocale)}
-                    flettefelter={{ barnetsNavn: barn?.navn }}
                 />
 
                 {oppholdslandFraDato.svar && (
                     <OppsummeringFelt
-                        spørsmålstekst={hentFraDatoSpørsmål(årsak, teksterForPersonType)}
+                        tittel={
+                            <TekstBlock block={hentFraDatoSpørsmål(årsak, teksterForPersonType)} />
+                        }
                         søknadsvar={formaterDato(oppholdslandFraDato.svar)}
                     />
                 )}
 
                 {oppholdslandTilDato.svar && (
                     <OppsummeringFelt
-                        spørsmålstekst={hentTilDatoSpørsmål(årsak, teksterForPersonType)}
+                        tittel={
+                            <TekstBlock block={hentTilDatoSpørsmål(årsak, teksterForPersonType)} />
+                        }
                         søknadsvar={formaterDatoMedUkjent(
                             oppholdslandTilDato.svar,
                             plainTekst(teksterForPersonType.sluttdatoFremtid.checkboxLabel)
@@ -98,7 +106,7 @@ export const UtenlandsperiodeOppsummering: React.FC<UtenlandsperiodeOppsummering
 
                 {adresse.svar && (
                     <OppsummeringFelt
-                        spørsmålstekst={adresseTekst?.sporsmal}
+                        tittel={<TekstBlock block={adresseTekst?.sporsmal} />}
                         søknadsvar={
                             adresse.svar === AlternativtSvarForInput.UKJENT
                                 ? plainTekst(adresseTekst?.checkboxLabel)

--- a/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/UtenlandsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/UtenlandsoppholdModal/UtenlandsperiodeOppsummering.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useApp } from '../../../context/AppContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { AlternativtSvarForInput, Typografi } from '../../../typer/common';
+import { AlternativtSvarForInput } from '../../../typer/common';
 import { IUtenlandsperiode } from '../../../typer/perioder';
 import { PeriodePersonTypeMedBarnProps } from '../../../typer/personType';
 import { IUtenlandsoppholdTekstinnhold } from '../../../typer/sanity/modaler/utenlandsopphold';
@@ -63,7 +63,6 @@ export const UtenlandsperiodeOppsummering: React.FC<UtenlandsperiodeOppsummering
                     <TekstBlock
                         block={teksterForPersonType.oppsummeringstittel}
                         flettefelter={{ antall: nummer.toString() }}
-                        typografi={Typografi.HeadingH3}
                     />
                 }
                 fjernPeriodeCallback={fjernPeriodeCallback && (() => fjernPeriodeCallback(periode))}

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/EøsForBarn.tsx
@@ -97,11 +97,13 @@ const EøsForBarn: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
                 settSøknadsdataCallback: oppdaterSøknad,
             }}
         >
-            <SamletIdNummerForBarn
-                barn={barn}
-                settIdNummerFelter={settIdNummerFelterForBarn}
-                skjema={skjema}
-            />
+            <KomponentGruppe>
+                <SamletIdNummerForBarn
+                    barn={barn}
+                    settIdNummerFelter={settIdNummerFelterForBarn}
+                    skjema={skjema}
+                />
+            </KomponentGruppe>
 
             {skjema.felter.søkersSlektsforhold.erSynlig && (
                 <KomponentGruppe>

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Barn/SamletIdNummerForBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Barn/SamletIdNummerForBarn.tsx
@@ -1,7 +1,6 @@
 import React, { Dispatch, SetStateAction } from 'react';
 
 import { Alpha3Code } from 'i18n-iso-countries';
-import styled from 'styled-components';
 
 import { Felt, ISkjema } from '@navikt/familie-skjema';
 
@@ -45,10 +44,6 @@ const IdNummerForBarn: React.FC<{
     );
 };
 
-const SamleIdNummerContainer = styled.div<{ $lesevisning: boolean }>`
-    margin-bottom: ${props => (props.$lesevisning ? '2.5rem' : '4rem')};
-`;
-
 const SamletIdNummerForBarn: React.FC<{
     skjema: ISkjema<IEøsForBarnFeltTyper, string>;
     barn: IBarnMedISøknad;
@@ -70,7 +65,7 @@ const SamletIdNummerForBarn: React.FC<{
     );
 
     return skalSpørreOmIdNummerForPågåendeSøknad || idNummerSomMåOppgisFraPerioder.length ? (
-        <SamleIdNummerContainer $lesevisning={lesevisning}>
+        <>
             {idNummerSomMåOppgisFraPerioder.map((landMedPeriodeType, index) => {
                 return (
                     !!landMedPeriodeType.land && (
@@ -95,7 +90,7 @@ const SamletIdNummerForBarn: React.FC<{
                     barn={barn}
                 />
             )}
-        </SamleIdNummerContainer>
+        </>
     ) : null;
 };
 

--- a/src/frontend/components/SøknadsSteg/EøsSteg/IdNummer.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/IdNummer.tsx
@@ -1,7 +1,6 @@
 import React, { Dispatch, SetStateAction, useEffect } from 'react';
 
 import { Alpha3Code } from 'i18n-iso-countries';
-import styled from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 
 import { ESvar } from '@navikt/familie-form-elements';
@@ -20,10 +19,6 @@ import TekstBlock from '../../Felleskomponenter/TekstBlock';
 import { OppsummeringFelt } from '../Oppsummering/OppsummeringFelt';
 
 import { idNummerKeyPrefix, PeriodeType } from './idnummerUtils';
-
-export const IdNummerContainer = styled.div<{ $lesevisning: boolean }>`
-    margin-bottom: ${props => (props.$lesevisning ? '1rem' : '2rem')};
-`;
 
 export const IdNummer: React.FC<{
     skjema: ISkjema<IEøsForSøkerFeltTyper | IEøsForBarnFeltTyper, string>;
@@ -90,10 +85,15 @@ export const IdNummer: React.FC<{
     }, [idNummerFelt.verdi, idNummerFelt.valideringsstatus]);
 
     return (
-        <IdNummerContainer $lesevisning={lesevisning}>
+        <>
             {lesevisning ? (
                 <OppsummeringFelt
-                    spørsmålstekst={spørsmålDokument.sporsmal}
+                    tittel={
+                        <TekstBlock
+                            block={spørsmålDokument.sporsmal}
+                            flettefelter={{ land: landAlphaCode, barnetsNavn: barn?.navn }}
+                        />
+                    }
                     søknadsvar={
                         idNummerVerdiFraSøknad === AlternativtSvarForInput.UKJENT
                             ? plainTekst(spørsmålDokument.checkboxLabel, {
@@ -101,7 +101,6 @@ export const IdNummer: React.FC<{
                               })
                             : idNummerVerdiFraSøknad
                     }
-                    flettefelter={{ land: landAlphaCode, barnetsNavn: barn?.navn }}
                 />
             ) : (
                 <>
@@ -129,6 +128,6 @@ export const IdNummer: React.FC<{
                     )}
                 </>
             )}
-        </IdNummerContainer>
+        </>
     );
 };

--- a/src/frontend/components/SøknadsSteg/EøsSteg/Søker/EøsForSøker.tsx
+++ b/src/frontend/components/SøknadsSteg/EøsSteg/Søker/EøsForSøker.tsx
@@ -43,7 +43,10 @@ const EøsForSøker: React.FC = () => {
                 settSøknadsdataCallback: oppdaterSøknad,
             }}
         >
-            <IdNummerForSøker skjema={skjema} settIdNummerFelter={settIdNummerFelter} />
+            <KomponentGruppe>
+                <IdNummerForSøker skjema={skjema} settIdNummerFelter={settIdNummerFelter} />
+            </KomponentGruppe>
+
             {skjema.felter.adresseISøkeperiode.erSynlig && (
                 <KomponentGruppe>
                     <SkjemaFeltInput

--- a/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 
 import { useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
 
 import { BodyShort, VStack } from '@navikt/ds-react';
 
@@ -19,10 +18,6 @@ import OmBarnaOppsummering from './OppsummeringSteg/OmBarnaOppsummering';
 import OmBarnetOppsummering from './OppsummeringSteg/OmBarnet/OmBarnetOppsummering';
 import OmDegOppsummering from './OppsummeringSteg/OmDegOppsummering';
 import VelgBarnOppsummering from './OppsummeringSteg/VelgBarnOppsummering';
-
-const StyledBodyShort = styled(BodyShort)`
-    padding-bottom: 4rem;
-`;
 
 const Oppsummering: React.FC = () => {
     const { søknad, tekster, plainTekst } = useApp();
@@ -57,7 +52,7 @@ const Oppsummering: React.FC = () => {
             gåVidereCallback={gåVidereCallback}
         >
             <VStack gap="12">
-                <StyledBodyShort>{plainTekst(lesNoeye)}</StyledBodyShort>
+                <BodyShort>{plainTekst(lesNoeye)}</BodyShort>
 
                 <OmDegOppsummering settFeilAnchors={settFeilAnchors} />
                 <DinLivssituasjonOppsummering settFeilAnchors={settFeilAnchors} />

--- a/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { BodyShort } from '@navikt/ds-react';
+import { BodyShort, VStack } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
 import { useEøs } from '../../../context/EøsContext';
@@ -56,36 +56,38 @@ const Oppsummering: React.FC = () => {
             guide={<TekstBlock block={oppsummeringGuide} />}
             gåVidereCallback={gåVidereCallback}
         >
-            <StyledBodyShort>{plainTekst(lesNoeye)}</StyledBodyShort>
+            <VStack gap="12">
+                <StyledBodyShort>{plainTekst(lesNoeye)}</StyledBodyShort>
 
-            <OmDegOppsummering settFeilAnchors={settFeilAnchors} />
-            <DinLivssituasjonOppsummering settFeilAnchors={settFeilAnchors} />
-            <VelgBarnOppsummering settFeilAnchors={settFeilAnchors} />
-            <OmBarnaOppsummering settFeilAnchors={settFeilAnchors} />
+                <OmDegOppsummering settFeilAnchors={settFeilAnchors} />
+                <DinLivssituasjonOppsummering settFeilAnchors={settFeilAnchors} />
+                <VelgBarnOppsummering settFeilAnchors={settFeilAnchors} />
+                <OmBarnaOppsummering settFeilAnchors={settFeilAnchors} />
 
-            {søknad.barnInkludertISøknaden.map((barn, index) => {
-                return (
-                    <OmBarnetOppsummering
-                        key={`om-barnet-${index}`}
-                        barn={barn}
-                        settFeilAnchors={settFeilAnchors}
-                        index={index}
-                    />
-                );
-            })}
-
-            <>
-                {søkerHarEøsSteg && <EøsSøkerOppsummering settFeilAnchors={settFeilAnchors} />}
-                {barnSomHarEøsSteg.map((barn, index) => {
+                {søknad.barnInkludertISøknaden.map((barn, index) => {
                     return (
-                        <EøsBarnOppsummering
-                            key={`om-barnet-eøs-${index}`}
-                            settFeilAnchors={settFeilAnchors}
+                        <OmBarnetOppsummering
+                            key={`om-barnet-${index}`}
                             barn={barn}
+                            settFeilAnchors={settFeilAnchors}
+                            index={index}
                         />
                     );
                 })}
-            </>
+
+                <>
+                    {søkerHarEøsSteg && <EøsSøkerOppsummering settFeilAnchors={settFeilAnchors} />}
+                    {barnSomHarEøsSteg.map((barn, index) => {
+                        return (
+                            <EøsBarnOppsummering
+                                key={`om-barnet-eøs-${index}`}
+                                settFeilAnchors={settFeilAnchors}
+                                barn={barn}
+                            />
+                        );
+                    })}
+                </>
+            </VStack>
         </Steg>
     );
 };

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringFelt.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringFelt.tsx
@@ -3,35 +3,21 @@ import React, { ReactNode } from 'react';
 import { FormSummary } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
-import { LocaleRecordBlock, LocaleRecordString } from '../../../typer/common';
-import { FlettefeltVerdier } from '../../../typer/kontrakt/generelle';
 import { formaterSøknadsvar } from '../../../utils/språk';
 
 interface IOppsummeringsFeltProps {
-    /*
-    Tittel brukes istedenfor spørsmålstekst dersom man ønsker å vise tittel/spørsmål på en annen måte enn ved bruk av plainTekst, for eksempel ved å passere inn en <TekstBlock> komponent.
-    I oppgaven om Oppsummering iht Aksel (lenke) så skal OppsummeringsFelt endres, da vil også problemet med å ha to props (spørsmålstekst og tittel) løses slik at vil fungere likt som det nå er i BA.
-    */
     tittel?: ReactNode;
-    spørsmålstekst?: LocaleRecordBlock | LocaleRecordString;
     søknadsvar?: ReactNode | null;
-    flettefelter?: FlettefeltVerdier;
     children?: ReactNode;
 }
 
-export function OppsummeringFelt({
-    tittel,
-    søknadsvar,
-    spørsmålstekst,
-    flettefelter,
-    children,
-}: IOppsummeringsFeltProps) {
+export function OppsummeringFelt({ tittel, søknadsvar, children }: IOppsummeringsFeltProps) {
     const { plainTekst, tekster } = useApp();
 
     return (
         <FormSummary.Answer>
             <FormSummary.Label>
-                {tittel ? tittel : spørsmålstekst && plainTekst(spørsmålstekst, flettefelter)}
+                {tittel && <FormSummary.Label>{tittel}</FormSummary.Label>}
             </FormSummary.Label>
             <FormSummary.Value>
                 {søknadsvar

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringFelt.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringFelt.tsx
@@ -1,17 +1,11 @@
 import React, { ReactNode } from 'react';
 
-import styled from 'styled-components';
-
-import { BodyLong, Label } from '@navikt/ds-react';
+import { FormSummary } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
 import { LocaleRecordBlock, LocaleRecordString } from '../../../typer/common';
 import { FlettefeltVerdier } from '../../../typer/kontrakt/generelle';
 import { formaterSøknadsvar } from '../../../utils/språk';
-
-const StyledOppsummeringsFelt = styled.div`
-    margin-bottom: 1rem;
-`;
 
 interface IOppsummeringsFeltProps {
     /*
@@ -35,19 +29,15 @@ export function OppsummeringFelt({
     const { plainTekst, tekster } = useApp();
 
     return (
-        <StyledOppsummeringsFelt>
-            {tittel ? (
-                <Label>{tittel}</Label>
-            ) : (
-                spørsmålstekst && <Label>{plainTekst(spørsmålstekst, flettefelter)}</Label>
-            )}
-            {søknadsvar ? (
-                <BodyLong>
-                    {formaterSøknadsvar(søknadsvar, plainTekst, tekster().FELLES.frittståendeOrd)}
-                </BodyLong>
-            ) : (
-                children
-            )}
-        </StyledOppsummeringsFelt>
+        <FormSummary.Answer>
+            <FormSummary.Label>
+                {tittel ? tittel : spørsmålstekst && plainTekst(spørsmålstekst, flettefelter)}
+            </FormSummary.Label>
+            <FormSummary.Value>
+                {søknadsvar
+                    ? formaterSøknadsvar(søknadsvar, plainTekst, tekster().FELLES.frittståendeOrd)
+                    : children}
+            </FormSummary.Value>
+        </FormSummary.Answer>
     );
 }

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringFelt.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringFelt.tsx
@@ -19,11 +19,17 @@ export function OppsummeringFelt({ tittel, søknadsvar, children }: IOppsummerin
             <FormSummary.Label>
                 {tittel && <FormSummary.Label>{tittel}</FormSummary.Label>}
             </FormSummary.Label>
-            <FormSummary.Value>
-                {søknadsvar
-                    ? formaterSøknadsvar(søknadsvar, plainTekst, tekster().FELLES.frittståendeOrd)
-                    : children}
-            </FormSummary.Value>
+            {(søknadsvar || children) && (
+                <FormSummary.Value>
+                    {søknadsvar
+                        ? formaterSøknadsvar(
+                              søknadsvar,
+                              plainTekst,
+                              tekster().FELLES.frittståendeOrd
+                          )
+                        : children}
+                </FormSummary.Value>
+            )}
         </FormSummary.Answer>
     );
 }

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/DinLivssituasjonOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/DinLivssituasjonOppsummering.tsx
@@ -6,11 +6,11 @@ import { PersonType } from '../../../../typer/personType';
 import { RouteEnum } from '../../../../typer/routes';
 import { ArbeidsperiodeOppsummering } from '../../../Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering';
 import { PensjonsperiodeOppsummering } from '../../../Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering';
+import TekstBlock from '../../../Felleskomponenter/TekstBlock';
 import { UtenlandsperiodeOppsummering } from '../../../Felleskomponenter/UtenlandsoppholdModal/UtenlandsperiodeOppsummering';
 import { useDinLivssituasjon } from '../../DinLivssituasjon/useDinLivssituasjon';
 import { OppsummeringFelt } from '../OppsummeringFelt';
 import Oppsummeringsbolk from '../Oppsummeringsbolk';
-import { StyledOppsummeringsFeltGruppe } from '../OppsummeringsFeltGruppe';
 
 interface Props {
     settFeilAnchors: React.Dispatch<React.SetStateAction<string[]>>;
@@ -29,55 +29,57 @@ const DinLivssituasjonOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
             skjemaHook={dinLivsituasjonHook}
             settFeilAnchors={settFeilAnchors}
         >
-            <StyledOppsummeringsFeltGruppe>
-                <OppsummeringFelt
-                    spørsmålstekst={dinLivssituasjonTekster.asylsoeker.sporsmal}
-                    søknadsvar={søknad.søker.erAsylsøker.svar}
-                />
-                <OppsummeringFelt
-                    spørsmålstekst={dinLivssituasjonTekster.arbeidUtenforNorge.sporsmal}
-                    søknadsvar={søknad.søker.arbeidIUtlandet.svar}
-                />
+            <OppsummeringFelt
+                tittel={<TekstBlock block={dinLivssituasjonTekster.asylsoeker.sporsmal} />}
+                søknadsvar={søknad.søker.erAsylsøker.svar}
+            />
+            <OppsummeringFelt
+                tittel={<TekstBlock block={dinLivssituasjonTekster.arbeidUtenforNorge.sporsmal} />}
+                søknadsvar={søknad.søker.arbeidIUtlandet.svar}
+            />
 
-                {søknad.søker.arbeidsperioderUtland.map((periode, index) => (
-                    <ArbeidsperiodeOppsummering
-                        key={`arbeidsperiode-${index}`}
-                        nummer={index + 1}
-                        arbeidsperiode={periode}
-                        gjelderUtlandet={true}
-                        personType={PersonType.søker}
+            {søknad.søker.arbeidsperioderUtland.map((periode, index) => (
+                <ArbeidsperiodeOppsummering
+                    key={`arbeidsperiode-${index}`}
+                    nummer={index + 1}
+                    arbeidsperiode={periode}
+                    gjelderUtlandet={true}
+                    personType={PersonType.søker}
+                />
+            ))}
+
+            <OppsummeringFelt
+                tittel={
+                    <TekstBlock
+                        block={dinLivssituasjonTekster.utenlandsoppholdUtenArbeid.sporsmal}
                     />
-                ))}
+                }
+                søknadsvar={søknad.søker.utenlandsoppholdUtenArbeid.svar}
+            />
 
-                <OppsummeringFelt
-                    spørsmålstekst={dinLivssituasjonTekster.utenlandsoppholdUtenArbeid.sporsmal}
-                    søknadsvar={søknad.søker.utenlandsoppholdUtenArbeid.svar}
+            {søknad.søker.utenlandsperioder.map((periode, index) => (
+                <UtenlandsperiodeOppsummering
+                    key={index}
+                    periode={periode}
+                    nummer={index + 1}
+                    personType={PersonType.søker}
                 />
+            ))}
 
-                {søknad.søker.utenlandsperioder.map((periode, index) => (
-                    <UtenlandsperiodeOppsummering
-                        key={index}
-                        periode={periode}
-                        nummer={index + 1}
-                        personType={PersonType.søker}
-                    />
-                ))}
+            <OppsummeringFelt
+                tittel={<TekstBlock block={dinLivssituasjonTekster.pensjonUtland.sporsmal} />}
+                søknadsvar={søknad.søker.mottarUtenlandspensjon.svar}
+            />
 
-                <OppsummeringFelt
-                    spørsmålstekst={dinLivssituasjonTekster.pensjonUtland.sporsmal}
-                    søknadsvar={søknad.søker.mottarUtenlandspensjon.svar}
+            {søknad.søker.pensjonsperioderUtland.map((periode, index) => (
+                <PensjonsperiodeOppsummering
+                    key={`utenlandsperiode-${index}`}
+                    nummer={index + 1}
+                    pensjonsperiode={periode}
+                    gjelderUtlandet={true}
+                    personType={PersonType.søker}
                 />
-
-                {søknad.søker.pensjonsperioderUtland.map((periode, index) => (
-                    <PensjonsperiodeOppsummering
-                        key={`utenlandsperiode-${index}`}
-                        nummer={index + 1}
-                        pensjonsperiode={periode}
-                        gjelderUtlandet={true}
-                        personType={PersonType.søker}
-                    />
-                ))}
-            </StyledOppsummeringsFeltGruppe>
+            ))}
         </Oppsummeringsbolk>
     );
 };

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsAndreForelderOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsAndreForelderOppsummering.tsx
@@ -18,6 +18,7 @@ import { landkodeTilSpråk } from '../../../../../utils/språk';
 import { ArbeidsperiodeOppsummering } from '../../../../Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering';
 import { KontantstøttePeriodeOppsummering } from '../../../../Felleskomponenter/KontantstøttePeriode/KontantstøttePeriodeOppsummering';
 import { PensjonsperiodeOppsummering } from '../../../../Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering';
+import TekstBlock from '../../../../Felleskomponenter/TekstBlock';
 import { UtbetalingsperiodeOppsummering } from '../../../../Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering';
 import IdNummerForAndreForelder from '../../../EøsSteg/Barn/IdNummerForAndreForelder';
 import { OppsummeringFelt } from '../../OppsummeringFelt';
@@ -58,8 +59,7 @@ const EøsAndreForelderOppsummering: React.FC<{
     }) => {
         return barn.andreForelder && barn.andreForelder[andreForelderDataKeySpm].svar ? (
             <OppsummeringFelt
-                spørsmålstekst={spørsmålstekst}
-                flettefelter={flettefelter}
+                tittel={<TekstBlock block={spørsmålstekst} flettefelter={flettefelter} />}
                 søknadsvar={barn.andreForelder[andreForelderDataKeySpm].svar}
             />
         ) : null;
@@ -76,8 +76,12 @@ const EøsAndreForelderOppsummering: React.FC<{
             {andreForelder.adresse.svar && (
                 <StyledOppsummeringsFeltGruppe>
                     <OppsummeringFelt
-                        spørsmålstekst={hvorBorAndreForelder.sporsmal}
-                        flettefelter={flettefelter}
+                        tittel={
+                            <TekstBlock
+                                block={hvorBorAndreForelder.sporsmal}
+                                flettefelter={flettefelter}
+                            />
+                        }
                         søknadsvar={
                             andreForelder.adresse.svar === AlternativtSvarForInput.UKJENT
                                 ? plainTekst(hvorBorAndreForelder.checkboxLabel)
@@ -145,8 +149,12 @@ const EøsAndreForelderOppsummering: React.FC<{
                 })}
                 {andreForelder.pågåendeSøknadHvilketLand.svar && (
                     <OppsummeringFelt
-                        spørsmålstekst={hvilketLandSoektYtelseAndreForelder.sporsmal}
-                        flettefelter={flettefelter}
+                        tittel={
+                            <TekstBlock
+                                block={hvilketLandSoektYtelseAndreForelder.sporsmal}
+                                flettefelter={flettefelter}
+                            />
+                        }
                         søknadsvar={landkodeTilSpråk(
                             andreForelder.pågåendeSøknadHvilketLand.svar,
                             valgtLocale

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsAndreForelderOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsAndreForelderOppsummering.tsx
@@ -22,7 +22,6 @@ import TekstBlock from '../../../../Felleskomponenter/TekstBlock';
 import { UtbetalingsperiodeOppsummering } from '../../../../Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering';
 import IdNummerForAndreForelder from '../../../EøsSteg/Barn/IdNummerForAndreForelder';
 import { OppsummeringFelt } from '../../OppsummeringFelt';
-import { StyledOppsummeringsFeltGruppe } from '../../OppsummeringsFeltGruppe';
 
 const EøsAndreForelderOppsummering: React.FC<{
     barn: IBarnMedISøknad;
@@ -74,111 +73,107 @@ const EøsAndreForelderOppsummering: React.FC<{
                 lesevisning={true}
             />
             {andreForelder.adresse.svar && (
-                <StyledOppsummeringsFeltGruppe>
-                    <OppsummeringFelt
-                        tittel={
-                            <TekstBlock
-                                block={hvorBorAndreForelder.sporsmal}
-                                flettefelter={flettefelter}
-                            />
-                        }
-                        søknadsvar={
-                            andreForelder.adresse.svar === AlternativtSvarForInput.UKJENT
-                                ? plainTekst(hvorBorAndreForelder.checkboxLabel)
-                                : andreForelder.adresse.svar
-                        }
-                    />
-                </StyledOppsummeringsFeltGruppe>
+                <OppsummeringFelt
+                    tittel={
+                        <TekstBlock
+                            block={hvorBorAndreForelder.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
+                    søknadsvar={
+                        andreForelder.adresse.svar === AlternativtSvarForInput.UKJENT
+                            ? plainTekst(hvorBorAndreForelder.checkboxLabel)
+                            : andreForelder.adresse.svar
+                    }
+                />
             )}
-            <StyledOppsummeringsFeltGruppe>
-                {jaNeiSpmOppsummering({
-                    andreForelderDataKeySpm: andreForelderDataKeySpørsmål.arbeidNorge,
-                    spørsmålstekst: andreForelderErDød
-                        ? arbeidNorgeAndreForelderGjenlevende.sporsmal
-                        : arbeidNorgeAndreForelder.sporsmal,
-                })}
-                {andreForelder.arbeidsperioderNorge.map((arbeidsperiode, index) => (
-                    <ArbeidsperiodeOppsummering
-                        key={`arbeidsperiode-andre-forelder-norge-${index}`}
-                        arbeidsperiode={arbeidsperiode}
-                        nummer={index + 1}
-                        personType={PersonType.andreForelder}
-                        erDød={andreForelderErDød}
-                        gjelderUtlandet={false}
-                        barn={barn}
-                    />
-                ))}
-                {jaNeiSpmOppsummering({
-                    andreForelderDataKeySpm: andreForelderDataKeySpørsmål.pensjonNorge,
-                    spørsmålstekst: andreForelderErDød
-                        ? pensjonNorgeAndreForelderGjenlevende.sporsmal
-                        : pensjonNorgeAndreForelder.sporsmal,
-                })}
-                {andreForelder.pensjonsperioderNorge.map((pensjonsperiode, index) => (
-                    <PensjonsperiodeOppsummering
-                        key={`pensjonsperiode-andre-forelder-norge-${index}`}
-                        pensjonsperiode={pensjonsperiode}
-                        nummer={index + 1}
-                        personType={PersonType.andreForelder}
-                        erDød={andreForelderErDød}
-                        barn={barn}
-                        gjelderUtlandet={false}
-                    />
-                ))}
-                {jaNeiSpmOppsummering({
-                    andreForelderDataKeySpm: andreForelderDataKeySpørsmål.andreUtbetalinger,
-                    spørsmålstekst: andreForelderErDød
-                        ? utbetalingerAndreForelderGjenlevende.sporsmal
-                        : utbetalingerAndreForelder.sporsmal,
-                })}
-                {andreForelder.andreUtbetalingsperioder.map((utbetalingsperiode, index) => (
-                    <UtbetalingsperiodeOppsummering
-                        key={`utbetalingsperiode-andre-forelder-${index}`}
-                        utbetalingsperiode={utbetalingsperiode}
-                        nummer={index + 1}
-                        personType={PersonType.andreForelder}
-                        erDød={andreForelderErDød}
-                        barn={barn}
-                    />
-                ))}
 
-                {jaNeiSpmOppsummering({
-                    andreForelderDataKeySpm:
-                        andreForelderDataKeySpørsmål.pågåendeSøknadFraAnnetEøsLand,
-                    spørsmålstekst: paagaaendeSoeknadYtelseAndreForelder.sporsmal,
-                })}
-                {andreForelder.pågåendeSøknadHvilketLand.svar && (
-                    <OppsummeringFelt
-                        tittel={
-                            <TekstBlock
-                                block={hvilketLandSoektYtelseAndreForelder.sporsmal}
-                                flettefelter={flettefelter}
-                            />
-                        }
-                        søknadsvar={landkodeTilSpråk(
-                            andreForelder.pågåendeSøknadHvilketLand.svar,
-                            valgtLocale
-                        )}
-                    />
-                )}
+            {jaNeiSpmOppsummering({
+                andreForelderDataKeySpm: andreForelderDataKeySpørsmål.arbeidNorge,
+                spørsmålstekst: andreForelderErDød
+                    ? arbeidNorgeAndreForelderGjenlevende.sporsmal
+                    : arbeidNorgeAndreForelder.sporsmal,
+            })}
+            {andreForelder.arbeidsperioderNorge.map((arbeidsperiode, index) => (
+                <ArbeidsperiodeOppsummering
+                    key={`arbeidsperiode-andre-forelder-norge-${index}`}
+                    arbeidsperiode={arbeidsperiode}
+                    nummer={index + 1}
+                    personType={PersonType.andreForelder}
+                    erDød={andreForelderErDød}
+                    gjelderUtlandet={false}
+                    barn={barn}
+                />
+            ))}
+            {jaNeiSpmOppsummering({
+                andreForelderDataKeySpm: andreForelderDataKeySpørsmål.pensjonNorge,
+                spørsmålstekst: andreForelderErDød
+                    ? pensjonNorgeAndreForelderGjenlevende.sporsmal
+                    : pensjonNorgeAndreForelder.sporsmal,
+            })}
+            {andreForelder.pensjonsperioderNorge.map((pensjonsperiode, index) => (
+                <PensjonsperiodeOppsummering
+                    key={`pensjonsperiode-andre-forelder-norge-${index}`}
+                    pensjonsperiode={pensjonsperiode}
+                    nummer={index + 1}
+                    personType={PersonType.andreForelder}
+                    erDød={andreForelderErDød}
+                    barn={barn}
+                    gjelderUtlandet={false}
+                />
+            ))}
+            {jaNeiSpmOppsummering({
+                andreForelderDataKeySpm: andreForelderDataKeySpørsmål.andreUtbetalinger,
+                spørsmålstekst: andreForelderErDød
+                    ? utbetalingerAndreForelderGjenlevende.sporsmal
+                    : utbetalingerAndreForelder.sporsmal,
+            })}
+            {andreForelder.andreUtbetalingsperioder.map((utbetalingsperiode, index) => (
+                <UtbetalingsperiodeOppsummering
+                    key={`utbetalingsperiode-andre-forelder-${index}`}
+                    utbetalingsperiode={utbetalingsperiode}
+                    nummer={index + 1}
+                    personType={PersonType.andreForelder}
+                    erDød={andreForelderErDød}
+                    barn={barn}
+                />
+            ))}
 
-                {jaNeiSpmOppsummering({
-                    andreForelderDataKeySpm: andreForelderDataKeySpørsmål.kontantstøtteFraEøs,
-                    spørsmålstekst: andreForelderErDød
-                        ? ytelseFraAnnetLandAndreForelderGjenlevende.sporsmal
-                        : ytelseFraAnnetLandAndreForelder.sporsmal,
-                })}
-                {andreForelder.eøsKontantstøttePerioder.map((periode, index) => (
-                    <KontantstøttePeriodeOppsummering
-                        key={`kontantstøtte-periode-andre-forelder-${index}`}
-                        nummer={index + 1}
-                        kontantstøttePeriode={periode}
-                        barnetsNavn={barn.navn}
-                        personType={PersonType.andreForelder}
-                        erDød={andreForelderErDød}
-                    />
-                ))}
-            </StyledOppsummeringsFeltGruppe>
+            {jaNeiSpmOppsummering({
+                andreForelderDataKeySpm: andreForelderDataKeySpørsmål.pågåendeSøknadFraAnnetEøsLand,
+                spørsmålstekst: paagaaendeSoeknadYtelseAndreForelder.sporsmal,
+            })}
+            {andreForelder.pågåendeSøknadHvilketLand.svar && (
+                <OppsummeringFelt
+                    tittel={
+                        <TekstBlock
+                            block={hvilketLandSoektYtelseAndreForelder.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
+                    søknadsvar={landkodeTilSpråk(
+                        andreForelder.pågåendeSøknadHvilketLand.svar,
+                        valgtLocale
+                    )}
+                />
+            )}
+
+            {jaNeiSpmOppsummering({
+                andreForelderDataKeySpm: andreForelderDataKeySpørsmål.kontantstøtteFraEøs,
+                spørsmålstekst: andreForelderErDød
+                    ? ytelseFraAnnetLandAndreForelderGjenlevende.sporsmal
+                    : ytelseFraAnnetLandAndreForelder.sporsmal,
+            })}
+            {andreForelder.eøsKontantstøttePerioder.map((periode, index) => (
+                <KontantstøttePeriodeOppsummering
+                    key={`kontantstøtte-periode-andre-forelder-${index}`}
+                    nummer={index + 1}
+                    kontantstøttePeriode={periode}
+                    barnetsNavn={barn.navn}
+                    personType={PersonType.andreForelder}
+                    erDød={andreForelderErDød}
+                />
+            ))}
         </>
     );
 };

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsBarnOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsBarnOppsummering.tsx
@@ -5,6 +5,7 @@ import { useSteg } from '../../../../../context/StegContext';
 import { IBarnMedISøknad } from '../../../../../typer/barn';
 import { AlternativtSvarForInput } from '../../../../../typer/common';
 import { hentSlektsforhold } from '../../../../../utils/språk';
+import TekstBlock from '../../../../Felleskomponenter/TekstBlock';
 import SamletIdNummerForBarn from '../../../EøsSteg/Barn/SamletIdNummerForBarn';
 import { useEøsForBarn } from '../../../EøsSteg/Barn/useEøsForBarn';
 import { OppsummeringFelt } from '../../OppsummeringFelt';
@@ -45,16 +46,24 @@ const EøsBarnOppsummering: React.FC<Props> = ({ settFeilAnchors, barn }) => {
             {barn.søkersSlektsforhold.svar && (
                 <StyledOppsummeringsFeltGruppe>
                     <OppsummeringFelt
-                        spørsmålstekst={eøsBarnTekster.slektsforhold.sporsmal}
-                        flettefelter={flettefelter}
+                        tittel={
+                            <TekstBlock
+                                block={eøsBarnTekster.slektsforhold.sporsmal}
+                                flettefelter={flettefelter}
+                            />
+                        }
                         søknadsvar={plainTekst(
                             hentSlektsforhold(barn.søkersSlektsforhold.svar, eøsBarnTekster)
                         )}
                     />
                     {barn.søkersSlektsforholdSpesifisering.svar && (
                         <OppsummeringFelt
-                            spørsmålstekst={eøsBarnTekster.hvilkenRelasjon.sporsmal}
-                            flettefelter={flettefelter}
+                            tittel={
+                                <TekstBlock
+                                    block={eøsBarnTekster.hvilkenRelasjon.sporsmal}
+                                    flettefelter={flettefelter}
+                                />
+                            }
                             søknadsvar={barn.søkersSlektsforholdSpesifisering.svar}
                         />
                     )}
@@ -63,15 +72,23 @@ const EøsBarnOppsummering: React.FC<Props> = ({ settFeilAnchors, barn }) => {
 
             {barn.borMedAndreForelder.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.borMedAndreForelder.sporsmal}
-                    flettefelter={flettefelter}
+                    tittel={
+                        <TekstBlock
+                            block={eøsBarnTekster.borMedAndreForelder.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
                     søknadsvar={barn.borMedAndreForelder.svar}
                 />
             )}
             {barn.borMedOmsorgsperson.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.borMedOmsorgsperson.sporsmal}
-                    flettefelter={flettefelter}
+                    tittel={
+                        <TekstBlock
+                            block={eøsBarnTekster.borMedOmsorgsperson.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
                     søknadsvar={barn.borMedOmsorgsperson.svar}
                 />
             )}
@@ -82,8 +99,12 @@ const EøsBarnOppsummering: React.FC<Props> = ({ settFeilAnchors, barn }) => {
 
             {barn.adresse.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.hvorBorBarnet.sporsmal}
-                    flettefelter={flettefelter}
+                    tittel={
+                        <TekstBlock
+                            block={eøsBarnTekster.hvorBorBarnet.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
                     søknadsvar={
                         barn.adresse.svar === AlternativtSvarForInput.UKJENT
                             ? plainTekst(eøsBarnTekster.hvorBorBarnet.checkboxLabel)

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsBarnOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsBarnOppsummering.tsx
@@ -10,7 +10,6 @@ import SamletIdNummerForBarn from '../../../EøsSteg/Barn/SamletIdNummerForBarn'
 import { useEøsForBarn } from '../../../EøsSteg/Barn/useEøsForBarn';
 import { OppsummeringFelt } from '../../OppsummeringFelt';
 import Oppsummeringsbolk from '../../Oppsummeringsbolk';
-import { StyledOppsummeringsFeltGruppe } from '../../OppsummeringsFeltGruppe';
 
 import EøsAndreForelderOppsummering from './EøsAndreForelderOppsummering';
 import EøsOmsorgspersonOppsummering from './EøsOmsorgspersonOppsummering';
@@ -44,7 +43,7 @@ const EøsBarnOppsummering: React.FC<Props> = ({ settFeilAnchors, barn }) => {
                 lesevisning={true}
             />
             {barn.søkersSlektsforhold.svar && (
-                <StyledOppsummeringsFeltGruppe>
+                <>
                     <OppsummeringFelt
                         tittel={
                             <TekstBlock
@@ -67,7 +66,7 @@ const EøsBarnOppsummering: React.FC<Props> = ({ settFeilAnchors, barn }) => {
                             søknadsvar={barn.søkersSlektsforholdSpesifisering.svar}
                         />
                     )}
-                </StyledOppsummeringsFeltGruppe>
+                </>
             )}
 
             {barn.borMedAndreForelder.svar && (

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsOmsorgspersonOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsOmsorgspersonOppsummering.tsx
@@ -13,7 +13,6 @@ import { PensjonsperiodeOppsummering } from '../../../../Felleskomponenter/Pensj
 import TekstBlock from '../../../../Felleskomponenter/TekstBlock';
 import { UtbetalingsperiodeOppsummering } from '../../../../Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering';
 import { OppsummeringFelt } from '../../OppsummeringFelt';
-import { StyledOppsummeringsFeltGruppe } from '../../OppsummeringsFeltGruppe';
 
 const EøsOmsorgspersonOppsummering: React.FC<{
     omsorgsperson: IOmsorgsperson;
@@ -26,7 +25,7 @@ const EøsOmsorgspersonOppsummering: React.FC<{
 
     const flettefelter = { barnetsNavn: barn.navn };
     return (
-        <StyledOppsummeringsFeltGruppe>
+        <>
             {omsorgsperson.navn.svar && (
                 <OppsummeringFelt
                     tittel={<TekstBlock block={eøsBarnTekster.hvaHeterOmsorgspersonen.sporsmal} />}
@@ -187,7 +186,7 @@ const EøsOmsorgspersonOppsummering: React.FC<{
                 />
             ))}
             {omsorgsperson.pågåendeSøknadFraAnnetEøsLand.svar && (
-                <StyledOppsummeringsFeltGruppe>
+                <>
                     <OppsummeringFelt
                         tittel={
                             <TekstBlock
@@ -213,7 +212,7 @@ const EøsOmsorgspersonOppsummering: React.FC<{
                             )}
                         />
                     )}
-                </StyledOppsummeringsFeltGruppe>
+                </>
             )}
             {omsorgsperson.kontantstøtteFraEøs.svar && (
                 <OppsummeringFelt
@@ -235,7 +234,7 @@ const EøsOmsorgspersonOppsummering: React.FC<{
                     personType={PersonType.omsorgsperson}
                 />
             ))}
-        </StyledOppsummeringsFeltGruppe>
+        </>
     );
 };
 

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsOmsorgspersonOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsOmsorgspersonOppsummering.tsx
@@ -10,6 +10,7 @@ import { hentSlektsforhold, landkodeTilSpråk } from '../../../../../utils/språ
 import { ArbeidsperiodeOppsummering } from '../../../../Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering';
 import { KontantstøttePeriodeOppsummering } from '../../../../Felleskomponenter/KontantstøttePeriode/KontantstøttePeriodeOppsummering';
 import { PensjonsperiodeOppsummering } from '../../../../Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering';
+import TekstBlock from '../../../../Felleskomponenter/TekstBlock';
 import { UtbetalingsperiodeOppsummering } from '../../../../Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering';
 import { OppsummeringFelt } from '../../OppsummeringFelt';
 import { StyledOppsummeringsFeltGruppe } from '../../OppsummeringsFeltGruppe';
@@ -28,15 +29,19 @@ const EøsOmsorgspersonOppsummering: React.FC<{
         <StyledOppsummeringsFeltGruppe>
             {omsorgsperson.navn.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.hvaHeterOmsorgspersonen.sporsmal}
+                    tittel={<TekstBlock block={eøsBarnTekster.hvaHeterOmsorgspersonen.sporsmal} />}
                     søknadsvar={omsorgsperson.navn.svar}
                 />
             )}
 
             {omsorgsperson.slektsforhold.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.slektsforhold.sporsmal}
-                    flettefelter={flettefelter}
+                    tittel={
+                        <TekstBlock
+                            block={eøsBarnTekster.slektsforhold.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
                     søknadsvar={plainTekst(
                         hentSlektsforhold(omsorgsperson.slektsforhold.svar, eøsBarnTekster)
                     )}
@@ -45,15 +50,19 @@ const EøsOmsorgspersonOppsummering: React.FC<{
 
             {omsorgsperson.slektsforholdSpesifisering.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.hvilkenRelasjonOmsorgsperson.sporsmal}
-                    flettefelter={flettefelter}
+                    tittel={
+                        <TekstBlock
+                            block={eøsBarnTekster.hvilkenRelasjonOmsorgsperson.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
                     søknadsvar={omsorgsperson.slektsforholdSpesifisering.svar}
                 />
             )}
 
             {omsorgsperson.idNummer.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.idNummerOmsorgsperson.sporsmal}
+                    tittel={<TekstBlock block={eøsBarnTekster.idNummerOmsorgsperson.sporsmal} />}
                     søknadsvar={
                         omsorgsperson.idNummer.svar === AlternativtSvarForInput.UKJENT
                             ? plainTekst(eøsBarnTekster.idNummerOmsorgsperson.checkboxLabel)
@@ -64,7 +73,7 @@ const EøsOmsorgspersonOppsummering: React.FC<{
 
             {omsorgsperson.adresse.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.hvorBorOmsorgsperson.sporsmal}
+                    tittel={<TekstBlock block={eøsBarnTekster.hvorBorOmsorgsperson.sporsmal} />}
                     søknadsvar={
                         omsorgsperson.adresse.svar === AlternativtSvarForInput.UKJENT
                             ? plainTekst(eøsBarnTekster.hvorBorOmsorgsperson.checkboxLabel)
@@ -75,8 +84,12 @@ const EøsOmsorgspersonOppsummering: React.FC<{
 
             {omsorgsperson.arbeidUtland.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.arbeidUtenforNorgeOmsorgsperson.sporsmal}
-                    flettefelter={flettefelter}
+                    tittel={
+                        <TekstBlock
+                            block={eøsBarnTekster.arbeidUtenforNorgeOmsorgsperson.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
                     søknadsvar={omsorgsperson.arbeidUtland.svar}
                 />
             )}
@@ -92,8 +105,12 @@ const EøsOmsorgspersonOppsummering: React.FC<{
             ))}
             {omsorgsperson.arbeidNorge.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.arbeidNorgeOmsorgsperson.sporsmal}
-                    flettefelter={flettefelter}
+                    tittel={
+                        <TekstBlock
+                            block={eøsBarnTekster.arbeidNorgeOmsorgsperson.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
                     søknadsvar={omsorgsperson.arbeidNorge.svar}
                 />
             )}
@@ -109,8 +126,12 @@ const EøsOmsorgspersonOppsummering: React.FC<{
             ))}
             {omsorgsperson.pensjonUtland.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.pensjonUtlandOmsorgsperson.sporsmal}
-                    flettefelter={flettefelter}
+                    tittel={
+                        <TekstBlock
+                            block={eøsBarnTekster.pensjonUtlandOmsorgsperson.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
                     søknadsvar={omsorgsperson.pensjonUtland.svar}
                 />
             )}
@@ -126,8 +147,12 @@ const EøsOmsorgspersonOppsummering: React.FC<{
             ))}
             {omsorgsperson.pensjonNorge.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.pensjonNorgeOmsorgsperson.sporsmal}
-                    flettefelter={flettefelter}
+                    tittel={
+                        <TekstBlock
+                            block={eøsBarnTekster.pensjonNorgeOmsorgsperson.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
                     søknadsvar={omsorgsperson.pensjonNorge.svar}
                 />
             )}
@@ -143,8 +168,12 @@ const EøsOmsorgspersonOppsummering: React.FC<{
             ))}
             {omsorgsperson.andreUtbetalinger.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.utbetalingerOmsorgsperson.sporsmal}
-                    flettefelter={flettefelter}
+                    tittel={
+                        <TekstBlock
+                            block={eøsBarnTekster.utbetalingerOmsorgsperson.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
                     søknadsvar={omsorgsperson.andreUtbetalinger.svar}
                 />
             )}
@@ -160,18 +189,24 @@ const EøsOmsorgspersonOppsummering: React.FC<{
             {omsorgsperson.pågåendeSøknadFraAnnetEøsLand.svar && (
                 <StyledOppsummeringsFeltGruppe>
                     <OppsummeringFelt
-                        spørsmålstekst={
-                            eøsBarnTekster.paagaaendeSoeknadYtelseOmsorgsperson.sporsmal
+                        tittel={
+                            <TekstBlock
+                                block={eøsBarnTekster.paagaaendeSoeknadYtelseOmsorgsperson.sporsmal}
+                                flettefelter={flettefelter}
+                            />
                         }
-                        flettefelter={flettefelter}
                         søknadsvar={omsorgsperson.pågåendeSøknadFraAnnetEøsLand.svar}
                     />
                     {omsorgsperson.pågåendeSøknadHvilketLand.svar && (
                         <OppsummeringFelt
-                            spørsmålstekst={
-                                eøsBarnTekster.hvilketLandSoektYtelseOmsorgsperson.sporsmal
+                            tittel={
+                                <TekstBlock
+                                    block={
+                                        eøsBarnTekster.hvilketLandSoektYtelseOmsorgsperson.sporsmal
+                                    }
+                                    flettefelter={flettefelter}
+                                />
                             }
-                            flettefelter={flettefelter}
                             søknadsvar={landkodeTilSpråk(
                                 omsorgsperson.pågåendeSøknadHvilketLand.svar,
                                 valgtLocale
@@ -182,8 +217,12 @@ const EøsOmsorgspersonOppsummering: React.FC<{
             )}
             {omsorgsperson.kontantstøtteFraEøs.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={eøsBarnTekster.ytelseFraAnnetLandOmsorgsperson.sporsmal}
-                    flettefelter={flettefelter}
+                    tittel={
+                        <TekstBlock
+                            block={eøsBarnTekster.ytelseFraAnnetLandOmsorgsperson.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
                     søknadsvar={omsorgsperson.kontantstøtteFraEøs.svar}
                 />
             )}

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsSøkerOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsSøkerOppsummering.tsx
@@ -16,7 +16,6 @@ import IdNummerForSøker from '../../../EøsSteg/Søker/IdNummerForSøker';
 import { useEøsForSøker } from '../../../EøsSteg/Søker/useEøsForSøker';
 import { OppsummeringFelt } from '../../OppsummeringFelt';
 import Oppsummeringsbolk from '../../Oppsummeringsbolk';
-import { StyledOppsummeringsFeltGruppe } from '../../OppsummeringsFeltGruppe';
 
 interface Props {
     settFeilAnchors: React.Dispatch<React.SetStateAction<string[]>>;
@@ -50,55 +49,51 @@ const EøsSøkerOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
                 lesevisning={true}
             />
             {søker.adresseISøkeperiode.svar && (
-                <StyledOppsummeringsFeltGruppe>
-                    <OppsummeringFelt
-                        tittel={<TekstBlock block={eøsSøkerTekster.hvorBor.sporsmal} />}
-                        søknadsvar={søker.adresseISøkeperiode.svar}
-                    />
-                </StyledOppsummeringsFeltGruppe>
+                <OppsummeringFelt
+                    tittel={<TekstBlock block={eøsSøkerTekster.hvorBor.sporsmal} />}
+                    søknadsvar={søker.adresseISøkeperiode.svar}
+                />
             )}
-            <StyledOppsummeringsFeltGruppe>
-                {jaNeiSpmOppsummering({
-                    spørsmålstekst: eøsSøkerTekster.arbeidNorge.sporsmal,
-                    søknadSvar: søker.arbeidINorge,
-                })}
-                {søker.arbeidsperioderNorge.map((arbeidsperiode, index) => (
-                    <ArbeidsperiodeOppsummering
-                        key={`arbeidsperiode-søker-norge-${index}`}
-                        arbeidsperiode={arbeidsperiode}
-                        nummer={index + 1}
-                        personType={PersonType.søker}
-                        gjelderUtlandet={false}
-                    />
-                ))}
+            {jaNeiSpmOppsummering({
+                spørsmålstekst: eøsSøkerTekster.arbeidNorge.sporsmal,
+                søknadSvar: søker.arbeidINorge,
+            })}
+            {søker.arbeidsperioderNorge.map((arbeidsperiode, index) => (
+                <ArbeidsperiodeOppsummering
+                    key={`arbeidsperiode-søker-norge-${index}`}
+                    arbeidsperiode={arbeidsperiode}
+                    nummer={index + 1}
+                    personType={PersonType.søker}
+                    gjelderUtlandet={false}
+                />
+            ))}
 
-                {jaNeiSpmOppsummering({
-                    spørsmålstekst: eøsSøkerTekster.pensjonNorge.sporsmal,
-                    søknadSvar: søker.pensjonNorge,
-                })}
-                {søker.pensjonsperioderNorge.map((pensjonsperiode, index) => (
-                    <PensjonsperiodeOppsummering
-                        key={`pensjonsperiode-søker-norge-${index}`}
-                        pensjonsperiode={pensjonsperiode}
-                        nummer={index + 1}
-                        gjelderUtlandet={false}
-                        personType={PersonType.søker}
-                    />
-                ))}
+            {jaNeiSpmOppsummering({
+                spørsmålstekst: eøsSøkerTekster.pensjonNorge.sporsmal,
+                søknadSvar: søker.pensjonNorge,
+            })}
+            {søker.pensjonsperioderNorge.map((pensjonsperiode, index) => (
+                <PensjonsperiodeOppsummering
+                    key={`pensjonsperiode-søker-norge-${index}`}
+                    pensjonsperiode={pensjonsperiode}
+                    nummer={index + 1}
+                    gjelderUtlandet={false}
+                    personType={PersonType.søker}
+                />
+            ))}
 
-                {jaNeiSpmOppsummering({
-                    spørsmålstekst: eøsSøkerTekster.utbetalinger.sporsmal,
-                    søknadSvar: søker.andreUtbetalinger,
-                })}
-                {søker.andreUtbetalingsperioder.map((utbetalingsperiode, index) => (
-                    <UtbetalingsperiodeOppsummering
-                        key={`utbetalingsperiode-søker-norge-${index}`}
-                        utbetalingsperiode={utbetalingsperiode}
-                        nummer={index + 1}
-                        personType={PersonType.søker}
-                    />
-                ))}
-            </StyledOppsummeringsFeltGruppe>
+            {jaNeiSpmOppsummering({
+                spørsmålstekst: eøsSøkerTekster.utbetalinger.sporsmal,
+                søknadSvar: søker.andreUtbetalinger,
+            })}
+            {søker.andreUtbetalingsperioder.map((utbetalingsperiode, index) => (
+                <UtbetalingsperiodeOppsummering
+                    key={`utbetalingsperiode-søker-norge-${index}`}
+                    utbetalingsperiode={utbetalingsperiode}
+                    nummer={index + 1}
+                    personType={PersonType.søker}
+                />
+            ))}
         </Oppsummeringsbolk>
     );
 };

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsSøkerOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsSøkerOppsummering.tsx
@@ -10,6 +10,7 @@ import { RouteEnum } from '../../../../../typer/routes';
 import { ISøknadSpørsmål } from '../../../../../typer/spørsmål';
 import { ArbeidsperiodeOppsummering } from '../../../../Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering';
 import { PensjonsperiodeOppsummering } from '../../../../Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering';
+import TekstBlock from '../../../../Felleskomponenter/TekstBlock';
 import { UtbetalingsperiodeOppsummering } from '../../../../Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering';
 import IdNummerForSøker from '../../../EøsSteg/Søker/IdNummerForSøker';
 import { useEøsForSøker } from '../../../EøsSteg/Søker/useEøsForSøker';
@@ -23,7 +24,7 @@ interface Props {
 
 const EøsSøkerOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
     const { hentRouteObjektForRouteEnum } = useRoutes();
-    const { søknad, tekster } = useApp();
+    const { søknad, tekster, plainTekst } = useApp();
     const eøsSøkerTekster = tekster().EØS_FOR_SØKER;
     const { søker } = søknad;
     const eøsForSøkerHook = useEøsForSøker();
@@ -34,7 +35,7 @@ const EøsSøkerOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
     }: {
         spørsmålstekst: LocaleRecordBlock | LocaleRecordString;
         søknadSvar: ISøknadSpørsmål<ESvar | null>;
-    }) => <OppsummeringFelt spørsmålstekst={spørsmålstekst} søknadsvar={søknadSvar.svar} />;
+    }) => <OppsummeringFelt tittel={plainTekst(spørsmålstekst)} søknadsvar={søknadSvar.svar} />;
 
     return (
         <Oppsummeringsbolk
@@ -51,7 +52,7 @@ const EøsSøkerOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
             {søker.adresseISøkeperiode.svar && (
                 <StyledOppsummeringsFeltGruppe>
                     <OppsummeringFelt
-                        spørsmålstekst={eøsSøkerTekster.hvorBor.sporsmal}
+                        tittel={<TekstBlock block={eøsSøkerTekster.hvorBor.sporsmal} />}
                         søknadsvar={søker.adresseISøkeperiode.svar}
                     />
                 </StyledOppsummeringsFeltGruppe>

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnaOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnaOppsummering.tsx
@@ -11,7 +11,6 @@ import { OmBarnaDineSpørsmålId } from '../../OmBarnaDine/spørsmål';
 import { useOmBarnaDine } from '../../OmBarnaDine/useOmBarnaDine';
 import { OppsummeringFelt } from '../OppsummeringFelt';
 import Oppsummeringsbolk from '../Oppsummeringsbolk';
-import { StyledOppsummeringsFeltGruppe } from '../OppsummeringsFeltGruppe';
 
 interface Props {
     settFeilAnchors: React.Dispatch<React.SetStateAction<string[]>>;
@@ -36,112 +35,87 @@ const OmBarnaOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
             skjemaHook={omBarnaDineHook}
             settFeilAnchors={settFeilAnchors}
         >
-            <StyledOppsummeringsFeltGruppe>
+            <OppsummeringFelt
+                tittel={<TekstBlock block={omBarnaTekster.fosterbarn.sporsmal} />}
+                søknadsvar={søknad.erNoenAvBarnaFosterbarn.svar}
+            />
+            {søknad.erNoenAvBarnaFosterbarn.svar === ESvar.JA && (
                 <OppsummeringFelt
-                    tittel={<TekstBlock block={omBarnaTekster.fosterbarn.sporsmal} />}
-                    søknadsvar={søknad.erNoenAvBarnaFosterbarn.svar}
+                    tittel={<TekstBlock block={omBarnaTekster.hvemFosterbarn.sporsmal} />}
+                    søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.erFosterbarn)}
                 />
-                {søknad.erNoenAvBarnaFosterbarn.svar === ESvar.JA && (
-                    <OppsummeringFelt
-                        tittel={<TekstBlock block={omBarnaTekster.hvemFosterbarn.sporsmal} />}
-                        søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.erFosterbarn)}
-                    />
-                )}
-            </StyledOppsummeringsFeltGruppe>
-            <StyledOppsummeringsFeltGruppe>
+            )}
+            <OppsummeringFelt
+                tittel={<TekstBlock block={omBarnaTekster.institusjonKontantstoette.sporsmal} />}
+                søknadsvar={søknad.oppholderBarnSegIInstitusjon.svar}
+            />
+
+            {søknad.oppholderBarnSegIInstitusjon.svar === ESvar.JA && (
+                <OppsummeringFelt
+                    tittel={<TekstBlock block={omBarnaTekster.hvemInstitusjon.sporsmal} />}
+                    søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.oppholderSegIInstitusjon)}
+                />
+            )}
+            <OppsummeringFelt
+                tittel={<TekstBlock block={omBarnaTekster.adoptertKontantstoette.sporsmal} />}
+                søknadsvar={søknad.erBarnAdoptert.svar}
+            />
+            {søknad.erBarnAdoptert.svar === ESvar.JA && (
                 <OppsummeringFelt
                     tittel={
-                        <TekstBlock block={omBarnaTekster.institusjonKontantstoette.sporsmal} />
+                        <TekstBlock block={omBarnaTekster.hvemAdoptertKontantstoette.sporsmal} />
                     }
-                    søknadsvar={søknad.oppholderBarnSegIInstitusjon.svar}
+                    søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.erAdoptert)}
                 />
+            )}
+            <OppsummeringFelt
+                tittel={<TekstBlock block={omBarnaTekster.asyl.sporsmal} />}
+                søknadsvar={søknad.søktAsylForBarn.svar}
+            />
+            {søknad.søktAsylForBarn.svar === ESvar.JA && (
+                <OppsummeringFelt
+                    tittel={<TekstBlock block={omBarnaTekster.hvemAsyl.sporsmal} />}
+                    søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.erAsylsøker)}
+                />
+            )}
+            <OppsummeringFelt
+                tittel={<TekstBlock block={omBarnaTekster.sammenhengendeOppholdINorge.sporsmal} />}
+                søknadsvar={søknad.barnOppholdtSegTolvMndSammenhengendeINorge.svar}
+            />
 
-                {søknad.oppholderBarnSegIInstitusjon.svar === ESvar.JA && (
-                    <OppsummeringFelt
-                        tittel={<TekstBlock block={omBarnaTekster.hvemInstitusjon.sporsmal} />}
-                        søknadsvar={genererListeMedBarn(
-                            barnDataKeySpørsmål.oppholderSegIInstitusjon
-                        )}
-                    />
-                )}
-            </StyledOppsummeringsFeltGruppe>
-            <StyledOppsummeringsFeltGruppe>
+            {søknad.barnOppholdtSegTolvMndSammenhengendeINorge.svar === ESvar.NEI && (
                 <OppsummeringFelt
-                    tittel={<TekstBlock block={omBarnaTekster.adoptertKontantstoette.sporsmal} />}
-                    søknadsvar={søknad.erBarnAdoptert.svar}
+                    tittel={<TekstBlock block={omBarnaTekster.hvemOppholdUtenforNorge.sporsmal} />}
+                    søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.boddMindreEnn12MndINorge)}
                 />
-                {søknad.erBarnAdoptert.svar === ESvar.JA && (
-                    <OppsummeringFelt
-                        tittel={
-                            <TekstBlock
-                                block={omBarnaTekster.hvemAdoptertKontantstoette.sporsmal}
-                            />
-                        }
-                        søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.erAdoptert)}
-                    />
-                )}
-            </StyledOppsummeringsFeltGruppe>
-            <StyledOppsummeringsFeltGruppe>
-                <OppsummeringFelt
-                    tittel={<TekstBlock block={omBarnaTekster.asyl.sporsmal} />}
-                    søknadsvar={søknad.søktAsylForBarn.svar}
-                />
-                {søknad.søktAsylForBarn.svar === ESvar.JA && (
-                    <OppsummeringFelt
-                        tittel={<TekstBlock block={omBarnaTekster.hvemAsyl.sporsmal} />}
-                        søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.erAsylsøker)}
-                    />
-                )}
-            </StyledOppsummeringsFeltGruppe>
-            <StyledOppsummeringsFeltGruppe>
-                <OppsummeringFelt
-                    tittel={
-                        <TekstBlock block={omBarnaTekster.sammenhengendeOppholdINorge.sporsmal} />
-                    }
-                    søknadsvar={søknad.barnOppholdtSegTolvMndSammenhengendeINorge.svar}
-                />
+            )}
+            <OppsummeringFelt
+                tittel={<TekstBlock block={omBarnaTekster.soektYtelseEuEoes.sporsmal} />}
+                søknadsvar={søknad.mottarKontantstøtteForBarnFraAnnetEøsland.svar}
+            />
 
-                {søknad.barnOppholdtSegTolvMndSammenhengendeINorge.svar === ESvar.NEI && (
-                    <OppsummeringFelt
-                        tittel={
-                            <TekstBlock block={omBarnaTekster.hvemOppholdUtenforNorge.sporsmal} />
-                        }
-                        søknadsvar={genererListeMedBarn(
-                            barnDataKeySpørsmål.boddMindreEnn12MndINorge
-                        )}
-                    />
-                )}
-            </StyledOppsummeringsFeltGruppe>
-            <StyledOppsummeringsFeltGruppe>
+            {søknad.mottarKontantstøtteForBarnFraAnnetEøsland.svar === ESvar.JA && (
                 <OppsummeringFelt
-                    tittel={<TekstBlock block={omBarnaTekster.soektYtelseEuEoes.sporsmal} />}
-                    søknadsvar={søknad.mottarKontantstøtteForBarnFraAnnetEøsland.svar}
+                    tittel={<TekstBlock block={omBarnaTekster.hvemSoektYtelse.sporsmal} />}
+                    søknadsvar={genererListeMedBarn(
+                        barnDataKeySpørsmål.kontantstøtteFraAnnetEøsland
+                    )}
                 />
+            )}
 
-                {søknad.mottarKontantstøtteForBarnFraAnnetEøsland.svar === ESvar.JA && (
-                    <OppsummeringFelt
-                        tittel={<TekstBlock block={omBarnaTekster.hvemSoektYtelse.sporsmal} />}
-                        søknadsvar={genererListeMedBarn(
-                            barnDataKeySpørsmål.kontantstøtteFraAnnetEøsland
-                        )}
-                    />
-                )}
-            </StyledOppsummeringsFeltGruppe>
-            <StyledOppsummeringsFeltGruppe>
+            <OppsummeringFelt
+                tittel={<TekstBlock block={omBarnaTekster.barnehageplass.sporsmal} />}
+                søknadsvar={søknad.harEllerTildeltBarnehageplass.svar}
+            />
+
+            {søknad.harEllerTildeltBarnehageplass.svar === ESvar.JA && (
                 <OppsummeringFelt
-                    tittel={<TekstBlock block={omBarnaTekster.barnehageplass.sporsmal} />}
-                    søknadsvar={søknad.harEllerTildeltBarnehageplass.svar}
+                    tittel={<TekstBlock block={omBarnaTekster.hvemBarnehageplass.sporsmal} />}
+                    søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.harBarnehageplass)}
                 />
-
-                {søknad.harEllerTildeltBarnehageplass.svar === ESvar.JA && (
-                    <OppsummeringFelt
-                        tittel={<TekstBlock block={omBarnaTekster.hvemBarnehageplass.sporsmal} />}
-                        søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.harBarnehageplass)}
-                    />
-                )}
-            </StyledOppsummeringsFeltGruppe>
+            )}
             {søknad.erAvdødPartnerForelder.svar && (
-                <StyledOppsummeringsFeltGruppe>
+                <>
                     <OppsummeringFelt
                         tittel={
                             <TekstBlock
@@ -171,7 +145,7 @@ const OmBarnaOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
                             søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.andreForelderErDød)}
                         />
                     )}
-                </StyledOppsummeringsFeltGruppe>
+                </>
             )}
         </Oppsummeringsbolk>
     );

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnaOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnaOppsummering.tsx
@@ -6,6 +6,7 @@ import { useApp } from '../../../../context/AppContext';
 import { useRoutes } from '../../../../context/RoutesContext';
 import { barnDataKeySpørsmål } from '../../../../typer/barn';
 import { RouteEnum } from '../../../../typer/routes';
+import TekstBlock from '../../../Felleskomponenter/TekstBlock';
 import { OmBarnaDineSpørsmålId } from '../../OmBarnaDine/spørsmål';
 import { useOmBarnaDine } from '../../OmBarnaDine/useOmBarnaDine';
 import { OppsummeringFelt } from '../OppsummeringFelt';
@@ -37,25 +38,27 @@ const OmBarnaOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
         >
             <StyledOppsummeringsFeltGruppe>
                 <OppsummeringFelt
-                    spørsmålstekst={omBarnaTekster.fosterbarn.sporsmal}
+                    tittel={<TekstBlock block={omBarnaTekster.fosterbarn.sporsmal} />}
                     søknadsvar={søknad.erNoenAvBarnaFosterbarn.svar}
                 />
                 {søknad.erNoenAvBarnaFosterbarn.svar === ESvar.JA && (
                     <OppsummeringFelt
-                        spørsmålstekst={omBarnaTekster.hvemFosterbarn.sporsmal}
+                        tittel={<TekstBlock block={omBarnaTekster.hvemFosterbarn.sporsmal} />}
                         søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.erFosterbarn)}
                     />
                 )}
             </StyledOppsummeringsFeltGruppe>
             <StyledOppsummeringsFeltGruppe>
                 <OppsummeringFelt
-                    spørsmålstekst={omBarnaTekster.institusjonKontantstoette.sporsmal}
+                    tittel={
+                        <TekstBlock block={omBarnaTekster.institusjonKontantstoette.sporsmal} />
+                    }
                     søknadsvar={søknad.oppholderBarnSegIInstitusjon.svar}
                 />
 
                 {søknad.oppholderBarnSegIInstitusjon.svar === ESvar.JA && (
                     <OppsummeringFelt
-                        spørsmålstekst={omBarnaTekster.hvemInstitusjon.sporsmal}
+                        tittel={<TekstBlock block={omBarnaTekster.hvemInstitusjon.sporsmal} />}
                         søknadsvar={genererListeMedBarn(
                             barnDataKeySpørsmål.oppholderSegIInstitusjon
                         )}
@@ -64,37 +67,45 @@ const OmBarnaOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
             </StyledOppsummeringsFeltGruppe>
             <StyledOppsummeringsFeltGruppe>
                 <OppsummeringFelt
-                    spørsmålstekst={omBarnaTekster.adoptertKontantstoette.sporsmal}
+                    tittel={<TekstBlock block={omBarnaTekster.adoptertKontantstoette.sporsmal} />}
                     søknadsvar={søknad.erBarnAdoptert.svar}
                 />
                 {søknad.erBarnAdoptert.svar === ESvar.JA && (
                     <OppsummeringFelt
-                        spørsmålstekst={omBarnaTekster.hvemAdoptertKontantstoette.sporsmal}
+                        tittel={
+                            <TekstBlock
+                                block={omBarnaTekster.hvemAdoptertKontantstoette.sporsmal}
+                            />
+                        }
                         søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.erAdoptert)}
                     />
                 )}
             </StyledOppsummeringsFeltGruppe>
             <StyledOppsummeringsFeltGruppe>
                 <OppsummeringFelt
-                    spørsmålstekst={omBarnaTekster.asyl.sporsmal}
+                    tittel={<TekstBlock block={omBarnaTekster.asyl.sporsmal} />}
                     søknadsvar={søknad.søktAsylForBarn.svar}
                 />
                 {søknad.søktAsylForBarn.svar === ESvar.JA && (
                     <OppsummeringFelt
-                        spørsmålstekst={omBarnaTekster.hvemAsyl.sporsmal}
+                        tittel={<TekstBlock block={omBarnaTekster.hvemAsyl.sporsmal} />}
                         søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.erAsylsøker)}
                     />
                 )}
             </StyledOppsummeringsFeltGruppe>
             <StyledOppsummeringsFeltGruppe>
                 <OppsummeringFelt
-                    spørsmålstekst={omBarnaTekster.sammenhengendeOppholdINorge.sporsmal}
+                    tittel={
+                        <TekstBlock block={omBarnaTekster.sammenhengendeOppholdINorge.sporsmal} />
+                    }
                     søknadsvar={søknad.barnOppholdtSegTolvMndSammenhengendeINorge.svar}
                 />
 
                 {søknad.barnOppholdtSegTolvMndSammenhengendeINorge.svar === ESvar.NEI && (
                     <OppsummeringFelt
-                        spørsmålstekst={omBarnaTekster.hvemOppholdUtenforNorge.sporsmal}
+                        tittel={
+                            <TekstBlock block={omBarnaTekster.hvemOppholdUtenforNorge.sporsmal} />
+                        }
                         søknadsvar={genererListeMedBarn(
                             barnDataKeySpørsmål.boddMindreEnn12MndINorge
                         )}
@@ -103,13 +114,13 @@ const OmBarnaOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
             </StyledOppsummeringsFeltGruppe>
             <StyledOppsummeringsFeltGruppe>
                 <OppsummeringFelt
-                    spørsmålstekst={omBarnaTekster.soektYtelseEuEoes.sporsmal}
+                    tittel={<TekstBlock block={omBarnaTekster.soektYtelseEuEoes.sporsmal} />}
                     søknadsvar={søknad.mottarKontantstøtteForBarnFraAnnetEøsland.svar}
                 />
 
                 {søknad.mottarKontantstøtteForBarnFraAnnetEøsland.svar === ESvar.JA && (
                     <OppsummeringFelt
-                        spørsmålstekst={omBarnaTekster.hvemSoektYtelse.sporsmal}
+                        tittel={<TekstBlock block={omBarnaTekster.hvemSoektYtelse.sporsmal} />}
                         søknadsvar={genererListeMedBarn(
                             barnDataKeySpørsmål.kontantstøtteFraAnnetEøsland
                         )}
@@ -118,13 +129,13 @@ const OmBarnaOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
             </StyledOppsummeringsFeltGruppe>
             <StyledOppsummeringsFeltGruppe>
                 <OppsummeringFelt
-                    spørsmålstekst={omBarnaTekster.barnehageplass.sporsmal}
+                    tittel={<TekstBlock block={omBarnaTekster.barnehageplass.sporsmal} />}
                     søknadsvar={søknad.harEllerTildeltBarnehageplass.svar}
                 />
 
                 {søknad.harEllerTildeltBarnehageplass.svar === ESvar.JA && (
                     <OppsummeringFelt
-                        spørsmålstekst={omBarnaTekster.hvemBarnehageplass.sporsmal}
+                        tittel={<TekstBlock block={omBarnaTekster.hvemBarnehageplass.sporsmal} />}
                         søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.harBarnehageplass)}
                     />
                 )}
@@ -132,22 +143,30 @@ const OmBarnaOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
             {søknad.erAvdødPartnerForelder.svar && (
                 <StyledOppsummeringsFeltGruppe>
                     <OppsummeringFelt
-                        spørsmålstekst={
-                            søknad.erAvdødPartnerForelder.id ===
-                            OmBarnaDineSpørsmålId.erFolkeregAvdødPartnerForelder
-                                ? omBarnaTekster.folkeregistrertGjenlevende.sporsmal
-                                : omBarnaTekster.folkeregistrertEnkeEnkemann.sporsmal
+                        tittel={
+                            <TekstBlock
+                                block={
+                                    søknad.erAvdødPartnerForelder.id ===
+                                    OmBarnaDineSpørsmålId.erFolkeregAvdødPartnerForelder
+                                        ? omBarnaTekster.folkeregistrertGjenlevende.sporsmal
+                                        : omBarnaTekster.folkeregistrertEnkeEnkemann.sporsmal
+                                }
+                            />
                         }
                         søknadsvar={søknad.erAvdødPartnerForelder.svar}
                     />
 
                     {søknad.erAvdødPartnerForelder.svar === ESvar.JA && (
                         <OppsummeringFelt
-                            spørsmålstekst={
-                                søknad.erAvdødPartnerForelder.id ===
-                                OmBarnaDineSpørsmålId.erFolkeregAvdødPartnerForelder
-                                    ? omBarnaTekster.hvemAvBarnaAvdoedPartner.sporsmal
-                                    : omBarnaTekster.hvemAvBarnaAvdoedEktefelle.sporsmal
+                            tittel={
+                                <TekstBlock
+                                    block={
+                                        søknad.erAvdødPartnerForelder.id ===
+                                        OmBarnaDineSpørsmålId.erFolkeregAvdødPartnerForelder
+                                            ? omBarnaTekster.hvemAvBarnaAvdoedPartner.sporsmal
+                                            : omBarnaTekster.hvemAvBarnaAvdoedEktefelle.sporsmal
+                                    }
+                                />
                             }
                             søknadsvar={genererListeMedBarn(barnDataKeySpørsmål.andreForelderErDød)}
                         />

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/AndreForelderOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/AndreForelderOppsummering.tsx
@@ -16,6 +16,7 @@ import { ESanitySteg } from '../../../../../typer/sanity/sanity';
 import { formaterDatoMedUkjent } from '../../../../../utils/dato';
 import { ArbeidsperiodeOppsummering } from '../../../../Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering';
 import { PensjonsperiodeOppsummering } from '../../../../Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering';
+import TekstBlock from '../../../../Felleskomponenter/TekstBlock';
 import { UtenlandsperiodeOppsummering } from '../../../../Felleskomponenter/UtenlandsoppholdModal/UtenlandsperiodeOppsummering';
 import { IOmBarnetTekstinnhold } from '../../../OmBarnet/innholdTyper';
 import { OppsummeringFelt } from '../../OppsummeringFelt';
@@ -37,7 +38,9 @@ const AndreForelderOppsummering: React.FC<{
                 <StyledOppsummeringsFeltGruppe>
                     {andreForelder[andreForelderDataKeySpørsmål.navn].svar && (
                         <OppsummeringFelt
-                            spørsmålstekst={omBarnetTekster.navnAndreForelder.sporsmal}
+                            tittel={
+                                <TekstBlock block={omBarnetTekster.navnAndreForelder.sporsmal} />
+                            }
                             søknadsvar={
                                 andreForelder[andreForelderDataKeySpørsmål.navn].svar !==
                                 AlternativtSvarForInput.UKJENT
@@ -48,8 +51,12 @@ const AndreForelderOppsummering: React.FC<{
                     )}
                     {andreForelder[andreForelderDataKeySpørsmål.fnr].svar && (
                         <OppsummeringFelt
-                            spørsmålstekst={
-                                omBarnetTekster.foedselsnummerDnummerAndreForelder.sporsmal
+                            tittel={
+                                <TekstBlock
+                                    block={
+                                        omBarnetTekster.foedselsnummerDnummerAndreForelder.sporsmal
+                                    }
+                                />
                             }
                             søknadsvar={
                                 andreForelder[andreForelderDataKeySpørsmål.fnr].svar !==
@@ -64,7 +71,11 @@ const AndreForelderOppsummering: React.FC<{
                     )}
                     {andreForelder[andreForelderDataKeySpørsmål.fødselsdato].svar && (
                         <OppsummeringFelt
-                            spørsmålstekst={omBarnetTekster.foedselsdatoAndreForelder.sporsmal}
+                            tittel={
+                                <TekstBlock
+                                    block={omBarnetTekster.foedselsdatoAndreForelder.sporsmal}
+                                />
+                            }
                             søknadsvar={formaterDatoMedUkjent(
                                 andreForelder[andreForelderDataKeySpørsmål.fødselsdato].svar,
                                 plainTekst(omBarnetTekster.foedselsdatoAndreForelder.checkboxLabel)
@@ -73,10 +84,14 @@ const AndreForelderOppsummering: React.FC<{
                     )}
                     {andreForelder[andreForelderDataKeySpørsmål.yrkesaktivFemÅr].svar && (
                         <OppsummeringFelt
-                            spørsmålstekst={
-                                omBarnetTekster.medlemAvFolktetrygdenAndreForelder.sporsmal
+                            tittel={
+                                <TekstBlock
+                                    block={
+                                        omBarnetTekster.medlemAvFolktetrygdenAndreForelder.sporsmal
+                                    }
+                                    flettefelter={flettefelter}
+                                />
                             }
-                            flettefelter={flettefelter}
                             søknadsvar={
                                 andreForelder[andreForelderDataKeySpørsmål.yrkesaktivFemÅr].svar
                             }
@@ -84,13 +99,19 @@ const AndreForelderOppsummering: React.FC<{
                     )}
                     {andreForelder[andreForelderDataKeySpørsmål.arbeidUtlandet].svar && (
                         <OppsummeringFelt
-                            spørsmålstekst={
-                                andreForelderErDød
-                                    ? omBarnetTekster.arbeidUtenforNorgeAndreForelderGjenlevende
-                                          .sporsmal
-                                    : omBarnetTekster.arbeidUtenforNorgeAndreForelder.sporsmal
+                            tittel={
+                                <TekstBlock
+                                    block={
+                                        andreForelderErDød
+                                            ? omBarnetTekster
+                                                  .arbeidUtenforNorgeAndreForelderGjenlevende
+                                                  .sporsmal
+                                            : omBarnetTekster.arbeidUtenforNorgeAndreForelder
+                                                  .sporsmal
+                                    }
+                                    flettefelter={flettefelter}
+                                />
                             }
-                            flettefelter={flettefelter}
                             søknadsvar={
                                 andreForelder[andreForelderDataKeySpørsmål.arbeidUtlandet].svar
                             }
@@ -111,10 +132,15 @@ const AndreForelderOppsummering: React.FC<{
 
                     {andreForelder.utenlandsoppholdUtenArbeid.svar && (
                         <OppsummeringFelt
-                            spørsmålstekst={
-                                omBarnetTekster.utenlandsoppholdUtenArbeidAndreForelder.sporsmal
+                            tittel={
+                                <TekstBlock
+                                    block={
+                                        omBarnetTekster.utenlandsoppholdUtenArbeidAndreForelder
+                                            .sporsmal
+                                    }
+                                    flettefelter={flettefelter}
+                                />
                             }
-                            flettefelter={flettefelter}
                             søknadsvar={andreForelder.utenlandsoppholdUtenArbeid.svar}
                         />
                     )}
@@ -131,12 +157,17 @@ const AndreForelderOppsummering: React.FC<{
 
                     {andreForelder[andreForelderDataKeySpørsmål.pensjonUtland].svar && (
                         <OppsummeringFelt
-                            spørsmålstekst={
-                                andreForelderErDød
-                                    ? omBarnetTekster.pensjonUtlandAndreForelderGjenlevende.sporsmal
-                                    : omBarnetTekster.pensjonUtlandAndreForelder.sporsmal
+                            tittel={
+                                <TekstBlock
+                                    block={
+                                        andreForelderErDød
+                                            ? omBarnetTekster.pensjonUtlandAndreForelderGjenlevende
+                                                  .sporsmal
+                                            : omBarnetTekster.pensjonUtlandAndreForelder.sporsmal
+                                    }
+                                    flettefelter={flettefelter}
+                                />
                             }
-                            flettefelter={flettefelter}
                             søknadsvar={
                                 andreForelder[andreForelderDataKeySpørsmål.pensjonUtland].svar
                             }

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/AndreForelderOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/AndreForelderOppsummering.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BodyShort } from '@navikt/ds-react';
+import { BodyShort, FormSummary } from '@navikt/ds-react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../../../context/AppContext';
@@ -20,7 +20,6 @@ import TekstBlock from '../../../../Felleskomponenter/TekstBlock';
 import { UtenlandsperiodeOppsummering } from '../../../../Felleskomponenter/UtenlandsoppholdModal/UtenlandsperiodeOppsummering';
 import { IOmBarnetTekstinnhold } from '../../../OmBarnet/innholdTyper';
 import { OppsummeringFelt } from '../../OppsummeringFelt';
-import { StyledOppsummeringsFeltGruppe } from '../../OppsummeringsFeltGruppe';
 
 const AndreForelderOppsummering: React.FC<{
     barn: IBarnMedISøknad;
@@ -32,10 +31,10 @@ const AndreForelderOppsummering: React.FC<{
 
     const flettefelter = { barnetsNavn: barn.navn };
     return (
-        <>
+        <FormSummary.Answers>
             {andreForelder[andreForelderDataKeySpørsmål.kanIkkeGiOpplysninger].svar ===
             ESvar.NEI ? (
-                <StyledOppsummeringsFeltGruppe>
+                <>
                     {andreForelder[andreForelderDataKeySpørsmål.navn].svar && (
                         <OppsummeringFelt
                             tittel={
@@ -185,15 +184,11 @@ const AndreForelderOppsummering: React.FC<{
                             barn={barn}
                         />
                     ))}
-                </StyledOppsummeringsFeltGruppe>
+                </>
             ) : (
-                <StyledOppsummeringsFeltGruppe>
-                    <BodyShort>
-                        {plainTekst(omBarnetTekster.navnAndreForelder.checkboxLabel)}
-                    </BodyShort>
-                </StyledOppsummeringsFeltGruppe>
+                <BodyShort>{plainTekst(omBarnetTekster.navnAndreForelder.checkboxLabel)}</BodyShort>
             )}
-        </>
+        </FormSummary.Answers>
     );
 };
 

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/OmBarnetOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/OmBarnetOppsummering.tsx
@@ -16,7 +16,6 @@ import { UtenlandsperiodeOppsummering } from '../../../../Felleskomponenter/Uten
 import { useOmBarnet } from '../../../OmBarnet/useOmBarnet';
 import { OppsummeringFelt } from '../../OppsummeringFelt';
 import Oppsummeringsbolk from '../../Oppsummeringsbolk';
-import { StyledOppsummeringsFeltGruppe } from '../../OppsummeringsFeltGruppe';
 
 import AndreForelderOppsummering from './AndreForelderOppsummering';
 
@@ -45,23 +44,20 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, barn, index })
             barn={barn}
         >
             {barn[barnDataKeySpørsmål.utbetaltForeldrepengerEllerEngangsstønad].svar && (
-                <StyledOppsummeringsFeltGruppe>
-                    <OppsummeringFelt
-                        tittel={
-                            <TekstBlock
-                                block={
-                                    omBarnetTekster.utbetaltForeldrepengerEllerEngangsstoenad
-                                        .sporsmal
-                                }
-                            />
-                        }
-                        søknadsvar={barn.utbetaltForeldrepengerEllerEngangsstønad.svar}
-                    />
-                </StyledOppsummeringsFeltGruppe>
+                <OppsummeringFelt
+                    tittel={
+                        <TekstBlock
+                            block={
+                                omBarnetTekster.utbetaltForeldrepengerEllerEngangsstoenad.sporsmal
+                            }
+                        />
+                    }
+                    søknadsvar={barn.utbetaltForeldrepengerEllerEngangsstønad.svar}
+                />
             )}
 
             {barn[barnDataKeySpørsmål.boddMindreEnn12MndINorge].svar === ESvar.JA && (
-                <StyledOppsummeringsFeltGruppe>
+                <>
                     <OppsummeringFelt
                         tittel={
                             <TekstBlock
@@ -89,11 +85,11 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, barn, index })
                             søknadsvar={barn[barnDataKeySpørsmål.planleggerÅBoINorge12Mnd].svar}
                         />
                     )}
-                </StyledOppsummeringsFeltGruppe>
+                </>
             )}
 
             {barn[barnDataKeySpørsmål.kontantstøtteFraAnnetEøsland].svar === ESvar.JA && (
-                <StyledOppsummeringsFeltGruppe>
+                <>
                     <OppsummeringFelt
                         tittel={
                             <TekstBlock
@@ -148,10 +144,10 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, barn, index })
                             personType={PersonType.søker}
                         />
                     ))}
-                </StyledOppsummeringsFeltGruppe>
+                </>
             )}
             {barn[barnDataKeySpørsmål.harBarnehageplass].svar === ESvar.JA && (
-                <StyledOppsummeringsFeltGruppe>
+                <>
                     <OppsummeringFelt
                         tittel={
                             <TekstBlock
@@ -167,50 +163,46 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, barn, index })
                             nummer={index + 1}
                         />
                     ))}
-                </StyledOppsummeringsFeltGruppe>
+                </>
             )}
 
             {barn.andreForelder && (
-                <>
-                    <OppsummeringFelt tittel={plainTekst(omBarnetTekster.barnetsAndreForelder)} />
+                <OppsummeringFelt tittel={plainTekst(omBarnetTekster.barnetsAndreForelder)}>
                     <AndreForelderOppsummering andreForelder={barn.andreForelder} barn={barn} />
-                </>
+                </OppsummeringFelt>
             )}
-            <StyledOppsummeringsFeltGruppe>
-                <OppsummeringFelt tittel={plainTekst(omBarnetTekster.bosted)} />
 
+            <OppsummeringFelt
+                tittel={
+                    <TekstBlock
+                        block={omBarnetTekster.borBarnFastSammenMedDeg.sporsmal}
+                        flettefelter={flettefelter}
+                    />
+                }
+                søknadsvar={barn[barnDataKeySpørsmål.borFastMedSøker].svar}
+            />
+            {barn[barnDataKeySpørsmål.foreldreBorSammen].svar && (
                 <OppsummeringFelt
                     tittel={
                         <TekstBlock
-                            block={omBarnetTekster.borBarnFastSammenMedDeg.sporsmal}
+                            block={omBarnetTekster.borForeldreSammen.sporsmal}
                             flettefelter={flettefelter}
                         />
                     }
-                    søknadsvar={barn[barnDataKeySpørsmål.borFastMedSøker].svar}
+                    søknadsvar={barn[barnDataKeySpørsmål.foreldreBorSammen].svar}
                 />
-                {barn[barnDataKeySpørsmål.foreldreBorSammen].svar && (
-                    <OppsummeringFelt
-                        tittel={
-                            <TekstBlock
-                                block={omBarnetTekster.borForeldreSammen.sporsmal}
-                                flettefelter={flettefelter}
-                            />
-                        }
-                        søknadsvar={barn[barnDataKeySpørsmål.foreldreBorSammen].svar}
-                    />
-                )}
-                {barn[barnDataKeySpørsmål.søkerDeltKontantstøtte].svar && (
-                    <OppsummeringFelt
-                        tittel={
-                            <TekstBlock
-                                block={omBarnetTekster.soekerDeltKontantstoette.sporsmal}
-                                flettefelter={flettefelter}
-                            />
-                        }
-                        søknadsvar={barn[barnDataKeySpørsmål.søkerDeltKontantstøtte].svar}
-                    />
-                )}
-            </StyledOppsummeringsFeltGruppe>
+            )}
+            {barn[barnDataKeySpørsmål.søkerDeltKontantstøtte].svar && (
+                <OppsummeringFelt
+                    tittel={
+                        <TekstBlock
+                            block={omBarnetTekster.soekerDeltKontantstoette.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
+                    søknadsvar={barn[barnDataKeySpørsmål.søkerDeltKontantstøtte].svar}
+                />
+            )}
         </Oppsummeringsbolk>
     );
 };

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/OmBarnetOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnet/OmBarnetOppsummering.tsx
@@ -11,6 +11,7 @@ import { PersonType } from '../../../../../typer/personType';
 import { landkodeTilSpråk } from '../../../../../utils/språk';
 import { BarnehageplassPeriodeOppsummering } from '../../../../Felleskomponenter/Barnehagemodal/BarnehageplassPeriodeOppsummering';
 import { KontantstøttePeriodeOppsummering } from '../../../../Felleskomponenter/KontantstøttePeriode/KontantstøttePeriodeOppsummering';
+import TekstBlock from '../../../../Felleskomponenter/TekstBlock';
 import { UtenlandsperiodeOppsummering } from '../../../../Felleskomponenter/UtenlandsoppholdModal/UtenlandsperiodeOppsummering';
 import { useOmBarnet } from '../../../OmBarnet/useOmBarnet';
 import { OppsummeringFelt } from '../../OppsummeringFelt';
@@ -27,7 +28,7 @@ interface Props {
 
 const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, barn, index }) => {
     const { hentStegObjektForBarn } = useSteg();
-    const { tekster } = useApp();
+    const { tekster, plainTekst } = useApp();
     const omBarnetTekster = tekster().OM_BARNET;
     const { valgtLocale } = useSpråk();
     const omBarnetHook = useOmBarnet(barn.id);
@@ -46,8 +47,13 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, barn, index })
             {barn[barnDataKeySpørsmål.utbetaltForeldrepengerEllerEngangsstønad].svar && (
                 <StyledOppsummeringsFeltGruppe>
                     <OppsummeringFelt
-                        spørsmålstekst={
-                            omBarnetTekster.utbetaltForeldrepengerEllerEngangsstoenad.sporsmal
+                        tittel={
+                            <TekstBlock
+                                block={
+                                    omBarnetTekster.utbetaltForeldrepengerEllerEngangsstoenad
+                                        .sporsmal
+                                }
+                            />
                         }
                         søknadsvar={barn.utbetaltForeldrepengerEllerEngangsstønad.svar}
                     />
@@ -57,8 +63,12 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, barn, index })
             {barn[barnDataKeySpørsmål.boddMindreEnn12MndINorge].svar === ESvar.JA && (
                 <StyledOppsummeringsFeltGruppe>
                     <OppsummeringFelt
-                        spørsmålstekst={omBarnetTekster.opplystBarnOppholdUtenforNorge}
-                        flettefelter={flettefelter}
+                        tittel={
+                            <TekstBlock
+                                block={omBarnetTekster.opplystBarnOppholdUtenforNorge}
+                                flettefelter={flettefelter}
+                            />
+                        }
                     />
                     {barn.utenlandsperioder.map((periode, index) => (
                         <UtenlandsperiodeOppsummering
@@ -70,8 +80,12 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, barn, index })
                     ))}
                     {barn[barnDataKeySpørsmål.planleggerÅBoINorge12Mnd].svar && (
                         <OppsummeringFelt
-                            spørsmålstekst={omBarnetTekster.planlagtBoSammenhengendeINorge.sporsmal}
-                            flettefelter={flettefelter}
+                            tittel={
+                                <TekstBlock
+                                    block={omBarnetTekster.planlagtBoSammenhengendeINorge.sporsmal}
+                                    flettefelter={flettefelter}
+                                />
+                            }
                             søknadsvar={barn[barnDataKeySpørsmål.planleggerÅBoINorge12Mnd].svar}
                         />
                     )}
@@ -81,12 +95,20 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, barn, index })
             {barn[barnDataKeySpørsmål.kontantstøtteFraAnnetEøsland].svar === ESvar.JA && (
                 <StyledOppsummeringsFeltGruppe>
                     <OppsummeringFelt
-                        spørsmålstekst={omBarnetTekster.opplystFaarHarFaattEllerSoektYtelse}
-                        flettefelter={flettefelter}
+                        tittel={
+                            <TekstBlock
+                                block={omBarnetTekster.opplystFaarHarFaattEllerSoektYtelse}
+                                flettefelter={flettefelter}
+                            />
+                        }
                     />
                     {barn[barnDataKeySpørsmål.pågåendeSøknadFraAnnetEøsLand].svar && (
                         <OppsummeringFelt
-                            spørsmålstekst={omBarnetTekster.paagaaendeSoeknadYtelse.sporsmal}
+                            tittel={
+                                <TekstBlock
+                                    block={omBarnetTekster.paagaaendeSoeknadYtelse.sporsmal}
+                                />
+                            }
                             søknadsvar={
                                 barn[barnDataKeySpørsmål.pågåendeSøknadFraAnnetEøsLand].svar
                             }
@@ -94,7 +116,9 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, barn, index })
                     )}
                     {barn[barnDataKeySpørsmål.pågåendeSøknadHvilketLand].svar && (
                         <OppsummeringFelt
-                            spørsmålstekst={omBarnetTekster.hvilketLandYtelse.sporsmal}
+                            tittel={
+                                <TekstBlock block={omBarnetTekster.hvilketLandYtelse.sporsmal} />
+                            }
                             søknadsvar={landkodeTilSpråk(
                                 barn[barnDataKeySpørsmål.pågåendeSøknadHvilketLand].svar,
                                 valgtLocale
@@ -103,8 +127,12 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, barn, index })
                     )}
                     {barn[barnDataKeySpørsmål.mottarEllerMottokEøsKontantstøtte].svar && (
                         <OppsummeringFelt
-                            spørsmålstekst={
-                                omBarnetTekster.faarEllerHarFaattYtelseFraAnnetLand.sporsmal
+                            tittel={
+                                <TekstBlock
+                                    block={
+                                        omBarnetTekster.faarEllerHarFaattYtelseFraAnnetLand.sporsmal
+                                    }
+                                />
                             }
                             søknadsvar={
                                 barn[barnDataKeySpørsmål.mottarEllerMottokEøsKontantstøtte].svar
@@ -125,8 +153,12 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, barn, index })
             {barn[barnDataKeySpørsmål.harBarnehageplass].svar === ESvar.JA && (
                 <StyledOppsummeringsFeltGruppe>
                     <OppsummeringFelt
-                        spørsmålstekst={omBarnetTekster.opplystBarnehageplass}
-                        flettefelter={flettefelter}
+                        tittel={
+                            <TekstBlock
+                                block={omBarnetTekster.opplystBarnehageplass}
+                                flettefelter={flettefelter}
+                            />
+                        }
                     />
                     {barn.barnehageplassPerioder.map((periode, index) => (
                         <BarnehageplassPeriodeOppsummering
@@ -140,29 +172,41 @@ const OmBarnetOppsummering: React.FC<Props> = ({ settFeilAnchors, barn, index })
 
             {barn.andreForelder && (
                 <>
-                    <OppsummeringFelt spørsmålstekst={omBarnetTekster.barnetsAndreForelder} />
+                    <OppsummeringFelt tittel={plainTekst(omBarnetTekster.barnetsAndreForelder)} />
                     <AndreForelderOppsummering andreForelder={barn.andreForelder} barn={barn} />
                 </>
             )}
             <StyledOppsummeringsFeltGruppe>
-                <OppsummeringFelt spørsmålstekst={omBarnetTekster.bosted} />
+                <OppsummeringFelt tittel={plainTekst(omBarnetTekster.bosted)} />
 
                 <OppsummeringFelt
-                    spørsmålstekst={omBarnetTekster.borBarnFastSammenMedDeg.sporsmal}
-                    flettefelter={flettefelter}
+                    tittel={
+                        <TekstBlock
+                            block={omBarnetTekster.borBarnFastSammenMedDeg.sporsmal}
+                            flettefelter={flettefelter}
+                        />
+                    }
                     søknadsvar={barn[barnDataKeySpørsmål.borFastMedSøker].svar}
                 />
                 {barn[barnDataKeySpørsmål.foreldreBorSammen].svar && (
                     <OppsummeringFelt
-                        spørsmålstekst={omBarnetTekster.borForeldreSammen.sporsmal}
-                        flettefelter={flettefelter}
+                        tittel={
+                            <TekstBlock
+                                block={omBarnetTekster.borForeldreSammen.sporsmal}
+                                flettefelter={flettefelter}
+                            />
+                        }
                         søknadsvar={barn[barnDataKeySpørsmål.foreldreBorSammen].svar}
                     />
                 )}
                 {barn[barnDataKeySpørsmål.søkerDeltKontantstøtte].svar && (
                     <OppsummeringFelt
-                        spørsmålstekst={omBarnetTekster.soekerDeltKontantstoette.sporsmal}
-                        flettefelter={flettefelter}
+                        tittel={
+                            <TekstBlock
+                                block={omBarnetTekster.soekerDeltKontantstoette.sporsmal}
+                                flettefelter={flettefelter}
+                            />
+                        }
                         søknadsvar={barn[barnDataKeySpørsmål.søkerDeltKontantstøtte].svar}
                     />
                 )}

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
@@ -15,7 +15,6 @@ import TekstBlock from '../../../Felleskomponenter/TekstBlock';
 import { useOmdeg } from '../../OmDeg/useOmdeg';
 import { OppsummeringFelt } from '../OppsummeringFelt';
 import Oppsummeringsbolk from '../Oppsummeringsbolk';
-import { StyledOppsummeringsFeltGruppe } from '../OppsummeringsFeltGruppe';
 
 interface Props {
     settFeilAnchors: React.Dispatch<React.SetStateAction<string[]>>;
@@ -45,72 +44,65 @@ const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
             skjemaHook={omDegHook}
             settFeilAnchors={settFeilAnchors}
         >
-            <StyledOppsummeringsFeltGruppe>
-                <OppsummeringFelt
-                    // spørsmålstekst={forsideTekster.bekreftelsesboksBroedtekst}
-                    tittel={
-                        <TekstBlock
-                            block={
-                                fellesTekster.midlertidigeTekster.forsideBekreftelsesboksBroedtekst
-                            }
-                        />
-                    }
-                    søknadsvar={plainTekst(
-                        søknad.lestOgForståttBekreftelse
-                            ? // ? tekster().FORSIDE.bekreftelsesboksErklaering
-                              fellesTekster.midlertidigeTekster.forsideBekreftelsesboksErklaering
-                            : jaNeiSvarTilSpråkId(ESvar.NEI, tekster().FELLES.frittståendeOrd)
-                    )}
-                />
-            </StyledOppsummeringsFeltGruppe>
-            <StyledOppsummeringsFeltGruppe>
-                <OppsummeringFelt
-                    spørsmålstekst={omDegTekster.ident}
-                    søknadsvar={søknad.søker.ident}
-                />
-                <OppsummeringFelt
-                    spørsmålstekst={omDegTekster.statsborgerskap}
-                    søknadsvar={søknad.søker.statsborgerskap
-                        .map((statsborgerskap: { landkode: Alpha3Code }) =>
-                            landkodeTilSpråk(statsborgerskap.landkode, valgtLocale)
-                        )
-                        .join(', ')}
-                />
-                <OppsummeringFelt
-                    spørsmålstekst={omDegTekster.sivilstatus}
-                    søknadsvar={plainTekst(
-                        fellesTekster.frittståendeOrd[
-                            sivilstandTilSanitySivilstandApiKey(søknad.søker.sivilstand.type)
-                        ]
-                    )}
-                />
-
-                <OppsummeringFelt
-                    spørsmålstekst={omDegTekster.adresse}
-                    children={genererAdresseVisning(søknad.søker, omDegTekster, plainTekst)}
-                />
-                {søknad.søker.borPåRegistrertAdresse.svar && (
-                    <OppsummeringFelt
-                        spørsmålstekst={omDegTekster.borPaaAdressen.sporsmal}
-                        søknadsvar={søknad.søker.borPåRegistrertAdresse.svar}
+            <OppsummeringFelt
+                // tittel={forsideTekster.bekreftelsesboksBroedtekst}
+                tittel={
+                    <TekstBlock
+                        block={fellesTekster.midlertidigeTekster.forsideBekreftelsesboksBroedtekst}
                     />
+                }
+                søknadsvar={plainTekst(
+                    søknad.lestOgForståttBekreftelse
+                        ? // ? tekster().FORSIDE.bekreftelsesboksErklaering
+                          fellesTekster.midlertidigeTekster.forsideBekreftelsesboksErklaering
+                        : jaNeiSvarTilSpråkId(ESvar.NEI, tekster().FELLES.frittståendeOrd)
                 )}
-            </StyledOppsummeringsFeltGruppe>
+            />
 
-            <StyledOppsummeringsFeltGruppe>
+            <OppsummeringFelt
+                tittel={plainTekst(omDegTekster.ident)}
+                søknadsvar={søknad.søker.ident}
+            />
+            <OppsummeringFelt
+                tittel={plainTekst(omDegTekster.statsborgerskap)}
+                søknadsvar={søknad.søker.statsborgerskap
+                    .map((statsborgerskap: { landkode: Alpha3Code }) =>
+                        landkodeTilSpråk(statsborgerskap.landkode, valgtLocale)
+                    )
+                    .join(', ')}
+            />
+            <OppsummeringFelt
+                tittel={plainTekst(omDegTekster.sivilstatus)}
+                søknadsvar={plainTekst(
+                    fellesTekster.frittståendeOrd[
+                        sivilstandTilSanitySivilstandApiKey(søknad.søker.sivilstand.type)
+                    ]
+                )}
+            />
+
+            <OppsummeringFelt
+                tittel={plainTekst(omDegTekster.adresse)}
+                children={genererAdresseVisning(søknad.søker, omDegTekster, plainTekst)}
+            />
+            {søknad.søker.borPåRegistrertAdresse.svar && (
                 <OppsummeringFelt
-                    spørsmålstekst={omDegTekster.oppholdtDegSammenhengende.sporsmal}
-                    søknadsvar={søknad.søker.værtINorgeITolvMåneder.svar}
+                    tittel={<TekstBlock block={omDegTekster.borPaaAdressen.sporsmal} />}
+                    søknadsvar={søknad.søker.borPåRegistrertAdresse.svar}
                 />
-                <OppsummeringFelt
-                    spørsmålstekst={omDegTekster.planleggerAaBoSammenhengende.sporsmal}
-                    søknadsvar={søknad.søker.planleggerÅBoINorgeTolvMnd.svar}
-                />
-                <OppsummeringFelt
-                    spørsmålstekst={omDegTekster.medlemAvFolketrygden.sporsmal}
-                    søknadsvar={søknad.søker.yrkesaktivFemÅr.svar}
-                />
-            </StyledOppsummeringsFeltGruppe>
+            )}
+
+            <OppsummeringFelt
+                tittel={<TekstBlock block={omDegTekster.oppholdtDegSammenhengende.sporsmal} />}
+                søknadsvar={søknad.søker.værtINorgeITolvMåneder.svar}
+            />
+            <OppsummeringFelt
+                tittel={<TekstBlock block={omDegTekster.planleggerAaBoSammenhengende.sporsmal} />}
+                søknadsvar={søknad.søker.planleggerÅBoINorgeTolvMnd.svar}
+            />
+            <OppsummeringFelt
+                tittel={<TekstBlock block={omDegTekster.medlemAvFolketrygden.sporsmal} />}
+                søknadsvar={søknad.søker.yrkesaktivFemÅr.svar}
+            />
         </Oppsummeringsbolk>
     );
 };

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/VelgBarnOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/VelgBarnOppsummering.tsx
@@ -30,8 +30,8 @@ const VelgBarnOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
             skjemaHook={velgBarnHook}
             settFeilAnchors={settFeilAnchors}
         >
-            {søknad.barnInkludertISøknaden.map(barn => (
-                <>
+            {søknad.barnInkludertISøknaden.map((barn, index) => (
+                <React.Fragment key={index}>
                     <OppsummeringFelt
                         tittel={<TekstBlock block={leggTilBarnModalTekster.barnetsNavnSubtittel} />}
                         søknadsvar={
@@ -54,7 +54,7 @@ const VelgBarnOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
                             søknadsvar={plainTekst(hentBostedSpråkId(barn, teksterForSteg))}
                         />
                     )}
-                </>
+                </React.Fragment>
             ))}
         </Oppsummeringsbolk>
     );

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/VelgBarnOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/VelgBarnOppsummering.tsx
@@ -10,7 +10,6 @@ import { IVelgBarnTekstinnhold } from '../../VelgBarn/innholdTyper';
 import { useVelgBarn } from '../../VelgBarn/useVelgBarn';
 import { OppsummeringFelt } from '../OppsummeringFelt';
 import Oppsummeringsbolk from '../Oppsummeringsbolk';
-import { StyledOppsummeringsFeltGruppe } from '../OppsummeringsFeltGruppe';
 
 interface Props {
     settFeilAnchors: React.Dispatch<React.SetStateAction<string[]>>;
@@ -31,8 +30,8 @@ const VelgBarnOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
             skjemaHook={velgBarnHook}
             settFeilAnchors={settFeilAnchors}
         >
-            {søknad.barnInkludertISøknaden.map((barn, index) => (
-                <StyledOppsummeringsFeltGruppe key={index}>
+            {søknad.barnInkludertISøknaden.map(barn => (
+                <>
                     <OppsummeringFelt
                         tittel={<TekstBlock block={leggTilBarnModalTekster.barnetsNavnSubtittel} />}
                         søknadsvar={
@@ -55,7 +54,7 @@ const VelgBarnOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
                             søknadsvar={plainTekst(hentBostedSpråkId(barn, teksterForSteg))}
                         />
                     )}
-                </StyledOppsummeringsFeltGruppe>
+                </>
             ))}
         </Oppsummeringsbolk>
     );

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/VelgBarnOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/VelgBarnOppsummering.tsx
@@ -5,6 +5,7 @@ import { useRoutes } from '../../../../context/RoutesContext';
 import { RouteEnum } from '../../../../typer/routes';
 import { ESanitySteg } from '../../../../typer/sanity/sanity';
 import { hentBostedSpråkId } from '../../../../utils/språk';
+import TekstBlock from '../../../Felleskomponenter/TekstBlock';
 import { IVelgBarnTekstinnhold } from '../../VelgBarn/innholdTyper';
 import { useVelgBarn } from '../../VelgBarn/useVelgBarn';
 import { OppsummeringFelt } from '../OppsummeringFelt';
@@ -33,7 +34,7 @@ const VelgBarnOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
             {søknad.barnInkludertISøknaden.map((barn, index) => (
                 <StyledOppsummeringsFeltGruppe key={index}>
                     <OppsummeringFelt
-                        spørsmålstekst={leggTilBarnModalTekster.barnetsNavnSubtittel}
+                        tittel={<TekstBlock block={leggTilBarnModalTekster.barnetsNavnSubtittel} />}
                         søknadsvar={
                             barn.adressebeskyttelse
                                 ? plainTekst(velgBarnTekster.registrertMedAdressesperre)
@@ -42,7 +43,7 @@ const VelgBarnOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
                     />
 
                     <OppsummeringFelt
-                        spørsmålstekst={velgBarnTekster.foedselsnummerLabel}
+                        tittel={<TekstBlock block={velgBarnTekster.foedselsnummerLabel} />}
                         søknadsvar={barn.ident}
                     />
 
@@ -50,7 +51,7 @@ const VelgBarnOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
                         barnRegistrertManuelt => barnRegistrertManuelt.ident === barn.ident
                     ) && (
                         <OppsummeringFelt
-                            spørsmålstekst={velgBarnTekster.registrertBostedLabel}
+                            tittel={<TekstBlock block={velgBarnTekster.registrertBostedLabel} />}
                             søknadsvar={plainTekst(hentBostedSpråkId(barn, teksterForSteg))}
                         />
                     )}

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringsFeltGruppe.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringsFeltGruppe.tsx
@@ -1,5 +1,0 @@
-import styled from 'styled-components';
-
-export const StyledOppsummeringsFeltGruppe = styled.div`
-    margin-bottom: 2.5rem;
-`;

--- a/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummeringsbolk.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummeringsbolk.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { Accordion } from '@navikt/ds-react';
+import { FormSummary } from '@navikt/ds-react';
 import { ISkjema } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
@@ -22,8 +22,10 @@ interface IHookReturn {
     skjema: ISkjema<SkjemaFeltTyper, string>;
 }
 
-const StyledAccordionContent = styled(Accordion.Content)`
-    width: 100%;
+const StyledAppLenkeTekst = styled.span`
+    && {
+        white-space: nowrap;
+    }
 `;
 
 interface Props {
@@ -74,28 +76,30 @@ function Oppsummeringsbolk({
     const stegnummer = hentStegNummer(steg?.route ?? RouteEnum.OmDeg, barn);
 
     return (
-        <Accordion>
-            <Accordion.Item defaultOpen={true}>
-                <Accordion.Header type="button">
+        <FormSummary>
+            <FormSummary.Header>
+                <FormSummary.Heading level="2">
                     {`${stegnummer}. ${uppercaseFørsteBokstav(plainTekst(tittel, flettefelter))}`}
-                </Accordion.Header>
-                <StyledAccordionContent>
-                    {children}
-                    {visFeil && (
-                        <SkjemaFeiloppsummering
-                            skjema={skjema}
-                            stegMedFeil={steg}
-                            id={feilOppsummeringId}
-                        />
-                    )}
-                    {steg && !visFeil && (
-                        <AppLenke steg={steg}>
+                </FormSummary.Heading>
+                {steg && !visFeil && (
+                    <AppLenke steg={steg}>
+                        <StyledAppLenkeTekst>
                             {plainTekst(tekster().OPPSUMMERING.endreSvarLenkeTekst)}
-                        </AppLenke>
-                    )}
-                </StyledAccordionContent>
-            </Accordion.Item>
-        </Accordion>
+                        </StyledAppLenkeTekst>
+                    </AppLenke>
+                )}
+            </FormSummary.Header>
+            <FormSummary.Answers>
+                {children}
+                {visFeil && (
+                    <SkjemaFeiloppsummering
+                        skjema={skjema}
+                        stegMedFeil={steg}
+                        id={feilOppsummeringId}
+                    />
+                )}
+            </FormSummary.Answers>
+        </FormSummary>
     );
 }
 

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -132,6 +132,13 @@ export interface IFrittståendeOrdTekstinnhold {
     steg: LocaleRecordString;
     visAlleSteg: LocaleRecordString;
     skjulAlleSteg: LocaleRecordString;
+    fra: LocaleRecordString;
+    utenlandsopphold: LocaleRecordString;
+    arbeidsperioder: LocaleRecordString;
+    pensjonsperioder: LocaleRecordString;
+    utbetalingsperioder: LocaleRecordString;
+    kontantstoetteperioder: LocaleRecordString;
+    barnehageplassperioder: LocaleRecordString;
 }
 
 export interface INavigasjonTekstinnhold {


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21854

Samme oppgave gjøres i BA: https://github.com/navikt/familie-ba-soknad/pull/1334

### 💰 Hva forsøker du å løse i denne PR'en
- Endrer oppsummeringer til å ta i bruk [FormSummary fra Aksel](https://aksel.nav.no/komponenter/core/formsummary).
  - På oppsummeringssiden.
  - I periode-oppsummeringer løpende i søknaden.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig

### 🤷‍♀ ️Hvor er det lurt å starte?
- Gå gjennom alle stegene i søknaden og fyll ut perioder (arbeidsperioder, pensjonsperioder, etc.)
- Se spesielt på oppsummeringssiden at all informasjon som er fylt ut i søknaden vises som forventet.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Perioder
##### Før
![image](https://github.com/user-attachments/assets/c29a61b8-5266-4de4-98e1-b5a67e11bed6)

##### Etter
![image](https://github.com/user-attachments/assets/b954436d-9b9e-4e63-9657-ffeb2ae83956)

#### Oppsummeringssiden
##### Før
![image](https://github.com/user-attachments/assets/fbadc417-cef1-4e78-ab1f-ae4961a4e6e5)

##### Etter
![image](https://github.com/user-attachments/assets/ef16365e-3c3a-415c-8a56-2752459588ef)