### PR TITLE
Skriver om SpråkContext fra constate til renskrevet react context med egen hook

### DIFF
--- a/src/frontend/context/SpråkContext.test.tsx
+++ b/src/frontend/context/SpråkContext.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { Cookies, CookiesProvider } from 'react-cookie';
+
+import '@testing-library/jest-dom';
+
+import { SpråkProvider, useSpråk } from './SpråkContext';
+
+test('Kan hente ut valgt locale fra SpråkContext som defaultes til "nb" hvis dekoratøren ikke har satt en egen', () => {
+    const Eksempelkomponent = () => {
+        const { valgtLocale } = useSpråk();
+
+        return <span>Språket er: {valgtLocale}</span>;
+    };
+    render(
+        <SpråkProvider>
+            <Eksempelkomponent />
+        </SpråkProvider>
+    );
+    expect(screen.getByText(/^Språket er:/)).toHaveTextContent('Språket er: nb');
+});
+
+test('Kan hente ut valgt locale fra SpråkContext når den er satt av dekoratøren', () => {
+    const cookies = new Cookies();
+    cookies.set('decorator-language', 'en');
+
+    const Eksempelkomponent = () => {
+        const { valgtLocale } = useSpråk();
+
+        return <span>Språket er: {valgtLocale}</span>;
+    };
+    render(
+        <CookiesProvider cookies={cookies}>
+            <SpråkProvider>
+                <Eksempelkomponent />
+            </SpråkProvider>
+        </CookiesProvider>
+    );
+    expect(screen.getByText(/^Språket er:/)).toHaveTextContent('Språket er: en');
+});

--- a/src/frontend/context/SpråkContext.tsx
+++ b/src/frontend/context/SpråkContext.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from 'react';
+import React, { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react';
 
-import createUseContext from 'constate';
 import { useCookies } from 'react-cookie';
 
 import { onLanguageSelect, setParams } from '@navikt/nav-dekoratoren-moduler';
@@ -9,17 +8,22 @@ import { erGyldigSpråk, LocaleType } from '../typer/common';
 
 const dekoratorLanguageCookieName = 'decorator-language';
 
-export const [SpråkProvider, useSpråk] = createUseContext(() => {
+interface ISpråkContext {
+    valgtLocale: LocaleType;
+}
+
+const SpråkContext = createContext<ISpråkContext | undefined>(undefined);
+
+export function SpråkProvider(props: PropsWithChildren) {
     const [cookies, setCookie] = useCookies([dekoratorLanguageCookieName]);
     const { [dekoratorLanguageCookieName]: dekoratørSpråk } = cookies;
-
     const defaultSpråk = erGyldigSpråk(dekoratørSpråk) ? dekoratørSpråk : LocaleType.nb;
-
     const [valgtLocale, settValgtLocale] = useState<LocaleType>(defaultSpråk);
 
     useEffect(() => {
-        // Bryr oss egenlig ikke om hva som skjer etterpå men intellij klager på ignorert promise
-        setParams({ language: defaultSpråk }).then();
+        if (dekoratørSpråk !== defaultSpråk) {
+            setParams({ language: defaultSpråk });
+        }
     }, []);
 
     onLanguageSelect(language => {
@@ -28,5 +32,15 @@ export const [SpråkProvider, useSpråk] = createUseContext(() => {
         setCookie(dekoratorLanguageCookieName, language.locale);
     });
 
-    return { valgtLocale };
-});
+    return <SpråkContext.Provider value={{ valgtLocale }}>{props.children}</SpråkContext.Provider>;
+}
+
+export function useSpråk() {
+    const context = useContext(SpråkContext);
+
+    if (context === undefined) {
+        throw new Error('useSpråk må brukes innenfor SpråkProvider');
+    }
+
+    return context;
+}

--- a/src/frontend/utils/testing.tsx
+++ b/src/frontend/utils/testing.tsx
@@ -24,7 +24,6 @@ import * as sanityContext from '../context/SanityContext';
 import { SanityProvider } from '../context/SanityContext';
 import { SpråkProvider } from '../context/SpråkContext';
 import { StegProvider } from '../context/StegContext';
-import { LocaleType } from '../typer/common';
 import { EFeatureToggle } from '../typer/feature-toggles';
 import { ESivilstand } from '../typer/kontrakt/generelle';
 import { IKvittering } from '../typer/kvittering';
@@ -163,12 +162,7 @@ export const wrapMedProvidere = (
     children?: ReactNode
 ) => {
     const [Første, ...resten] = providerComponents;
-    const erSpråkprovider = Første === SpråkProvider;
-    return (
-        <Første {...(erSpråkprovider ? { defaultLocale: LocaleType.nb } : {})}>
-            {resten.length ? wrapMedProvidere(resten, children) : children}
-        </Første>
-    );
+    return <Første>{resten.length ? wrapMedProvidere(resten, children) : children}</Første>;
 };
 
 const wrapMedDefaultProvidere = (children: ReactNode) =>


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Vi har brukt `constate` til å skrive contexter i React helt frem til nå. Dette biblioteket har ikke blitt oppdatert på tre år, og har ikke støtte for React v19. Skriver oss derfor vekk fra dette over til en ren context i React pluss en egen hook. `valgtLocale` hentes på nøyaktig samme måte som før. 

Jeg har tatt inspirasjon i [denne artikkelen](https://medium.com/comsystoreply/how-to-use-react-context-with-usestate-c8ae4fe72fb9) og hvordan de allerede gjør det på samme måte i [søknaden om dagpenger](https://github.com/navikt/dp-soknadsdialog/blob/main/src/context/user-info-context.tsx).

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingen store bekymringer. Men om mulig hadde det vært fint om den som ser over kan spinne opp søknaden lokalt og se at språket settes riktig og beholder riktig state gjennom søknaden.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer