### PR TITLE
Bytter til Aksel-komponent FileUpload

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@grafana/faro-web-sdk": "^1.13.3",
-    "@navikt/aksel-icons": "^6.12.0",
+    "@navikt/aksel-icons": "^7.10.0",
     "@navikt/ds-css": "^7.13.0",
     "@navikt/ds-react": "^7.13.0",
     "@navikt/familie-form-elements": "^21.0.4",

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
@@ -6,6 +6,7 @@ import { Alert, BodyShort, Heading, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureTogglesContext';
 import useFørsteRender from '../../../hooks/useFørsteRender';
 import { useSendInnSkjema } from '../../../hooks/useSendInnSkjema';
 import { Typografi } from '../../../typer/common';
@@ -22,6 +23,7 @@ import { VedleggOppsummering } from '../../Felleskomponenter/VedleggOppsummering
 import { IVedleggOppsummering } from '../../Felleskomponenter/VedleggOppsummering/vedleggOppsummering.types';
 
 import LastOppVedlegg from './LastOppVedlegg';
+import LastOppVedlegg2 from './LastOppVedlegg2';
 
 // Vedlegg er lagret 48 timer
 export const erVedleggstidspunktGyldig = (vedleggTidspunkt: string): boolean => {
@@ -31,6 +33,7 @@ export const erVedleggstidspunktGyldig = (vedleggTidspunkt: string): boolean => 
 
 const Dokumentasjon: React.FC = () => {
     const { søknad, settSøknad, innsendingStatus, tekster, plainTekst } = useApp();
+    const { toggles } = useFeatureToggles();
     const { sendInnSkjema } = useSendInnSkjema();
     const [slettaVedlegg, settSlettaVedlegg] = useState<IVedlegg[]>([]);
 
@@ -166,11 +169,21 @@ const Dokumentasjon: React.FC = () => {
                     </>
                 )}
                 {relevateDokumentasjoner.map((dokumentasjon, index) => (
-                    <LastOppVedlegg
-                        key={index}
-                        dokumentasjon={dokumentasjon}
-                        oppdaterDokumentasjon={oppdaterDokumentasjon}
-                    />
+                    <>
+                        {toggles.BRUK_NY_LAST_OPP_VEDLEGG_KOMPONENT ? (
+                            <LastOppVedlegg2
+                                key={index}
+                                dokumentasjon={dokumentasjon}
+                                oppdaterDokumentasjon={oppdaterDokumentasjon}
+                            />
+                        ) : (
+                            <LastOppVedlegg
+                                key={index}
+                                dokumentasjon={dokumentasjon}
+                                oppdaterDokumentasjon={oppdaterDokumentasjon}
+                            />
+                        )}
+                    </>
                 ))}
                 {innsendingStatus.status === RessursStatus.FEILET && <Feilside />}
             </VStack>

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg2.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg2.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+
+import { Checkbox, FormSummary, VStack } from '@navikt/ds-react';
+
+import { useApp } from '../../../context/AppContext';
+import { LocaleRecordBlock, Typografi } from '../../../typer/common';
+import {
+    dokumentasjonsbehovTilBeskrivelseSanityApiNavn,
+    dokumentasjonsbehovTilTittelSanityApiNavn,
+    IDokumentasjon,
+    IVedlegg,
+} from '../../../typer/dokumentasjon';
+import { Dokumentasjonsbehov } from '../../../typer/kontrakt/dokumentasjon';
+import { slåSammen } from '../../../utils/slåSammen';
+import TekstBlock from '../../Felleskomponenter/TekstBlock';
+
+import Filopplaster2 from './filopplaster/Filopplaster2';
+import { useFilopplaster2 } from './filopplaster/useFilopplaster2';
+
+interface Props {
+    dokumentasjon: IDokumentasjon;
+    oppdaterDokumentasjon: (
+        dokumentasjonsbehov: Dokumentasjonsbehov,
+        opplastedeVedlegg: IVedlegg[],
+        harSendtInn: boolean
+    ) => void;
+}
+
+const LastOppVedlegg2: React.FC<Props> = ({ dokumentasjon, oppdaterDokumentasjon }) => {
+    const { søknad, tekster, plainTekst } = useApp();
+
+    const dokumentasjonTekster = tekster().DOKUMENTASJON;
+
+    const { fjernAlleAvvisteFiler } = useFilopplaster2(
+        dokumentasjon,
+        oppdaterDokumentasjon,
+        dokumentasjonTekster,
+        plainTekst
+    );
+
+    const settHarSendtInnTidligere = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const huketAv = event.target.checked;
+        const vedlegg = huketAv ? [] : dokumentasjon.opplastedeVedlegg;
+        oppdaterDokumentasjon(dokumentasjon.dokumentasjonsbehov, vedlegg, huketAv);
+        if (huketAv) {
+            fjernAlleAvvisteFiler();
+        }
+    };
+
+    const tittel: LocaleRecordBlock =
+        dokumentasjonTekster[
+            dokumentasjonsbehovTilTittelSanityApiNavn(dokumentasjon.dokumentasjonsbehov)
+        ];
+
+    const barnDokumentasjonenGjelderFor = søknad.barnInkludertISøknaden.filter(barn =>
+        dokumentasjon.gjelderForBarnId.find(id => id === barn.id)
+    );
+    const barnasNavn = slåSammen(barnDokumentasjonenGjelderFor.map(barn => barn.navn));
+
+    const dokumentasjonsbeskrivelse = dokumentasjonsbehovTilBeskrivelseSanityApiNavn(
+        dokumentasjon.dokumentasjonsbehov
+    );
+
+    return (
+        <FormSummary>
+            <FormSummary.Header>
+                <FormSummary.Heading level="3">
+                    {plainTekst(tittel, { barnetsNavn: barnasNavn })}
+                </FormSummary.Heading>
+            </FormSummary.Header>
+            <VStack gap="6" paddingInline="6" paddingBlock="5 6">
+                {dokumentasjonsbeskrivelse && (
+                    <div>
+                        <TekstBlock
+                            data-testid={'dokumentasjonsbeskrivelse'}
+                            block={dokumentasjonTekster[dokumentasjonsbeskrivelse]}
+                            flettefelter={{ barnetsNavn: barnasNavn }}
+                            typografi={Typografi.BodyLong}
+                        />
+                    </div>
+                )}
+
+                {dokumentasjon.dokumentasjonsbehov !== Dokumentasjonsbehov.ANNEN_DOKUMENTASJON && (
+                    <Checkbox
+                        data-testid={'dokumentasjon-er-sendt-inn-checkboks'}
+                        aria-label={`${plainTekst(
+                            dokumentasjonTekster.sendtInnTidligere
+                        )} (${plainTekst(tittel, { barnetsNavn: barnasNavn })})`}
+                        checked={dokumentasjon.harSendtInn}
+                        onChange={settHarSendtInnTidligere}
+                    >
+                        {plainTekst(dokumentasjonTekster.sendtInnTidligere)}
+                    </Checkbox>
+                )}
+
+                {!dokumentasjon.harSendtInn && (
+                    <Filopplaster2
+                        dokumentasjon={dokumentasjon}
+                        oppdaterDokumentasjon={oppdaterDokumentasjon}
+                    />
+                )}
+            </VStack>
+        </FormSummary>
+    );
+};
+
+export default LastOppVedlegg2;

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/Filopplaster2.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/Filopplaster2.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+
+import { FileUpload, Heading, List, VStack } from '@navikt/ds-react';
+
+import { useApp } from '../../../../context/AppContext';
+import { IDokumentasjon, IVedlegg } from '../../../../typer/dokumentasjon';
+import { Dokumentasjonsbehov } from '../../../../typer/kontrakt/dokumentasjon';
+import { uppercaseFørsteBokstav } from '../../../../utils/visning';
+
+import { ECustomFileRejectionReasons, useFilopplaster2 } from './useFilopplaster2';
+
+interface IFilopplasterProps {
+    dokumentasjon: IDokumentasjon;
+    oppdaterDokumentasjon: (
+        dokumentasjonsBehov: Dokumentasjonsbehov,
+        opplastedeVedlegg: IVedlegg[],
+        harSendtInn: boolean
+    ) => void;
+}
+
+const Filopplaster2: React.FC<IFilopplasterProps> = ({ dokumentasjon, oppdaterDokumentasjon }) => {
+    const { tekster, plainTekst } = useApp();
+
+    const dokumentasjonTekster = tekster().DOKUMENTASJON;
+    const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
+
+    const {
+        filerUnderOpplastning,
+        avvisteFiler,
+        MAKS_FILSTØRRELSE_MB,
+        MAKS_FILSTØRRELSE_BYTES,
+        MAKS_ANTALL_FILER,
+        STØTTEDE_FILTYPER,
+        feilmeldinger,
+        leggTilVedlegg,
+        fjernVedlegg,
+        fjernAvvistFil,
+        prøvOpplastingAvAvvistFilPåNytt,
+    } = useFilopplaster2(dokumentasjon, oppdaterDokumentasjon, dokumentasjonTekster, plainTekst);
+
+    return (
+        <FileUpload
+            translations={{
+                dropzone: {
+                    button: plainTekst(dokumentasjonTekster.velgFil),
+                    buttonMultiple: plainTekst(dokumentasjonTekster.velgFiler),
+                    dragAndDrop: plainTekst(dokumentasjonTekster.draOgSlippFilenHer),
+                    dragAndDropMultiple: plainTekst(dokumentasjonTekster.draOgSlippFilerHer),
+                    drop: uppercaseFørsteBokstav(plainTekst(frittståendeOrdTekster.slipp)),
+                    or: plainTekst(frittståendeOrdTekster.eller),
+                    disabled: plainTekst(
+                        filerUnderOpplastning.length > 0
+                            ? dokumentasjonTekster.filopplastingDeaktivertFilerErUnderOpplastning
+                            : dokumentasjonTekster.filopplastingDeaktivert
+                    ),
+                    disabledFilelimit: plainTekst(
+                        dokumentasjonTekster.filopplastingDeaktivertMaksAntallFiler
+                    ),
+                },
+                item: {
+                    retryButtonTitle: plainTekst(dokumentasjonTekster.lastOppFilenPaNytt),
+                    deleteButtonTitle: plainTekst(dokumentasjonTekster.slettFilen),
+                    uploading: plainTekst(dokumentasjonTekster.lasterOpp),
+                    downloading: plainTekst(dokumentasjonTekster.lasterNed),
+                },
+            }}
+        >
+            <VStack gap="6">
+                <FileUpload.Dropzone
+                    label={plainTekst(dokumentasjonTekster.lastOppFiler)}
+                    description={
+                        <List as="ul" size="small">
+                            <List.Item>{`${plainTekst(dokumentasjonTekster.stottedeFiltyper)} ${STØTTEDE_FILTYPER.join(' ')}`}</List.Item>
+                            <List.Item>{`${plainTekst(dokumentasjonTekster.maksFilstorrelse)} ${MAKS_FILSTØRRELSE_MB} MB`}</List.Item>
+                            <List.Item>{`${plainTekst(dokumentasjonTekster.maksAntallFiler)} ${MAKS_ANTALL_FILER}`}</List.Item>
+                        </List>
+                    }
+                    accept={STØTTEDE_FILTYPER.join(',')}
+                    maxSizeInBytes={MAKS_FILSTØRRELSE_BYTES}
+                    fileLimit={{
+                        max: MAKS_ANTALL_FILER,
+                        current: dokumentasjon.opplastedeVedlegg.length,
+                    }}
+                    // Dersom disabled blir satt til false her vil dette overskrive disabled-staten som blir satt av "fileLimit" prop-en. Derfor settes den til undefined slik at "fileLimit" fungerer som forventet.
+                    disabled={filerUnderOpplastning.length > 0 ? true : undefined}
+                    onSelect={nyeFiler => leggTilVedlegg(nyeFiler)}
+                />
+
+                {(dokumentasjon.opplastedeVedlegg.length > 0 ||
+                    filerUnderOpplastning.length > 0) && (
+                    <VStack gap="2">
+                        <Heading level="4" size="xsmall">
+                            {`${plainTekst(frittståendeOrdTekster.vedlegg)} (${dokumentasjon.opplastedeVedlegg.length + filerUnderOpplastning.length})`}
+                        </Heading>
+                        <VStack as="ul" gap="3">
+                            {dokumentasjon.opplastedeVedlegg.map((opplastetVedlegg, index) => (
+                                <FileUpload.Item
+                                    as="li"
+                                    key={index}
+                                    file={{
+                                        name: opplastetVedlegg.navn,
+                                        size: opplastetVedlegg.størrelse,
+                                    }}
+                                    button={{
+                                        action: 'delete',
+                                        onClick: () => fjernVedlegg(opplastetVedlegg),
+                                    }}
+                                />
+                            ))}
+                            {filerUnderOpplastning.map((filUnderOpplastning, index) => (
+                                <FileUpload.Item
+                                    as="li"
+                                    key={index}
+                                    file={{
+                                        name: filUnderOpplastning.file.name,
+                                        size: filUnderOpplastning.file.size,
+                                    }}
+                                    status="uploading"
+                                />
+                            ))}
+                        </VStack>
+                    </VStack>
+                )}
+
+                {avvisteFiler.length > 0 && (
+                    <VStack gap="2">
+                        <Heading level="4" size="xsmall">
+                            {`${plainTekst(frittståendeOrdTekster.vedleggMedFeil)} (${avvisteFiler.length})`}
+                        </Heading>
+                        <VStack as="ul" gap="3">
+                            {avvisteFiler.map((fil, index) => (
+                                <FileUpload.Item
+                                    as="li"
+                                    key={index}
+                                    file={{
+                                        name: fil.file.name,
+                                        size: fil.file.size,
+                                    }}
+                                    error={feilmeldinger[fil.reasons[0]]}
+                                    button={
+                                        fil.reasons[0] === ECustomFileRejectionReasons.UKJENT_FEIL
+                                            ? {
+                                                  action: 'retry',
+                                                  onClick: () =>
+                                                      prøvOpplastingAvAvvistFilPåNytt(fil),
+                                              }
+                                            : {
+                                                  action: 'delete',
+                                                  onClick: () => fjernAvvistFil(fil),
+                                              }
+                                    }
+                                />
+                            ))}
+                        </VStack>
+                    </VStack>
+                )}
+            </VStack>
+        </FileUpload>
+    );
+};
+
+export default Filopplaster2;

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/useFilopplaster2.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/filopplaster/useFilopplaster2.tsx
@@ -1,0 +1,248 @@
+import { useState } from 'react';
+
+import axios from 'axios';
+
+import {
+    type FileAccepted,
+    type FileObject,
+    type FileRejected,
+    type FileRejectionReason,
+} from '@navikt/ds-react';
+
+import Miljø from '../../../../../shared-utils/Miljø';
+import { EFiltyper, IDokumentasjon, IVedlegg } from '../../../../typer/dokumentasjon';
+import { Dokumentasjonsbehov } from '../../../../typer/kontrakt/dokumentasjon';
+import { PlainTekst } from '../../../../typer/kontrakt/generelle';
+import { IDokumentasjonTekstinnhold } from '../innholdTyper';
+
+interface OpplastetVedlegg {
+    dokumentId: string;
+    filnavn: string;
+}
+
+export enum EStandardFileRejectionReasons {
+    FIL_TYPE = 'fileType',
+    FIL_STØRRELSE_FOR_STOR = 'fileSize',
+}
+
+export enum ECustomFileRejectionReasons {
+    FIL_DIMENSJONER_FOR_LITEN = 'filDimensjonerForLiten',
+    MAKS_ANTALL_FILER_NÅDD = 'maksAntallFilerNådd',
+    UKJENT_FEIL = 'ukjentFeil',
+}
+
+const filtrerFiler = (
+    filer: FileObject[],
+    antallEksisterendeFiler: number,
+    maksAntallFiler: number
+): { aksepterteFiler: FileAccepted[]; feilendeFiler: FileRejected[] } => {
+    const filerUtenFeil: FileAccepted[] = filer.filter(file => !file.error);
+    const filerMedFeil: FileRejected[] = filer.filter(file => file.error);
+
+    const ikkeForMangeFiler = antallEksisterendeFiler + filerUtenFeil.length <= maksAntallFiler;
+
+    if (ikkeForMangeFiler) {
+        return { aksepterteFiler: filerUtenFeil, feilendeFiler: filerMedFeil };
+    } else {
+        const ledigePlasser = maksAntallFiler - antallEksisterendeFiler;
+
+        const aksepterteFiler = filerUtenFeil.slice(0, ledigePlasser);
+
+        const filerOverMaksAntall = filerUtenFeil.slice(aksepterteFiler.length);
+        const filerOverMaksAntallMedFeil: FileRejected[] = filerOverMaksAntall.map(fil => ({
+            file: fil.file,
+            error: true,
+            reasons: [ECustomFileRejectionReasons.MAKS_ANTALL_FILER_NÅDD],
+        }));
+
+        const feilendeFiler = [...filerMedFeil, ...filerOverMaksAntallMedFeil];
+
+        return { aksepterteFiler, feilendeFiler };
+    }
+};
+
+enum BadRequestCode {
+    IMAGE_TOO_LARGE = 'IMAGE_TOO_LARGE',
+    IMAGE_DIMENSIONS_TOO_SMALL = 'IMAGE_DIMENSIONS_TOO_SMALL',
+    INVALID_DOCUMENT_FORMAT = 'INVALID_DOCUMENT_FORMAT',
+}
+
+// Meldingsfeltet på respons ved BadRequest inneholder tekst på følgende format: CODE=ENUM_NAVN
+const badRequestCodeFraError = (error): BadRequestCode | undefined => {
+    const melding = error.response?.data?.melding;
+    if (melding) {
+        return BadRequestCode[melding.split('=')[1]];
+    }
+    return;
+};
+
+const feilmeldingFraError = (error): string => {
+    const badRequestCode = badRequestCodeFraError(error);
+    switch (badRequestCode) {
+        case BadRequestCode.IMAGE_DIMENSIONS_TOO_SMALL:
+            return ECustomFileRejectionReasons.FIL_DIMENSJONER_FOR_LITEN;
+        case BadRequestCode.IMAGE_TOO_LARGE:
+            return EStandardFileRejectionReasons.FIL_STØRRELSE_FOR_STOR;
+        case BadRequestCode.INVALID_DOCUMENT_FORMAT:
+            return EStandardFileRejectionReasons.FIL_TYPE;
+        default:
+            return ECustomFileRejectionReasons.UKJENT_FEIL;
+    }
+};
+
+export const useFilopplaster2 = (
+    dokumentasjon: IDokumentasjon,
+    oppdaterDokumentasjon: (
+        dokumentasjonsBehov: Dokumentasjonsbehov,
+        opplastedeVedlegg: IVedlegg[],
+        harSendtInn: boolean
+    ) => void,
+    dokumentasjonTekster: IDokumentasjonTekstinnhold,
+    plainTekst: PlainTekst
+) => {
+    const [filerUnderOpplastning, setFilerUnderOpplastning] = useState<FileObject[]>([]);
+    const [avvisteFiler, setAvvsiteFiler] = useState<FileRejected[]>([]);
+
+    const MAKS_FILSTØRRELSE_MB = 10;
+    const MAKS_FILSTØRRELSE_BYTES = MAKS_FILSTØRRELSE_MB * 1024 * 1024;
+    const MAKS_ANTALL_FILER = 25;
+    const STØTTEDE_FILTYPER = [EFiltyper.PNG, EFiltyper.JPG, EFiltyper.JPEG, EFiltyper.PDF];
+
+    const feilmeldinger: Record<FileRejectionReason | ECustomFileRejectionReasons, string> = {
+        [EStandardFileRejectionReasons.FIL_TYPE]: plainTekst(
+            dokumentasjonTekster.filtypeFeilmelding
+        ),
+        [EStandardFileRejectionReasons.FIL_STØRRELSE_FOR_STOR]: `${plainTekst(dokumentasjonTekster.filstorrelseFeilmelding)} ${MAKS_FILSTØRRELSE_MB} MB`,
+        [ECustomFileRejectionReasons.FIL_DIMENSJONER_FOR_LITEN]: plainTekst(
+            dokumentasjonTekster.bildetForLite
+        ),
+        [ECustomFileRejectionReasons.MAKS_ANTALL_FILER_NÅDD]: `${plainTekst(dokumentasjonTekster.antallFilerFeilmelding)} ${MAKS_ANTALL_FILER}`,
+        [ECustomFileRejectionReasons.UKJENT_FEIL]: plainTekst(
+            dokumentasjonTekster.ukjentFeilmelding
+        ),
+    };
+
+    const dagensDatoStreng = new Date().toISOString();
+
+    const leggTilVedlegg = async (nyeFiler: FileObject[]) => {
+        const { aksepterteFiler, feilendeFiler } = filtrerFiler(
+            nyeFiler,
+            dokumentasjon.opplastedeVedlegg.length,
+            MAKS_ANTALL_FILER
+        );
+
+        if (feilendeFiler.length > 0) {
+            setAvvsiteFiler(eksisterendeAvvisteFiler => [
+                ...eksisterendeAvvisteFiler,
+                ...feilendeFiler,
+            ]);
+        }
+
+        if (aksepterteFiler.length > 0) {
+            setFilerUnderOpplastning(aksepterteFiler);
+
+            const aksepterteVedlegg: IVedlegg[] = [];
+            const feilendeVedlegg: FileRejected[] = [];
+
+            await Promise.all(
+                aksepterteFiler.map((fil: FileAccepted) => {
+                    const requestData = new FormData();
+                    requestData.append('file', fil.file);
+
+                    return axios
+                        .post<OpplastetVedlegg>(
+                            `${Miljø().dokumentProxyUrl}/mapper/familievedlegg`,
+                            requestData,
+                            {
+                                withCredentials: true,
+                                headers: {
+                                    'content-type': 'multipart/form-data',
+                                    accept: 'application/json',
+                                },
+                            }
+                        )
+                        .then((response: { data: OpplastetVedlegg }) => {
+                            const { data } = response;
+                            const nyttVedlegg: IVedlegg = {
+                                dokumentId: data.dokumentId,
+                                navn: fil.file.name,
+                                størrelse: fil.file.size,
+                                tidspunkt: dagensDatoStreng,
+                            };
+                            aksepterteVedlegg.push(nyttVedlegg);
+                        })
+                        .catch(error => {
+                            const filMedFeil: FileRejected = {
+                                file: fil.file,
+                                error: true,
+                                reasons: [feilmeldingFraError(error)],
+                            };
+                            feilendeVedlegg.push(filMedFeil);
+                        });
+                })
+            );
+
+            if (aksepterteVedlegg.length > 0) {
+                oppdaterDokumentasjon(
+                    dokumentasjon.dokumentasjonsbehov,
+                    [...dokumentasjon.opplastedeVedlegg, ...aksepterteVedlegg],
+                    dokumentasjon.harSendtInn
+                );
+            }
+
+            if (feilendeVedlegg.length > 0) {
+                setAvvsiteFiler(eksisterendeAvvisteFiler => [
+                    ...eksisterendeAvvisteFiler,
+                    ...feilendeVedlegg,
+                ]);
+            }
+
+            setFilerUnderOpplastning([]);
+        }
+    };
+
+    const fjernVedlegg = (vedleggSomSkalFjernes: IVedlegg) => {
+        const nyVedleggsliste = dokumentasjon.opplastedeVedlegg.filter(
+            (eksisterendeVedlegg: IVedlegg) =>
+                eksisterendeVedlegg.dokumentId !== vedleggSomSkalFjernes.dokumentId
+        );
+
+        oppdaterDokumentasjon(
+            dokumentasjon.dokumentasjonsbehov,
+            nyVedleggsliste,
+            dokumentasjon.harSendtInn
+        );
+    };
+
+    const fjernAvvistFil = (fil: FileRejected) => {
+        setAvvsiteFiler(avvisteFiler.filter(file => file !== fil));
+    };
+
+    const fjernAlleAvvisteFiler = () => {
+        setAvvsiteFiler([]);
+    };
+
+    const prøvOpplastingAvAvvistFilPåNytt = (fil: FileRejected) => {
+        fjernAvvistFil(fil);
+        const filUtenFeil: FileAccepted = {
+            file: fil.file,
+            error: false,
+        };
+        leggTilVedlegg([filUtenFeil]);
+    };
+
+    return {
+        filerUnderOpplastning,
+        avvisteFiler,
+        MAKS_FILSTØRRELSE_MB,
+        MAKS_FILSTØRRELSE_BYTES,
+        MAKS_ANTALL_FILER,
+        STØTTEDE_FILTYPER,
+        feilmeldinger,
+        leggTilVedlegg,
+        fjernVedlegg,
+        fjernAvvistFil,
+        fjernAlleAvvisteFiler,
+        prøvOpplastingAvAvvistFilPåNytt,
+    };
+};

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/innholdTyper.ts
@@ -43,6 +43,25 @@ export type IDokumentasjonTekstinnhold = {
     lastOppKnapp: LocaleRecordString;
     slippFilenHer: LocaleRecordString;
     slett: LocaleRecordString;
+    stottedeFiltyper: LocaleRecordString;
+    maksFilstorrelse: LocaleRecordString;
+    maksAntallFiler: LocaleRecordString;
+    lastOppFiler: LocaleRecordString;
+    filtypeFeilmelding: LocaleRecordString;
+    filstorrelseFeilmelding: LocaleRecordString;
+    antallFilerFeilmelding: LocaleRecordString;
+    ukjentFeilmelding: LocaleRecordString;
+    velgFil: LocaleRecordString;
+    velgFiler: LocaleRecordString;
+    draOgSlippFilenHer: LocaleRecordString;
+    draOgSlippFilerHer: LocaleRecordString;
+    filopplastingDeaktivert: LocaleRecordString;
+    filopplastingDeaktivertFilerErUnderOpplastning: LocaleRecordString;
+    filopplastingDeaktivertMaksAntallFiler: LocaleRecordString;
+    lastOppFilenPaNytt: LocaleRecordString;
+    slettFilen: LocaleRecordString;
+    lasterNed: LocaleRecordString;
+    lasterOpp: LocaleRecordString;
 } & {
     // Vedlegg - titler
     [TittelSanityApiNavn.avtaleOmDeltBostedTittel]: LocaleRecordBlock;

--- a/src/frontend/typer/feature-toggles.ts
+++ b/src/frontend/typer/feature-toggles.ts
@@ -6,6 +6,7 @@ export enum EFeatureToggle {
     // EKSEMPEL = 'EKSEMPEL',
     FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP = 'FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP',
     BRUK_NYTT_ENDEPUNKT_FOR_INNSENDING_AV_SOKNAD = 'BRUK_NYTT_ENDEPUNKT_FOR_INNSENDING_AV_SOKNAD',
+    BRUK_NY_LAST_OPP_VEDLEGG_KOMPONENT = 'BRUK_NY_LAST_OPP_VEDLEGG_KOMPONENT',
 }
 
 export const ToggleKeys: Record<EFeatureToggle, string> = {
@@ -14,6 +15,8 @@ export const ToggleKeys: Record<EFeatureToggle, string> = {
         'familie-ks-soknad.forklarende-tekster-over-legg-til-knapp',
     [EFeatureToggle.BRUK_NYTT_ENDEPUNKT_FOR_INNSENDING_AV_SOKNAD]:
         'familie-ks-soknad.bruk_nytt_endepunkt_for_innsending_av_soknad',
+    [EFeatureToggle.BRUK_NY_LAST_OPP_VEDLEGG_KOMPONENT]:
+        'familie-ba-soknad.bruk-ny-last-opp-vedlegg-komponent',
 };
 
 export type EAllFeatureToggles = Record<EFeatureToggle, boolean>;

--- a/src/frontend/typer/feature-toggles.ts
+++ b/src/frontend/typer/feature-toggles.ts
@@ -16,7 +16,7 @@ export const ToggleKeys: Record<EFeatureToggle, string> = {
     [EFeatureToggle.BRUK_NYTT_ENDEPUNKT_FOR_INNSENDING_AV_SOKNAD]:
         'familie-ks-soknad.bruk_nytt_endepunkt_for_innsending_av_soknad',
     [EFeatureToggle.BRUK_NY_LAST_OPP_VEDLEGG_KOMPONENT]:
-        'familie-ba-soknad.bruk-ny-last-opp-vedlegg-komponent',
+        'familie-ks-soknad.bruk-ny-last-opp-vedlegg-komponent',
 };
 
 export type EAllFeatureToggles = Record<EFeatureToggle, boolean>;

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -125,6 +125,7 @@ export interface IFrittståendeOrdTekstinnhold {
     jegVetIkke: LocaleRecordString;
     av: LocaleRecordString;
     vedlegg: LocaleRecordString;
+    vedleggMedFeil: LocaleRecordString;
     barn: LocaleRecordString;
     soeker: LocaleRecordString;
     skjult: LocaleRecordString;
@@ -138,6 +139,8 @@ export interface IFrittståendeOrdTekstinnhold {
     utbetalingsperioder: LocaleRecordString;
     kontantstoetteperioder: LocaleRecordString;
     barnehageplassperioder: LocaleRecordString;
+    slipp: LocaleRecordString;
+    eller: LocaleRecordString;
 }
 
 export interface INavigasjonTekstinnhold {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1823,10 +1823,10 @@
   resolved "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@navikt/aksel-icons@^6.12.0":
-  version "6.13.0"
-  resolved "https://npm.pkg.github.com/download/@navikt/aksel-icons/6.13.0/7378bad8c8230187b30a9e0b15675f7740dc96cf#7378bad8c8230187b30a9e0b15675f7740dc96cf"
-  integrity sha512-vmH1fXIijjPTiTBu02euPdEmBQPfoVrDdfHea246D6Sblg6tMXDI6pjPGfV0ojCOMOYSH1wrCnY2pPk3zfqnGQ==
+"@navikt/aksel-icons@^7.10.0":
+  version "7.17.4"
+  resolved "https://npm.pkg.github.com/download/@navikt/aksel-icons/7.17.4/294d943be11babbbeab9272c2de5c90a22585862#294d943be11babbbeab9272c2de5c90a22585862"
+  integrity sha512-RyKgnSO34azlwyC1ujApV3u67r2HfXmQ6e9QcPbrxaQP/E/AAlFWNotmuKT0NL34Mm5nNBfA2dPl8LiBt++hSg==
 
 "@navikt/aksel-icons@^7.13.0":
   version "7.13.0"


### PR DESCRIPTION
Favro: [NAV-20221](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-20221)
Aksel-komponent: [FileUpload](https://aksel.nav.no/komponenter/core/fileupload)
Unleash toggle: [familie-ks-soknad.bruk-ny-last-opp-vedlegg-komponent](https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ks-soknad.bruk-ny-last-opp-vedlegg-komponent)
Samme oppgave er gjort i BA: https://github.com/navikt/familie-ba-soknad/pull/1537

### 💰 Hva forsøker du å løse i denne PR'en
- Bytter fra å bruke en egen komponent til å laste opp filer, til å bruke Aksel sin FileUpload komponent.
- Legger til Sanity tekster knyttet til den nye løsningen.
- Legger til toggle for å bytte mellom gammel og ny løsning.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
- Det er viktig at den nye løsningen testes godt før den tas i bruk i prod. Ikke skru på toggle i prod før den er testet og godkjent av funksjonell test.

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Jeg er usikker på om skrevne tester vil fungere bra for å teste funksjonalitet av komponenten.
 
### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett.
- Test følgende:
  - Trykk på dropzone feltet og velg filer som skal lastes opp.
  ![image](https://github.com/user-attachments/assets/bc6bb285-7b7e-4a5a-ab04-ef93a27060d8)
    - Kun gyldige fil-typer (`.png`, `.jpg`, `.jpeg`, `.pdf`) skal være mulig å velge i fil-velgeren som åpnes.
    ![image](https://github.com/user-attachments/assets/1a608a18-cdff-4751-b4b6-ecbe2ffdc2a4)
  - Dra og slipp filer i dropzone feltet.
    - Alle fil-typer kan slippes i dropzone feltet.
    - Fil-typer som ikke støttes og filer med andre feil vil legges under "Vedlegg med feil".
    ![image](https://github.com/user-attachments/assets/71bf8ca3-1199-463d-96f7-7c7e35736bd1)
  - Velg filer som er for store. Maksgrensen på én fil er 10mb. Det skal føre til følgende feil:
  ![image](https://github.com/user-attachments/assets/49e129ad-805f-47fd-8804-37e9b4d805bf)
  - Velg filer som har for små dimensjoner. Minimum dimensjoner på én fil er 400x400px. Det skal føre til følgende feil:
  ![image](https://github.com/user-attachments/assets/28e5fc20-e2e5-4d82-8bc3-d212ab64ff3b)
  - Velg for mange filer. Maks er 25 filer. Det skal føre til følgende feil:
  ![image](https://github.com/user-attachments/assets/57a3f98d-b313-4ab3-9f6d-79a9bd52092a)
  - Blokker nettverkskall slik at det oppstår en feil under opplastingen av de neste filene du velger.
  ![image](https://github.com/user-attachments/assets/a380552c-c67f-49fb-89ad-373d50e5ad34)
  Det skal føre til følgende feil:
  ![image](https://github.com/user-attachments/assets/04bf12ff-42d4-49f1-aebb-bdc73ac1180b)
  Deretter fjern blokkeringen og trykk på "retry" knappen slik at vedlegget lastes opp på nytt. Det skal føre til at filen ligger under "vedlegg":
  ![image](https://github.com/user-attachments/assets/f9760d79-6a6c-4c3b-b6c5-3cff0a6400f2)

### 💬 Ønsker du en muntlig gjennomgang?
- [x] Ja
- [ ] Nei
  
### 👀 Screen shots
#### Før
![image](https://github.com/user-attachments/assets/fdd2c0d6-18a9-4e00-b676-145b5154be73)
#### Etter
![image](https://github.com/user-attachments/assets/0c23c14e-d570-4114-8134-ca13dbf1cd68)
#### Før - mens filer er under opplastning
Skjermen blir blurry og brukeren kan ikke gjøre noe annet enn å vente.
![image](https://github.com/user-attachments/assets/76039cb5-d769-4fc1-bb34-ee5c6b594e9c)
#### Etter - mens filer er under opplastning
"Laster opp" status legges til på filer under opplastning mens brukeren kan gjøre andre ting i mellomtiden.
![image](https://github.com/user-attachments/assets/0d061dd2-a5da-49de-936e-c6ae16704f7a)