### PR TITLE
Legger til guide på alle steg

### DIFF
--- a/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/OmBarnet.tsx
@@ -49,6 +49,7 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
 
     const {
         omBarnetTittel,
+        omBarnetGuide,
         bosted,
         borBarnFastSammenMedDeg,
         borForeldreSammen,
@@ -68,6 +69,7 @@ const OmBarnet: React.FC<{ barnetsId: BarnetsId }> = ({ barnetsId }) => {
     return barn ? (
         <Steg
             tittel={<TekstBlock block={omBarnetTittel} flettefelter={{ barnetsNavn }} />}
+            guide={<TekstBlock block={omBarnetGuide} />}
             skjema={{
                 validerFelterOgVisFeilmelding,
                 valideringErOk,

--- a/src/frontend/components/SøknadsSteg/OmBarnet/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/OmBarnet/innholdTyper.ts
@@ -3,6 +3,7 @@ import { ISanitySpørsmålDokument } from '../../../typer/sanity/sanity';
 
 export interface IOmBarnetTekstinnhold {
     omBarnetTittel: LocaleRecordBlock;
+    omBarnetGuide: LocaleRecordBlock;
     omBarnetTittelUtenFlettefelt: LocaleRecordBlock;
     borBarnFastSammenMedDeg: ISanitySpørsmålDokument;
     paagaaendeSoeknadYtelse: ISanitySpørsmålDokument;

--- a/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.tsx
@@ -6,6 +6,7 @@ import { BodyShort, VStack } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
 import { useEøs } from '../../../context/EøsContext';
+import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import Steg from '../../Felleskomponenter/Steg/Steg';
@@ -21,6 +22,7 @@ import VelgBarnOppsummering from './OppsummeringSteg/VelgBarnOppsummering';
 
 const Oppsummering: React.FC = () => {
     const { søknad, tekster, plainTekst } = useApp();
+    const { toggles } = useFeatureToggles();
     const navigate = useNavigate();
     const [feilAnchors, settFeilAnchors] = useState<string[]>([]);
     const { barnSomTriggerEøs, søkerTriggerEøs } = useEøs();
@@ -52,7 +54,7 @@ const Oppsummering: React.FC = () => {
             gåVidereCallback={gåVidereCallback}
         >
             <VStack gap="12">
-                <BodyShort>{plainTekst(lesNoeye)}</BodyShort>
+                {!toggles.VIS_GUIDE_I_STEG && <BodyShort>{plainTekst(lesNoeye)}</BodyShort>}
 
                 <OmDegOppsummering settFeilAnchors={settFeilAnchors} />
                 <DinLivssituasjonOppsummering settFeilAnchors={settFeilAnchors} />


### PR DESCRIPTION
Favro: [NAV-21827](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-21827)

### 💰 Hva forsøker du å løse i denne PR'en
- Legger til guide på "Om barnet" steget.
- Endrer "Oppsummering" steget til å kun vise gammel info dersom toggle for nye guider er slått av. 
  - Lenke til feature-toggle i Unleash: https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ks-soknad.vis-guide-i-steg

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig

### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Legger til guide for "Om barnet" steget
##### Før
![image](https://github.com/user-attachments/assets/05a1240d-c2a9-4cf9-a0ba-2d2cbb5ab1b4)

##### Etter
![image](https://github.com/user-attachments/assets/1224e2f0-2b67-4fea-8c60-bec94643bee4)

#### Stopper gammel info fra å vises dersom toggle for nye guider er slått av
##### Før (feil: viser to forskjellige info-tekster)
![image](https://github.com/user-attachments/assets/defc1101-e6c9-46da-97c4-b0645caadf1d)

##### Etter
![image](https://github.com/user-attachments/assets/9adbfeeb-d511-424c-a261-04690bd89674)
