### PR TITLE
Fikser CORS problem når vi har 2 ingresser i dev-gcp

### DIFF
--- a/src/shared-utils/Miljø.ts
+++ b/src/shared-utils/Miljø.ts
@@ -30,21 +30,26 @@ export const erDev = () => {
     return window.location.hostname.indexOf('dev') > -1;
 };
 
+export const erAnsattUrl = () => {
+    if (typeof window === 'undefined') {
+        return false;
+    }
+    return window.location.hostname.indexOf('ansatt') > -1;
+};
+
 export const erLokalt = () => !erProd() && !erDev();
 
 const Miljø = (): MiljøProps => {
     if (erDev()) {
         return {
             sanityDataset: 'production',
-            soknadApiProxyUrl: `https://familie-ks-soknad.intern.dev.nav.no${basePath}api`,
+            soknadApiProxyUrl: `https://familie-ks-soknad.${erAnsattUrl() ? 'ansatt' : 'intern'}.dev.nav.no${basePath}api`,
             soknadApiUrl: `http://familie-baks-soknad-api/api`,
-            dokumentProxyUrl: `https://familie-ks-soknad.intern.dev.nav.no${basePath}dokument`,
+            dokumentProxyUrl: `https://familie-ks-soknad.${erAnsattUrl() ? 'ansatt' : 'intern'}.dev.nav.no${basePath}dokument`,
             dokumentUrl: 'http://familie-dokument/familie/dokument/api', //Vil uansett gå til bucket "familievedlegg" enn så lenge
             modellVersjon: modellVersjon,
-            wonderwallUrl:
-                'https://familie-ks-soknad.intern.dev.nav.no/familie/kontantstotte/soknad/oauth2/login?redirect=',
-            oauthCallbackUri:
-                'https://familie-ks-soknad.intern.dev.nav.no/familie/kontantstotte/soknad/oauth2/callback',
+            wonderwallUrl: `https://familie-ks-soknad.${erAnsattUrl() ? 'ansatt' : 'intern'}.dev.nav.no/familie/kontantstotte/soknad/oauth2/login?redirect=`,
+            oauthCallbackUri: `https://familie-ks-soknad.${erAnsattUrl() ? 'ansatt' : 'intern'}.dev.nav.no/familie/kontantstotte/soknad/oauth2/callback`,
             port: 9000,
         };
     } else if (erProd()) {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi får en rekke CORS issues dersom man forsøker å bruke ansatt-url. Dette er fordi vi har satt opp koden til å bruke intern-url ved alle kall mot backend-del av frontend. Backend-del av frontend er satt opp til å ikke godta slike kall fra andre enn "self". Altså må url man står på samsvare med url man bruker mot backend-del av frontend:
* Står man på `*ansatt.dev.nav.no` må man gå mot backend-del av frontend med urlen `*ansatt.dev.nav.no`
* Står man på `*intern.dev.nav.no` må man gå mot backend-del av frontend med urlen `*intern.dev.nav.no`

Fikser dette ved å sjekke om man står på en ansatt-url når vi bestemmer urler i `Miljø.ts`.
