### PR TITLE
Tar i bruk dekoratøren sin amplitude-instans, logger amplitude og viser ux signals kun hvis samtykke er gitt

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     ]
   },
   "dependencies": {
-    "@amplitude/analytics-browser": "^2.11.9",
     "@grafana/faro-web-sdk": "^1.11.0",
     "@navikt/aksel-icons": "^6.12.0",
     "@navikt/ds-css": "^6.13.0",
@@ -88,7 +87,7 @@
     "@navikt/familie-skjema": "^8.0.9",
     "@navikt/familie-typer": "^8.0.2",
     "@navikt/fnrvalidator": "^2.0.7",
-    "@navikt/nav-dekoratoren-moduler": "^3.1.3",
+    "@navikt/nav-dekoratoren-moduler": "^3.2.0",
     "@portabletext/react": "^3.2.0",
     "@portabletext/toolkit": "^2.0.8",
     "@sanity/client": "^6.27.2",

--- a/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
+++ b/src/frontend/components/SøknadsSteg/Kvittering/Kvittering.tsx
@@ -11,7 +11,6 @@ import useUxSignals from '../../../hooks/useUxSignals';
 import { Typografi } from '../../../typer/common';
 import { Dokumentasjonsbehov } from '../../../typer/kontrakt/dokumentasjon';
 import { RouteEnum } from '../../../typer/routes';
-import { setUserProperty, UserProperty } from '../../../utils/amplitude';
 import { erDokumentasjonRelevant } from '../../../utils/dokumentasjon';
 import BlokkerTilbakeKnappModal from '../../Felleskomponenter/BlokkerTilbakeKnappModal/BlokkerTilbakeKnappModal';
 import Steg from '../../Felleskomponenter/Steg/Steg';
@@ -26,7 +25,6 @@ const Kvittering: React.FC = () => {
         søknad,
         tekster,
     } = useApp();
-    const { barnInkludertISøknaden } = søknad;
     const { hentStegNummer } = useSteg();
 
     const { innsendingStatus } = useApp();
@@ -50,10 +48,6 @@ const Kvittering: React.FC = () => {
     useEffect(() => {
         if (sisteUtfylteStegIndex === hentStegNummer(RouteEnum.Dokumentasjon)) {
             settFåttGyldigKvittering(true);
-
-            // I tilfelle vi kommer via mellomlagring og ikke har satt denne fra før, sett den her før vi nullstiller søknaden
-            setUserProperty(UserProperty.ANTALL_VALGTE_BARN, barnInkludertISøknaden.length);
-
             avbrytOgSlettSøknad();
         }
     }, []);

--- a/src/frontend/components/SøknadsSteg/VelgBarn/useVelgBarn.tsx
+++ b/src/frontend/components/SøknadsSteg/VelgBarn/useVelgBarn.tsx
@@ -10,7 +10,6 @@ import { BarnetsId } from '../../../typer/common';
 import { IBarn } from '../../../typer/person';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { IVelgBarnFeltTyper } from '../../../typer/skjema';
-import { setUserProperty, UserProperty } from '../../../utils/amplitude';
 import { genererInitialBarnMedISøknad } from '../../../utils/barn';
 
 import { IVelgBarnTekstinnhold } from './innholdTyper';
@@ -88,8 +87,6 @@ export const useVelgBarn = (): {
                 ),
             };
         });
