### PR TITLE
Fjerner "vis-guide-i-steg" toggle

### DIFF
--- a/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
+++ b/src/frontend/components/Felleskomponenter/Steg/Steg.tsx
@@ -10,7 +10,6 @@ import { setAvailableLanguages } from '@navikt/nav-dekoratoren-moduler';
 
 import { useApp } from '../../../context/AppContext';
 import { useAppNavigation } from '../../../context/AppNavigationContext';
-import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { useSteg } from '../../../context/StegContext';
 import useFørsteRender from '../../../hooks/useFørsteRender';
 import { device } from '../../../Theme';
@@ -87,7 +86,6 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, vedleggOppsummering, c
         erPåKvitteringsside,
     } = useSteg();
     const { komFra, settKomFra } = useAppNavigation();
-    const { toggles } = useFeatureToggles();
 
     const nesteRoute = hentNesteSteg();
     const forrigeRoute = hentForrigeSteg();
@@ -217,7 +215,7 @@ function Steg({ tittel, guide, skjema, gåVidereCallback, vedleggOppsummering, c
                         {tittel}
                     </Heading>
                 </Box>
-                {toggles.VIS_GUIDE_I_STEG && guide && (
+                {guide && (
                     <Box marginBlock="0 12">
                         <GuidePanel poster>{guide}</GuidePanel>
                     </Box>

--- a/src/frontend/components/SøknadsSteg/OmDeg/Personopplysninger.tsx
+++ b/src/frontend/components/SøknadsSteg/OmDeg/Personopplysninger.tsx
@@ -2,44 +2,28 @@ import React from 'react';
 
 import { Alpha3Code } from 'i18n-iso-countries';
 
-import { Alert, BodyShort, Label } from '@navikt/ds-react';
+import { BodyShort, Label } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
-import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { useSpråk } from '../../../context/SpråkContext';
-import { Typografi } from '../../../typer/common';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { genererAdresseVisning } from '../../../utils/adresse';
 import { landkodeTilSpråk, sivilstandTilSanitySivilstandApiKey } from '../../../utils/språk';
 import Informasjonsbolk from '../../Felleskomponenter/Informasjonsbolk/Informasjonsbolk';
-import TekstBlock from '../../Felleskomponenter/TekstBlock';
 
 export const Personopplysninger: React.FC = () => {
     const { valgtLocale } = useSpråk();
     const { søknad, tekster, plainTekst } = useApp();
-    const { toggles } = useFeatureToggles();
 
     const søker = søknad.søker;
 
     const {
-        [ESanitySteg.OM_DEG]: {
-            personopplysningerAlert,
-            ident,
-            statsborgerskap,
-            sivilstatus,
-            adresse,
-        },
+        [ESanitySteg.OM_DEG]: { ident, statsborgerskap, sivilstatus, adresse },
         [ESanitySteg.FELLES]: { frittståendeOrd },
     } = tekster();
 
     return (
         <>
-            {!toggles.VIS_GUIDE_I_STEG && (
-                <Alert variant={'info'} inline>
-                    <TekstBlock block={personopplysningerAlert} typografi={Typografi.BodyShort} />
-                </Alert>
-            )}
-
             <Informasjonsbolk>
                 <Label>{plainTekst(ident)}</Label>
                 <BodyShort>{søker.ident}</BodyShort>

--- a/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/Oppsummering.tsx
@@ -2,11 +2,10 @@ import React, { useState } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
-import { BodyShort, VStack } from '@navikt/ds-react';
+import { VStack } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
 import { useEøs } from '../../../context/EøsContext';
-import { useFeatureToggles } from '../../../context/FeatureToggleContext';
 import { IBarnMedISøknad } from '../../../typer/barn';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import Steg from '../../Felleskomponenter/Steg/Steg';
@@ -21,8 +20,7 @@ import OmDegOppsummering from './OppsummeringSteg/OmDegOppsummering';
 import VelgBarnOppsummering from './OppsummeringSteg/VelgBarnOppsummering';
 
 const Oppsummering: React.FC = () => {
-    const { søknad, tekster, plainTekst } = useApp();
-    const { toggles } = useFeatureToggles();
+    const { søknad, tekster } = useApp();
     const navigate = useNavigate();
     const [feilAnchors, settFeilAnchors] = useState<string[]>([]);
     const { barnSomTriggerEøs, søkerTriggerEøs } = useEøs();
@@ -32,7 +30,7 @@ const Oppsummering: React.FC = () => {
         : søknad.barnInkludertISøknaden.filter(barn => barn.triggetEøs);
 
     const {
-        [ESanitySteg.OPPSUMMERING]: { oppsummeringTittel, oppsummeringGuide, lesNoeye },
+        [ESanitySteg.OPPSUMMERING]: { oppsummeringTittel, oppsummeringGuide },
     } = tekster();
 
     const scrollTilFeil = (elementId: string) => {
@@ -54,8 +52,6 @@ const Oppsummering: React.FC = () => {
             gåVidereCallback={gåVidereCallback}
         >
             <VStack gap="12">
-                {!toggles.VIS_GUIDE_I_STEG && <BodyShort>{plainTekst(lesNoeye)}</BodyShort>}
-
                 <OmDegOppsummering settFeilAnchors={settFeilAnchors} />
                 <DinLivssituasjonOppsummering settFeilAnchors={settFeilAnchors} />
                 <VelgBarnOppsummering settFeilAnchors={settFeilAnchors} />

--- a/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/VelgBarn.tsx
@@ -5,8 +5,6 @@ import styled from 'styled-components';
 import { Alert, VStack } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
-import { useFeatureToggles } from '../../../context/FeatureToggleContext';
-import { Typografi } from '../../../typer/common';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import useModal from '../../Felleskomponenter/SkjemaModal/useModal';
 import Steg from '../../Felleskomponenter/Steg/Steg';
@@ -39,7 +37,6 @@ const VelgBarn: React.FC = () => {
         barnSomSkalVæreMed,
         fjernBarn,
     } = useVelgBarn();
-    const { toggles } = useFeatureToggles();
 
     const barnFraRespons = søknad.søker.barn;
     const barnManueltLagtTil = søknad.barnRegistrertManuelt;
@@ -47,14 +44,7 @@ const VelgBarn: React.FC = () => {
     const finnesBarnUnder1År = barnSomSkalVæreMed.some(barn => barn.erUnder11Mnd);
 
     const teksterForSteg: IVelgBarnTekstinnhold = tekster()[ESanitySteg.VELG_BARN];
-    const {
-        velgBarnTittel,
-        velgBarnGuide,
-        hvisOpplysningeneIkkeStemmer,
-        kanIkkeBestemmeRettUnder1Aar,
-    } = teksterForSteg;
-
-    const visGammelInfo = !toggles.VIS_GUIDE_I_STEG || !velgBarnGuide;
+    const { velgBarnTittel, velgBarnGuide, kanIkkeBestemmeRettUnder1Aar } = teksterForSteg;
 
     return (
         <>
@@ -70,21 +60,7 @@ const VelgBarn: React.FC = () => {
                     },
                 }}
             >
-                {visGammelInfo && (
-                    <Alert variant={'info'} inline>
-                        <TekstBlock
-                            block={hvisOpplysningeneIkkeStemmer}
-                            typografi={Typografi.BodyShort}
-                        />
-                    </Alert>
-                )}
-
-                <VStack
-                    id={VelgBarnSpørsmålId.velgBarn}
-                    className={'BarnekortStack'}
-                    marginBlock="12"
-                    gap="12"
-                >
+                <VStack id={VelgBarnSpørsmålId.velgBarn} className={'BarnekortStack'} gap="12">
                     {barn.map(barnet => (
                         <Barnekort
                             key={barnet.id}

--- a/src/frontend/typer/feature-toggles.ts
+++ b/src/frontend/typer/feature-toggles.ts
@@ -5,7 +5,6 @@ export enum EToggle {
 export enum EFeatureToggle {
     // EKSEMPEL = 'EKSEMPEL',
     FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP = 'FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP',
-    VIS_GUIDE_I_STEG = 'VIS_GUIDE_I_STEG',
     BRUK_NYTT_ENDEPUNKT_FOR_INNSENDING_AV_SOKNAD = 'BRUK_NYTT_ENDEPUNKT_FOR_INNSENDING_AV_SOKNAD',
 }
 
@@ -13,7 +12,6 @@ export const ToggleKeys: Record<EFeatureToggle, string> = {
     // [EFeatureToggle.EKSEMPEL]: 'familie-ks-soknad.eksempel',
     [EFeatureToggle.FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP]:
         'familie-ks-soknad.forklarende-tekster-over-legg-til-knapp',
-    [EFeatureToggle.VIS_GUIDE_I_STEG]: 'familie-ks-soknad.vis-guide-i-steg',
     [EFeatureToggle.BRUK_NYTT_ENDEPUNKT_FOR_INNSENDING_AV_SOKNAD]:
         'familie-ks-soknad.bruk_nytt_endepunkt_for_innsending_av_soknad',
 };

--- a/src/frontend/utils/testing.tsx
+++ b/src/frontend/utils/testing.tsx
@@ -151,7 +151,6 @@ export const mockFeatureToggle = () => {
                 // toggles: { [EFeatureToggle.EXAMPLE]: false },
                 toggles: {
                     [EFeatureToggle.FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP]: false,
-                    [EFeatureToggle.VIS_GUIDE_I_STEG]: false,
                 },
             })
         );


### PR DESCRIPTION
Favro: [NAV-22585](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-22585)

Feature toggle i unleash: [familie-ks-soknad.vis-guide-i-steg](https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ks-soknad.vis-guide-i-steg)

### 💰 Hva forsøker du å løse i denne PR'en
- Fjerner "vis-guide-i-steg" toggle slik at søknaden ser ut som om toggle er på.
- Toggle er på i prod fra før. Alt disse endringene gjør er å fjerne en gammel toggle som ikke lengre utgjør en forskjell eller trenger å bli testet mer på.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig

### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
- Ingen visuelle endringer ettersom toggle allerede er skrudd på.