### PR TITLE
Logger til Sentry ved kontraktsfeil

### DIFF
--- a/src/frontend/hooks/useSendInnSkjema.tsx
+++ b/src/frontend/hooks/useSendInnSkjema.tsx
@@ -49,6 +49,14 @@ export const useSendInnSkjema = (): {
                     const responseData = res.response?.data as Ressurs<IKvittering>;
                     if (responseData && erModellMismatchResponsRessurs(responseData)) {
                         settSisteModellVersjon(responseData.data.modellVersjon);
+
+                        // Denne skal feile mykt, kaster dermed ingen feil
+                        Sentry.captureException(
+                            new Error(
+                                'Klarte ikke sende inn søknaden pga. kontraktsfeil. Det kan skje i overgangen til ny kontrakt, men hvis det skjer for mange over tid er det feil i løsningen.',
+                                { cause: res.message }
+                            )
+                        );
                     } else {
                         //Denne skal feile mykt, med en custom feilmelding til brukeren. Kaster dermed ingen feil her.
                         Sentry.captureException(


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23608

### 💰 Hva forsøker du å løse i denne PR'en
Når KS-søknaden gikk ned på fredag fikk vi ingen pekepinn om det i Sentry og frontend-loggene. Heldigvis plukket vi opp på feilen i loggene for backend. Dette må ha vært fordi vi ikke logger noe feil i frontend når det er såkalte kontraktsendringer som er årsak til feilen. Jeg legger dermed på en logglinje på kontraktsfeil i koden, slik at vi får rapportert disse feilene når de skjer. 

Det er ikke gitt at søknaden er nede når disse feilene inntreffer, men hvis de treffer for flere over tid er det en god pekepinn.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Blir dette støy tror dere? Eller er det verdifullt å ha denne loggingen?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei