### PR TITLE
Begrenser antall opplastede vedlegg til 25

### DIFF
--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
@@ -111,7 +111,6 @@ const LastOppVedlegg: React.FC<Props> = ({ dokumentasjon, vedleggNr, oppdaterDok
                     <Filopplaster
                         oppdaterDokumentasjon={oppdaterDokumentasjon}
                         dokumentasjon={dokumentasjon}
-                        maxFilstørrelse={1024 * 1024 * 10}
                         tillatteFiltyper={{
                             'image/*': [EFiltyper.PNG, EFiltyper.JPG, EFiltyper.JPEG],
                             'application/pdf': [EFiltyper.PDF],

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/Filopplaster.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/Filopplaster.tsx
@@ -23,7 +23,6 @@ interface Props {
     ) => void;
     dokumentasjon: IDokumentasjon;
     tillatteFiltyper: { [key: string]: string[] };
-    maxFilstørrelse: number;
 }
 
 interface FilopplastningBoksProps {
@@ -68,10 +67,8 @@ const Filopplaster: React.FC<Props> = ({
     oppdaterDokumentasjon,
     dokumentasjon,
     tillatteFiltyper,
-    maxFilstørrelse,
 }) => {
     const { onDrop, harFeil, feilmeldinger, slettVedlegg } = useFilopplaster(
-        maxFilstørrelse,
         dokumentasjon,
         oppdaterDokumentasjon
     );

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/useFilopplaster.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/useFilopplaster.tsx
@@ -72,12 +72,12 @@ export const useFilopplaster = (
             const nyeVedlegg: IVedlegg[] = [];
             const feilmeldingMap: Map<LocaleRecordString, File[]> = new Map();
 
-            const pushFeilmelding = (feilmelding: LocaleRecordString, fil: File | null) => {
+            const pushFeilmelding = (feilmelding: LocaleRecordString, fil: File) => {
                 if (!feilmeldingMap.has(feilmelding)) {
                     feilmeldingMap.set(feilmelding, []);
                 }
                 const filer = feilmeldingMap.get(feilmelding);
-                if (filer && fil) {
+                if (filer) {
                     filer.push(fil);
                     feilmeldingMap.set(feilmelding, filer);
                 }

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/useFilopplaster.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/useFilopplaster.tsx
@@ -29,8 +29,10 @@ const badRequestCodeFraError = (error): BadRequestCode | undefined => {
     return;
 };
 
+const MAKS_FILSTØRRELSE = 1024 * 1024 * 10; // 10 MB
+const MAKS_ANTALL_FILER = 25;
+
 export const useFilopplaster = (
-    maxFilstørrelse: number,
     dokumentasjon: IDokumentasjon,
     oppdaterDokumentasjon: (
         dokumentasjonsBehov: Dokumentasjonsbehov,
@@ -39,11 +41,18 @@ export const useFilopplaster = (
     ) => void
 ) => {
     const { wrapMedSystemetLaster } = useLastRessurserContext();
-    const { tekster } = useApp();
+    const { tekster, søknad } = useApp();
     const [feilmeldinger, settFeilmeldinger] = useState<Map<LocaleRecordString, File[]>>(new Map());
     const [harFeil, settHarFeil] = useState<boolean>(false);
 
     const dokumentasjonTekster = tekster().DOKUMENTASJON;
+
+    const antallOpplastedeVedlegg = (): number =>
+        søknad.dokumentasjon.reduce(
+            (antallVedlegg: number, dokumentasjon: IDokumentasjon) =>
+                antallVedlegg + dokumentasjon.opplastedeVedlegg.length,
+            0
+        );
 
     const datoTilStreng = (date: Date): string => {
         return date.toISOString();
@@ -52,15 +61,23 @@ export const useFilopplaster = (
 
     const onDrop = useCallback(
         async (filer: File[], filRejections: FileRejection[]) => {
+            if (
+                filer.length > MAKS_ANTALL_FILER ||
+                filer.length + antallOpplastedeVedlegg() > MAKS_ANTALL_FILER
+            ) {
+                settFeilmeldinger(new Map().set(dokumentasjonTekster.forMange, []));
+                settHarFeil(true);
+                return;
+            }
             const nyeVedlegg: IVedlegg[] = [];
             const feilmeldingMap: Map<LocaleRecordString, File[]> = new Map();
 
-            const pushFeilmelding = (feilmelding: LocaleRecordString, fil: File) => {
+            const pushFeilmelding = (feilmelding: LocaleRecordString, fil: File | null) => {
                 if (!feilmeldingMap.has(feilmelding)) {
                     feilmeldingMap.set(feilmelding, []);
                 }
                 const filer = feilmeldingMap.get(feilmelding);
-                if (filer) {
+                if (filer && fil) {
                     filer.push(fil);
                     feilmeldingMap.set(feilmelding, filer);
                 }
@@ -75,7 +92,7 @@ export const useFilopplaster = (
             await Promise.all(
                 filer.map((fil: File) =>
                     wrapMedSystemetLaster(async () => {
-                        if (maxFilstørrelse && fil.size > maxFilstørrelse) {
+                        if (fil.size > MAKS_FILSTØRRELSE) {
                             pushFeilmelding(dokumentasjonTekster.forStor, fil);
                             return;
                         }

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
@@ -29,6 +29,7 @@ export type IDokumentasjonTekstinnhold = {
     sendSoeknad: LocaleRecordString;
     noeGikkFeil: LocaleRecordString;
     slett: LocaleRecordString;
+    forMange: LocaleRecordString;
 } & {
     [TittelSanityApiNavn.avtaleOmDeltBostedTittel]: LocaleRecordBlock;
     [TittelSanityApiNavn.annenDokumentasjon]: LocaleRecordBlock;


### PR DESCRIPTION
Favro: [NAV-22223](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22223)

### 💰 Hva forsøker du å løse i denne PR'en
Begrenser antall opplastede vedlegg til 25.

Dersom man forsøker å laste opp flere enn 25 vedlegg totalt i søknaden viser vi en feilmelding til bruker.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
![image](https://github.com/user-attachments/assets/7c1c6fb4-00ce-4272-9482-75411cf2ecef)
