### PR TITLE
Skriver RoutesContext vekk fra constate

### DIFF
--- a/src/frontend/Søknad.tsx
+++ b/src/frontend/Søknad.tsx
@@ -18,7 +18,7 @@ import Oppsummering from './components/SøknadsSteg/Oppsummering/Oppsummering';
 import VelgBarn from './components/SøknadsSteg/VelgBarn/VelgBarn';
 import { useApp } from './context/AppContext';
 import { useEøs } from './context/EøsContext';
-import { useRoutes } from './context/RoutesContext';
+import { useRoutesContext } from './context/RoutesContext';
 import { IRoute, RouteEnum } from './typer/routes';
 
 /**
@@ -45,7 +45,7 @@ const EøsForBarnWrapper: React.FC = () => {
 
 const Søknad = () => {
     const { systemetLaster } = useApp();
-    const { routes } = useRoutes();
+    const { routes } = useRoutesContext();
 
     const routeTilKomponent = (route: IRoute): React.FC => {
         switch (route.route) {

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/DinLivssituasjonOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/DinLivssituasjonOppsummering.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useApp } from '../../../../context/AppContext';
-import { useRoutes } from '../../../../context/RoutesContext';
+import { useRoutesContext } from '../../../../context/RoutesContext';
 import { PersonType } from '../../../../typer/personType';
 import { RouteEnum } from '../../../../typer/routes';
 import { ArbeidsperiodeOppsummering } from '../../../Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering';
@@ -19,7 +19,7 @@ interface Props {
 const DinLivssituasjonOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
     const { søknad, tekster } = useApp();
     const dinLivssituasjonTekster = tekster().DIN_LIVSSITUASJON;
-    const { hentRouteObjektForRouteEnum } = useRoutes();
+    const { hentRouteObjektForRouteEnum } = useRoutesContext();
     const dinLivsituasjonHook = useDinLivssituasjon();
 
     return (

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsSøkerOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/Eøs/EøsSøkerOppsummering.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../../../context/AppContext';
-import { useRoutes } from '../../../../../context/RoutesContext';
+import { useRoutesContext } from '../../../../../context/RoutesContext';
 import { LocaleRecordBlock, LocaleRecordString } from '../../../../../typer/common';
 import { PersonType } from '../../../../../typer/personType';
 import { RouteEnum } from '../../../../../typer/routes';
@@ -22,7 +22,7 @@ interface Props {
 }
 
 const EøsSøkerOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
-    const { hentRouteObjektForRouteEnum } = useRoutes();
+    const { hentRouteObjektForRouteEnum } = useRoutesContext();
     const { søknad, tekster, plainTekst } = useApp();
     const eøsSøkerTekster = tekster().EØS_FOR_SØKER;
     const { søker } = søknad;

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnaOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmBarnaOppsummering.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../../context/AppContext';
-import { useRoutes } from '../../../../context/RoutesContext';
+import { useRoutesContext } from '../../../../context/RoutesContext';
 import { barnDataKeySpørsmål } from '../../../../typer/barn';
 import { RouteEnum } from '../../../../typer/routes';
 import TekstBlock from '../../../Felleskomponenter/TekstBlock';
@@ -18,7 +18,7 @@ interface Props {
 
 const OmBarnaOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
     const { søknad, tekster } = useApp();
-    const { hentRouteObjektForRouteEnum } = useRoutes();
+    const { hentRouteObjektForRouteEnum } = useRoutesContext();
     const omBarnaTekster = tekster().OM_BARNA;
     const omBarnaDineHook = useOmBarnaDine();
 

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/OmDegOppsummering.tsx
@@ -5,7 +5,7 @@ import { Alpha3Code } from 'i18n-iso-countries';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../../context/AppContext';
-import { useRoutes } from '../../../../context/RoutesContext';
+import { useRoutesContext } from '../../../../context/RoutesContext';
 import { useSpråkContext } from '../../../../context/SpråkContext';
 import { RouteEnum } from '../../../../typer/routes';
 import { genererAdresseVisning } from '../../../../utils/adresse';
@@ -24,7 +24,7 @@ const OmDegOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
     const { søknad, tekster, plainTekst } = useApp();
     const { OM_DEG: omDegTekster, FORSIDE: forsideTekster, FELLES: fellesTekster } = tekster();
     const { valgtLocale } = useSpråkContext();
-    const { hentRouteObjektForRouteEnum } = useRoutes();
+    const { hentRouteObjektForRouteEnum } = useRoutesContext();
     const omDegHook = useOmdeg();
 
     return (

--- a/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/VelgBarnOppsummering.tsx
+++ b/src/frontend/components/SøknadsSteg/Oppsummering/OppsummeringSteg/VelgBarnOppsummering.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useApp } from '../../../../context/AppContext';
-import { useRoutes } from '../../../../context/RoutesContext';
+import { useRoutesContext } from '../../../../context/RoutesContext';
 import { RouteEnum } from '../../../../typer/routes';
 import { ESanitySteg } from '../../../../typer/sanity/sanity';
 import { hentBostedSpråkId } from '../../../../utils/språk';
@@ -19,7 +19,7 @@ const VelgBarnOppsummering: React.FC<Props> = ({ settFeilAnchors }) => {
     const { søknad, tekster, plainTekst } = useApp();
     const velgBarnTekster = tekster().VELG_BARN;
     const leggTilBarnModalTekster = tekster()[ESanitySteg.FELLES].modaler.leggTilBarn;
-    const { hentRouteObjektForRouteEnum } = useRoutes();
+    const { hentRouteObjektForRouteEnum } = useRoutesContext();
     const velgBarnHook = useVelgBarn();
     const teksterForSteg: IVelgBarnTekstinnhold = tekster()[ESanitySteg.VELG_BARN];
 

--- a/src/frontend/context/RoutesContext.test.tsx
+++ b/src/frontend/context/RoutesContext.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import '@testing-library/jest-dom';
+
+import { RouteEnum } from '../typer/routes';
+
+import { RoutesProvider, useRoutesContext } from './RoutesContext';
+
+test('Kan hente ut info om routes fra RoutesContext', () => {
+    const Eksempelkomponent = () => {
+        const { hentRouteObjektForRouteEnum } = useRoutesContext();
+
+        return (
+            <>
+                <span>
+                    Route-label: {hentRouteObjektForRouteEnum(RouteEnum.DinLivssituasjon).label}
+                </span>
+                <span>
+                    Route-path: {hentRouteObjektForRouteEnum(RouteEnum.DinLivssituasjon).path}
+                </span>
+            </>
+        );
+    };
+    render(
+        <RoutesProvider>
+            <Eksempelkomponent />
+        </RoutesProvider>
+    );
+    expect(screen.getByText(/^Route-label:/)).toHaveTextContent('Route-label: Din Livssituasjon');
+    expect(screen.getByText(/^Route-path:/)).toHaveTextContent('Route-path: /din-livssituasjon');
+});

--- a/src/frontend/context/RoutesContext.tsx
+++ b/src/frontend/context/RoutesContext.tsx
@@ -1,4 +1,4 @@
-import createUseContext from 'constate';
+import React, { createContext, PropsWithChildren, useContext } from 'react';
 
 import { RouteEnum } from '../typer/routes';
 
@@ -49,12 +49,37 @@ export const getRoutes = () => {
     ];
 };
 
-const [RoutesProvider, useRoutes] = createUseContext(() => {
+interface Route {
+    path: string;
+    label: string;
+    route: RouteEnum;
+}
+
+export interface RoutesContext {
+    routes: Array<Route>;
+    hentRouteObjektForRouteEnum: (RouteEnum) => Route;
+}
+
+const RoutesContext = createContext<RoutesContext | undefined>(undefined);
+
+export function RoutesProvider(props: PropsWithChildren) {
     const routes = getRoutes();
     const hentRouteObjektForRouteEnum = (routeEnum: RouteEnum) =>
         routes.find(route => route.route === routeEnum) ?? routes[0];
 
-    return { routes, hentRouteObjektForRouteEnum };
-});
+    return (
+        <RoutesContext.Provider value={{ routes, hentRouteObjektForRouteEnum }}>
+            {props.children}
+        </RoutesContext.Provider>
+    );
+}
 
-export { RoutesProvider, useRoutes };
+export function useRoutesContext() {
+    const context = useContext(RoutesContext);
+
+    if (context === undefined) {
+        throw new Error('useRoutesContext må brukes innenfor RoutesProvider');
+    }
+
+    return context;
+}

--- a/src/frontend/context/StegContext.tsx
+++ b/src/frontend/context/StegContext.tsx
@@ -8,13 +8,13 @@ import { ISteg, RouteEnum } from '../typer/routes';
 
 import { useApp } from './AppContext';
 import { useEøs } from './EøsContext';
-import { useRoutes } from './RoutesContext';
+import { useRoutesContext } from './RoutesContext';
 
 const [StegProvider, useSteg] = createUseContext(() => {
     const { søknad } = useApp();
     const { barnInkludertISøknaden } = søknad;
     const { pathname } = useLocation();
-    const { routes } = useRoutes();
+    const { routes } = useRoutesContext();
 
     const [barnForSteg, settBarnForSteg] = useState<IBarnMedISøknad[]>([]);
     const { barnSomTriggerEøs, søkerTriggerEøs } = useEøs();

--- a/src/frontend/utils/testing.tsx
+++ b/src/frontend/utils/testing.tsx
@@ -123,15 +123,15 @@ export const mockEøs = (barnSomTriggerEøs = [], søkerTriggerEøs = false) => 
     return { useEøs, erEøsLand };
 };
 
-export const mockRoutes = () => {
-    const useRoutes = jest.spyOn(routesContext, 'useRoutes').mockImplementation(
+export function mockRoutes() {
+    const useRoutes = jest.spyOn(routesContext, 'useRoutesContext').mockImplementation(
         jest.fn().mockReturnValue({
             routes: getRoutes(),
             hentRouteObjektForRouteEnum: jest.fn(),
         })
     );
     return { useRoutes };
-};
+}
 
 export const mockSanity = () => {
     const useSanity = jest.spyOn(sanityContext, 'useSanity').mockImplementation(


### PR DESCRIPTION
Samme endring som i SpråkContext: https://github.com/navikt/familie-ks-soknad/pull/793

### 💰 Hva forsøker du å løse i denne PR'en
Vi har brukt `constate` til å skrive contexter i React helt frem til nå. Dette biblioteket har ikke blitt oppdatert på tre år, og har ikke støtte for React v19. Skriver oss derfor vekk fra dette context for context, over til en ren context i React pluss en egen hook. Alt hentes på nøyaktig samme måte som før. 

Jeg har tatt inspirasjon i [denne artikkelen](https://medium.com/comsystoreply/how-to-use-react-context-with-usestate-c8ae4fe72fb9) og hvordan de allerede gjør det på samme måte i [søknaden om dagpenger](https://github.com/navikt/dp-soknadsdialog/blob/main/src/context/user-info-context.tsx).

#### Tl;dr om hvorfor vi gjør det på denne måten
Eneste måten vi kan bruke states i context er hvis vi oppretter de utenfor og sender de med til contexten sin provider, som gjør de tilgjengelige. En egen komponent er en ryddig måte å enkapsulere disse statene og diverse funksjoner i, men vi kunne strengt talt legge de der provideren kalles. 

Siden vi kun har mulighet til å bruke disse verdiene i komponenter wrappet i provideren er hooken som sjekker om vi har contexten satt riktig en hyggelig måte å minske feilsituasjoner. Men vi kunne jo selvsagt også brukt `useContext(RoutesContext)` direkte om vi hadde ønsket det.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingen store bekymringer.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer