### PR TITLE
Fjerner lenke på "Velg barn" steget

### DIFF
--- a/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
@@ -19,10 +19,6 @@ import { NyttBarnKort } from './LeggTilBarn/NyttBarnKort';
 import { VelgBarnSpørsmålId } from './spørsmål';
 import { useVelgBarn } from './useVelgBarn';
 
-const LenkeContainer = styled.div`
-    margin-top: 1.5rem;
-`;
-
 const StyledWarningAlert = styled(Alert)`
     margin-top: 1.5rem;
 `;
@@ -55,7 +51,6 @@ const VelgBarn: React.FC = () => {
         velgBarnTittel,
         velgBarnGuide,
         hvisOpplysningeneIkkeStemmer,
-        leseMerOmRegleneKontantstoette,
         kanIkkeBestemmeRettUnder1Aar,
     } = teksterForSteg;
 
@@ -107,10 +102,6 @@ const VelgBarn: React.FC = () => {
                         <TekstBlock block={kanIkkeBestemmeRettUnder1Aar} />
                     </StyledWarningAlert>
                 )}
-
-                <LenkeContainer>
-                    <TekstBlock block={leseMerOmRegleneKontantstoette} />
-                </LenkeContainer>
             </Steg>
             {erLeggTilBarnModalÅpen && (
                 <LeggTilBarnModal

--- a/src/frontend/components/SøknadsSteg/VelgBarn/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/innholdTyper.ts
@@ -4,7 +4,6 @@ export interface IVelgBarnTekstinnhold {
     velgBarnTittel: LocaleRecordBlock;
     velgBarnGuide: LocaleRecordBlock;
     hvisOpplysningeneIkkeStemmer: LocaleRecordBlock;
-    leseMerOmRegleneKontantstoette: LocaleRecordBlock;
     soekeForUregistrerteBarn: LocaleRecordBlock;
     alderLabel: LocaleRecordBlock;
     aar: LocaleRecordBlock;


### PR DESCRIPTION
Favro: [NAV-22337](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22337)

### 💰 Hva forsøker du å løse i denne PR'en
- Fjerner lenke nederst på steget "Velg barn".
- Denne lenken trengs ikke lengre ettersom brukeren får denne informasjonen på forsiden.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nøvdendig

### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Før
![image](https://github.com/user-attachments/assets/595508d7-e27c-4344-a6e6-fb51e18eb4aa)

#### Etter
![image](https://github.com/user-attachments/assets/405bb6b2-c69f-4b3b-9694-c499a4a227db)