-
-        setUserProperty(UserProperty.ANTALL_VALGTE_BARN, oppdaterteBarn.length);
 
         settSøknad({
             ...søknad,

--- a/src/frontend/hooks/useUxSignals.ts
+++ b/src/frontend/hooks/useUxSignals.ts
@@ -1,11 +1,14 @@
 import { useEffect } from 'react';
 
+import { getCurrentConsent } from '@navikt/nav-dekoratoren-moduler';
+
 const useUxSignals = (ready: boolean) => {
     useEffect(() => {
+        const consent = getCurrentConsent();
         const script = document.createElement('script');
         script.async = true;
         script.src = 'https://widget.uxsignals.com/embed.js';
-        if (ready) {
+        if (consent && consent.consent.surveys && ready) {
             document.body.appendChild(script);
         }
 

--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -4,6 +4,8 @@ import { registerLocale } from 'i18n-iso-countries';
 import ReactDOM from 'react-dom';
 import { createRoot } from 'react-dom/client';
 
+import { awaitDecoratorData } from '@navikt/nav-dekoratoren-moduler';
+
 import App from './App';
 import { hentDekorator } from './decorator';
 import FellesWrapper from './FellesWrapper';
@@ -26,7 +28,7 @@ const polyfillLocaledata = async () => {
 
 hentDekorator();
 
-polyfillLocaledata().then(() => {
+polyfillLocaledata().then(async () => {
     initSentry();
     initGrafanaFaro();
 
@@ -35,6 +37,8 @@ polyfillLocaledata().then(() => {
             axe(React, ReactDOM, 1000);
         });
     }
+
+    await awaitDecoratorData();
 
     const container = document.getElementById('root');
 

--- a/src/frontend/utils/amplitude.ts
+++ b/src/frontend/utils/amplitude.ts
@@ -1,31 +1,16 @@
-import * as amplitude from '@amplitude/analytics-browser';
-import { Identify } from '@amplitude/analytics-browser';
+import { getAmplitudeInstance, getCurrentConsent } from '@navikt/nav-dekoratoren-moduler';
 
 import { søknadstype } from '../typer/søknad';
 
-amplitude
-    .init('default', '', {
-        serverUrl: 'https://amplitude.nav.no/collect-auto',
-        autocapture: {
-            attribution: true,
-            pageViews: false,
-            sessions: true,
-            formInteractions: false,
-            fileDownloads: false,
-            elementInteractions: false,
-        },
-    })
-    .promise.catch(error => {
-        console.error('#MSA error initializing amplitude', error);
-    });
-
-export enum UserProperty {
-    ANTALL_VALGTE_BARN = 'antallValgteBarn',
-}
+const logger = getAmplitudeInstance('dekoratoren');
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export function logEvent(eventName: string, eventProperties: any) {
-    amplitude.track(eventName, eventProperties);
+    const consent = getCurrentConsent();
+
+    if (consent && consent.consent.analytics) {
+        logger(eventName, eventProperties);
+    }
 }
 
 export const logSidevisningKontantstøtte = (side: string) => {
@@ -69,9 +54,4 @@ export const logKlikkGåVidere = (steg: number) => {
         team_id: 'familie',
         steg,
     });
-};
-
-export const setUserProperty = (key: UserProperty, value: string | number) => {
-    const identify = new Identify().set(key, value);
-    amplitude.identify(identify);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,85 +12,6 @@
   resolved "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.1.tgz#2447a230bfe072c1659e6815129c03cf170710e3"
   integrity sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ==
 
-"@amplitude/analytics-browser@^2.11.9":
-  version "2.11.9"
-  resolved "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.11.9.tgz#d54de7b53e8578d6bde2d4690198acf0df19c8e7"
-  integrity sha512-FHejpsW3OypNKaIBvMwLm74UUSBcR+VwrBsj7V2VlPDNRdeaFi21kJgVYUW5AcjxTsadMzBQGBb4BarZ4k2+9Q==
-  dependencies:
-    "@amplitude/analytics-client-common" "^2.3.5"
-    "@amplitude/analytics-core" "^2.5.4"
-    "@amplitude/analytics-remote-config" "^0.4.0"
-    "@amplitude/analytics-types" "^2.8.4"
-    "@amplitude/plugin-autocapture-browser" "^1.0.2"
-    "@amplitude/plugin-page-view-tracking-browser" "^2.3.5"
-    tslib "^2.4.1"
-
-"@amplitude/analytics-client-common@>=1 <3", "@amplitude/analytics-client-common@^2.3.5":
-  version "2.3.5"
-  resolved "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.3.5.tgz#8c31d6d1848e26d705ad21205db79aceb7b1cf5a"
-  integrity sha512-BCP+jorfLMAKK/g87fAk4IPP/NzQLMCep+Qe23tqOCWguwTEINYnyzD/GmhaIKXSM2o9pmMLlHbhkA1vXUtF8g==
-  dependencies:
-    "@amplitude/analytics-connector" "^1.4.8"
-    "@amplitude/analytics-core" "^2.5.4"
-    "@amplitude/analytics-types" "^2.8.4"
-    tslib "^2.4.1"
-
-"@amplitude/analytics-connector@^1.4.8":
-  version "1.6.1"
-  resolved "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.6.1.tgz#954dcbcc37f4a19d898bedd88357b5275faafa46"
-  integrity sha512-QAGeOfBQc3tamwcECu6YqAPD4mFI1TLBoWi+n0iViYWUZma2FeDLPMihwIquxI8CVvqpn4gswFZsIPRit3q9tQ==
-  dependencies:
-    "@amplitude/experiment-core" "^0.10.0"
-
-"@amplitude/analytics-core@>=1 <3", "@amplitude/analytics-core@^2.5.4":
-  version "2.5.4"
-  resolved "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.5.4.tgz#b45308333c66bd75076c3bf256a51fd1565a807d"
-  integrity sha512-J5ZF8hQmxmxM+7bu25a2TfTnk/LQ/oH5FYdg79f1lJ85Aa6oUlCDxgvXwy1RVpwaFjWlZQgV4XVaAUrxtSPRFw==
-  dependencies:
-    "@amplitude/analytics-types" "^2.8.4"
-    tslib "^2.4.1"
-
-"@amplitude/analytics-remote-config@^0.4.0":
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/@amplitude/analytics-remote-config/-/analytics-remote-config-0.4.1.tgz#b62cf8aa82290f68b314197e20351b10ea44ae3e"
-  integrity sha512-BYl6kQ9qjztrCACsugpxO+foLaQIC0aSEzoXEAb/gwOzInmqkyyI+Ub+aWTBih4xgB/lhWlOcidWHAmNiTJTNw==
-  dependencies:
-    "@amplitude/analytics-client-common" ">=1 <3"
-    "@amplitude/analytics-core" ">=1 <3"
-    "@amplitude/analytics-types" ">=1 <3"
-    tslib "^2.4.1"
-
-"@amplitude/analytics-types@>=1 <3", "@amplitude/analytics-types@^2.8.2", "@amplitude/analytics-types@^2.8.4":
-  version "2.8.4"
-  resolved "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.8.4.tgz#0d9ec0d3a0d00b729b5520b38ef8a158e691ffd2"
-  integrity sha512-jQ8WY1aPbpBshl0L/0YEeQn/wZlBr8Jlqc20qf8nbuDuimFy8RqAkE+BVaMI86FCkr3AJ7PjMXkGwCSbUx88CA==
-
-"@amplitude/experiment-core@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.npmjs.org/@amplitude/experiment-core/-/experiment-core-0.10.0.tgz#5d225c6dc2b0e3a06ea3d61608c1096f86f50d85"
-  integrity sha512-FBfM6a4aHp+7OYLYiHO3kni3vCThInT6o4ucuNIB+EIvQ141gQDSjMPOET3ik82fMuJPQITex9sdpZ6cO30ALw==
-  dependencies:
-    js-base64 "^3.7.5"
-
-"@amplitude/plugin-autocapture-browser@^1.0.2":
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/@amplitude/plugin-autocapture-browser/-/plugin-autocapture-browser-1.0.4.tgz#ac1ed156c565bf6767ee7474110aa00f9ebca56c"
-  integrity sha512-+aUSsH4hRX4bWtSL90S3Irb3JctvIM+6aQ/wRSo1bYtnpXp7JQjWKzTYVxKx41b92Cb5DCBvmYgcWyg75BKi9Q==
-  dependencies:
-    "@amplitude/analytics-client-common" ">=1 <3"
-    "@amplitude/analytics-types" "^2.8.2"
-    rxjs "^7.8.1"
-    tslib "^2.4.1"
-
-"@amplitude/plugin-page-view-tracking-browser@^2.3.5":
-  version "2.3.5"
-  resolved "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.3.5.tgz#cd5bcdb7c53bb70baae1573d16ab4dc9fd8690bf"
-  integrity sha512-qcV4DLxRAZRriYBNvjc2PGW1EDad6PSsIXmxVs6j8i9fxY2SfdvsFd/Qd23CHj1e6Dt5QpAVJZpUMCEdqqDZbA==
-  dependencies:
-    "@amplitude/analytics-client-common" "^2.3.5"
-    "@amplitude/analytics-types" "^2.8.4"
-    tslib "^2.4.1"
-
 "@ampproject/remapping@^2.1.0", "@ampproject/remapping@^2.2.0":
   version "2.2.1"
   resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
@@ -1895,10 +1816,12 @@
   dependencies:
     typescript "^5.4.2"
 
-"@navikt/nav-dekoratoren-moduler@^3.1.3":
-  version "3.1.3"
-  resolved "https://npm.pkg.github.com/download/@navikt/nav-dekoratoren-moduler/3.1.3/5b4ff3c3727331eab2d8243ff96da8f8508dede0#5b4ff3c3727331eab2d8243ff96da8f8508dede0"
-  integrity sha512-gqXk5ovPBmu54voTJfJ2xlPvFMJGE+xm7aS5yGAtQHpDFD61M65C1iMyfW2SmxPPjItdl/Krht0fOXokDCmn/w==
+"@navikt/nav-dekoratoren-moduler@^3.2.0":
+  version "3.2.2"
+  resolved "https://npm.pkg.github.com/download/@navikt/nav-dekoratoren-moduler/3.2.2/75bf1d5df5211c8004befd47e840382398105403#75bf1d5df5211c8004befd47e840382398105403"
+  integrity sha512-fu/5YXJ9YLwSz8mfMLd8qxK/JAk7YS3sIj4Ub1lUbLefy2IKOYzknUjZ+4Ve1zRfYyqbZt/7cekf9CpKTgcSpw==
+  dependencies:
+    js-cookie "^3.0.5"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -7490,10 +7413,10 @@ jose@^4.15.1:
   resolved "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz#6475d0f467ecd3c630a1b5dadd2735a7288df706"
   integrity sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==
 
-js-base64@^3.7.5:
-  version "3.7.7"
-  resolved "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"
-  integrity sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==
+js-cookie@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
+  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -10796,7 +10719,7 @@ tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.5.0, tslib@^2.6.2:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-tslib@^2.4.1, tslib@^2.7.0:
+tslib@^2.7.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24165
Lik PR som for ba-soknad: https://github.com/navikt/familie-ba-soknad/pull/1508

### 💰 Hva forsøker du å løse i denne PR'en
Tar i bruk dekoratøren sin instans av Amplitude og sjekker samtykke før vi logger til Amplitude eller viser UX Signals sin widget.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingenting spesielt.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett?

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer