### PR TITLE
Fjerner midlertidig tekst for infoTilSoker

### DIFF
--- a/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
+++ b/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
@@ -81,9 +81,7 @@ const Kvittering: React.FC = () => {
                         </Alert>
                     )}
                     <TekstBlock
-                        // TODO: Endre infoTilSoker i Sanity til å inneholde samme tekst som infoTilSokerMidlertidigTekst.
-                        // Deretter, bytt koden under til å ta i bruk infoTilSoker.
-                        block={kvitteringTekster.infoTilSokerMidlertidigTekst}
+                        block={kvitteringTekster.infoTilSoker}
                         typografi={Typografi.BodyLong}
                     />
                 </VStack>

--- a/src/frontend/components/SøknadsSteg/Kvittering/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Kvittering/innholdTyper.ts
@@ -6,7 +6,6 @@ export interface IKvitteringTekstinnhold {
     trengerIkkeEttersendeVedlegg: LocaleRecordBlock;
     maaEttersendeVedleggAlert: LocaleRecordBlock;
     infoTilSoker: LocaleRecordBlock;
-    infoTilSokerMidlertidigTekst: LocaleRecordBlock;
     kontonummerEOES: LocaleRecordBlock;
     ettersendelseKontantstotte: LocaleRecordBlock;
     manglerKontonummerTittel: LocaleRecordBlock;


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
- Fjerner midlertidig tekst for infoTilSoker.
- I [en tidligere oppgave](https://github.com/navikt/familie-ks-soknad/pull/635) måtte vi endre tekstinnholdet på infoTilSøker, men dette kunne i gjøres i Sanity før koden var oppdatert. Derfor lagdes det en midlertidig tekst i Sanity for å sikre at disse var i sync. Nå trenger vi ikke lengre ta i bruk den midlertidige teksten.

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig

### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
- Tekstinnhold er det samme, Ingen visuelle endringer.
