### PR TITLE
Spør kun om måned hvor spesifikk dato ikke er nødvendig

### DIFF
--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeModal.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeModal.tsx
@@ -167,7 +167,7 @@ export const ArbeidsperiodeModal: React.FC<ArbeidsperiodeModalProps> = ({
                         />
                     )}
                     {tilDatoArbeidsperiode.erSynlig && (
-                        <>
+                        <div>
                             <MånedÅrVelger
                                 felt={skjema.felter.tilDatoArbeidsperiode}
                                 label={
@@ -198,7 +198,7 @@ export const ArbeidsperiodeModal: React.FC<ArbeidsperiodeModalProps> = ({
                                 felt={skjema.felter.tilDatoArbeidsperiodeUkjent}
                                 label={plainTekst(teksterForModal.sluttdatoFremtid.checkboxLabel)}
                             />
-                        </>
+                        </div>
                     )}
                 </>
             ) : (
@@ -212,7 +212,7 @@ export const ArbeidsperiodeModal: React.FC<ArbeidsperiodeModalProps> = ({
                         />
                     )}
                     {tilDatoArbeidsperiode.erSynlig && (
-                        <>
+                        <div>
                             <Datovelger
                                 felt={skjema.felter.tilDatoArbeidsperiode}
                                 skjema={skjema}
@@ -239,7 +239,7 @@ export const ArbeidsperiodeModal: React.FC<ArbeidsperiodeModalProps> = ({
                                 felt={skjema.felter.tilDatoArbeidsperiodeUkjent}
                                 label={plainTekst(teksterForModal.sluttdatoFremtid.checkboxLabel)}
                             />
-                        </>
+                        </div>
                     )}
                 </>
             )}

--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeModal.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeModal.tsx
@@ -3,17 +3,20 @@ import React from 'react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureTogglesContext';
 import { IBarnMedISøknad } from '../../../typer/barn';
+import { EFeatureToggle } from '../../../typer/feature-toggles';
 import { IArbeidsperiode } from '../../../typer/perioder';
 import { PersonType } from '../../../typer/personType';
 import { IArbeidsperiodeTekstinnhold } from '../../../typer/sanity/modaler/arbeidsperiode';
-import { dagensDato, gårsdagensDato } from '../../../utils/dato';
+import { dagensDato, gårsdagensDato, sisteDagDenneMåneden } from '../../../utils/dato';
 import { trimWhiteSpace, visFeiloppsummering } from '../../../utils/hjelpefunksjoner';
 import { minTilDatoForUtbetalingEllerArbeidsperiode } from '../../../utils/perioder';
 import { svarForSpørsmålMedUkjent } from '../../../utils/spørsmål';
 import Datovelger from '../Datovelger/Datovelger';
 import { LandDropdown } from '../Dropdowns/LandDropdown';
 import JaNeiSpm from '../JaNeiSpm/JaNeiSpm';
+import { DagIMåneden, MånedÅrVelger } from '../MånedÅrVelger/MånedÅrVelger';
 import { SkjemaCheckbox } from '../SkjemaCheckbox/SkjemaCheckbox';
 import { SkjemaFeiloppsummering } from '../SkjemaFeiloppsummering/SkjemaFeiloppsummering';
 import { SkjemaFeltInput } from '../SkjemaFeltInput/SkjemaFeltInput';
@@ -42,6 +45,7 @@ export const ArbeidsperiodeModal: React.FC<ArbeidsperiodeModalProps> = ({
     barn,
     forklaring = undefined,
 }) => {
+    const { toggles } = useFeatureToggles();
     const { tekster, plainTekst } = useApp();
     const { skjema, valideringErOk, nullstillSkjema, validerFelterOgVisFeilmelding } =
         useArbeidsperiodeSkjema(gjelderUtlandet, personType, erDød);
@@ -147,40 +151,96 @@ export const ArbeidsperiodeModal: React.FC<ArbeidsperiodeModalProps> = ({
                     label={<TekstBlock block={teksterForModal.arbeidsgiver.sporsmal} />}
                 />
             )}
-            {fraDatoArbeidsperiode.erSynlig && (
-                <Datovelger
-                    felt={skjema.felter.fraDatoArbeidsperiode}
-                    skjema={skjema}
-                    label={<TekstBlock block={teksterForModal.startdato.sporsmal} />}
-                    avgrensMaxDato={periodenErAvsluttet ? gårsdagensDato() : dagensDato()}
-                />
-            )}
-            {tilDatoArbeidsperiode.erSynlig && (
+
+            {toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO] ? (
                 <>
-                    <Datovelger
-                        felt={skjema.felter.tilDatoArbeidsperiode}
-                        skjema={skjema}
-                        label={
-                            <TekstBlock
-                                block={
-                                    periodenErAvsluttet
-                                        ? teksterForModal.sluttdatoFortid.sporsmal
-                                        : teksterForModal.sluttdatoFremtid.sporsmal
+                    {fraDatoArbeidsperiode.erSynlig && (
+                        <MånedÅrVelger
+                            felt={skjema.felter.fraDatoArbeidsperiode}
+                            label={<TekstBlock block={teksterForModal.startdato.sporsmal} />}
+                            senesteValgbareMåned={
+                                periodenErAvsluttet ? gårsdagensDato() : dagensDato()
+                            }
+                            visFeilmeldinger={skjema.visFeilmeldinger}
+                            dagIMåneden={DagIMåneden.FØRSTE_DAG}
+                            kanIkkeVæreFremtid={true}
+                        />
+                    )}
+                    {tilDatoArbeidsperiode.erSynlig && (
+                        <>
+                            <MånedÅrVelger
+                                felt={skjema.felter.tilDatoArbeidsperiode}
+                                label={
+                                    <TekstBlock
+                                        block={
+                                            periodenErAvsluttet
+                                                ? teksterForModal.sluttdatoFortid.sporsmal
+                                                : teksterForModal.sluttdatoFremtid.sporsmal
+                                        }
+                                    />
+                                }
+                                tidligsteValgbareMåned={minTilDatoForUtbetalingEllerArbeidsperiode(
+                                    periodenErAvsluttet,
+                                    skjema.felter.fraDatoArbeidsperiode.verdi
+                                )}
+                                senesteValgbareMåned={
+                                    periodenErAvsluttet ? sisteDagDenneMåneden() : undefined
+                                }
+                                dagIMåneden={DagIMåneden.SISTE_DAG}
+                                kanIkkeVæreFremtid={periodenErAvsluttet}
+                                kanIkkeVæreFortid={!periodenErAvsluttet}
+                                disabled={
+                                    skjema.felter.tilDatoArbeidsperiodeUkjent.verdi === ESvar.JA
                                 }
                             />
-                        }
-                        avgrensMinDato={minTilDatoForUtbetalingEllerArbeidsperiode(
-                            periodenErAvsluttet,
-                            skjema.felter.fraDatoArbeidsperiode.verdi
-                        )}
-                        avgrensMaxDato={periodenErAvsluttet ? dagensDato() : undefined}
-                        disabled={skjema.felter.tilDatoArbeidsperiodeUkjent.verdi === ESvar.JA}
-                    />
 
-                    <SkjemaCheckbox
-                        felt={skjema.felter.tilDatoArbeidsperiodeUkjent}
-                        label={plainTekst(teksterForModal.sluttdatoFremtid.checkboxLabel)}
-                    />
+                            <SkjemaCheckbox
+                                felt={skjema.felter.tilDatoArbeidsperiodeUkjent}
+                                label={plainTekst(teksterForModal.sluttdatoFremtid.checkboxLabel)}
+                            />
+                        </>
+                    )}
+                </>
+            ) : (
+                <>
+                    {fraDatoArbeidsperiode.erSynlig && (
+                        <Datovelger
+                            felt={skjema.felter.fraDatoArbeidsperiode}
+                            skjema={skjema}
+                            label={<TekstBlock block={teksterForModal.startdato.sporsmal} />}
+                            avgrensMaxDato={periodenErAvsluttet ? gårsdagensDato() : dagensDato()}
+                        />
+                    )}
+                    {tilDatoArbeidsperiode.erSynlig && (
+                        <>
+                            <Datovelger
+                                felt={skjema.felter.tilDatoArbeidsperiode}
+                                skjema={skjema}
+                                label={
+                                    <TekstBlock
+                                        block={
+                                            periodenErAvsluttet
+                                                ? teksterForModal.sluttdatoFortid.sporsmal
+                                                : teksterForModal.sluttdatoFremtid.sporsmal
+                                        }
+                                    />
+                                }
+                                avgrensMinDato={minTilDatoForUtbetalingEllerArbeidsperiode(
+                                    periodenErAvsluttet,
+                                    skjema.felter.fraDatoArbeidsperiode.verdi
+                                )}
+                                avgrensMaxDato={periodenErAvsluttet ? dagensDato() : undefined}
+                                disabled={
+                                    skjema.felter.tilDatoArbeidsperiodeUkjent.verdi === ESvar.JA
+                                }
+                            />
+
+                            <SkjemaCheckbox
+                                felt={skjema.felter.tilDatoArbeidsperiodeUkjent}
+                                label={plainTekst(teksterForModal.sluttdatoFremtid.checkboxLabel)}
+                            />
+                        </>
+                    )}
                 </>
             )}
             <div>

--- a/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Arbeidsperiode/ArbeidsperiodeOppsummering.tsx
@@ -3,13 +3,16 @@ import React from 'react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureTogglesContext';
 import { useSpråkContext } from '../../../context/SpråkContext';
 import { AlternativtSvarForInput } from '../../../typer/common';
+import { EFeatureToggle } from '../../../typer/feature-toggles';
 import { IArbeidsperiode } from '../../../typer/perioder';
 import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { IArbeidsperiodeTekstinnhold } from '../../../typer/sanity/modaler/arbeidsperiode';
-import { formaterDato, formaterDatoMedUkjent } from '../../../utils/dato';
+import { formaterDato, formaterDatostringKunMåned } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
+import { formaterMånedMedUkjent, uppercaseFørsteBokstav } from '../../../utils/visning';
 import { OppsummeringFelt } from '../../SøknadsSteg/Oppsummering/OppsummeringFelt';
 import PeriodeOppsummering from '../PeriodeOppsummering/PeriodeOppsummering';
 import TekstBlock from '../TekstBlock';
@@ -32,6 +35,7 @@ export const ArbeidsperiodeOppsummering: React.FC<ArbeidsperiodeOppsummeringProp
     erDød = false,
     barn,
 }) => {
+    const { toggles } = useFeatureToggles();
     const { tekster, plainTekst } = useApp();
     const { valgtLocale } = useSpråkContext();
     const {
@@ -96,7 +100,13 @@ export const ArbeidsperiodeOppsummering: React.FC<ArbeidsperiodeOppsummeringProp
             />
             <OppsummeringFelt
                 tittel={<TekstBlock block={teksterForModal.startdato.sporsmal} />}
-                søknadsvar={formaterDato(fraDatoArbeidsperiode.svar)}
+                søknadsvar={
+                    toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO]
+                        ? uppercaseFørsteBokstav(
+                              formaterDatostringKunMåned(fraDatoArbeidsperiode.svar, valgtLocale)
+                          )
+                        : formaterDato(fraDatoArbeidsperiode.svar)
+                }
             />
             <OppsummeringFelt
                 tittel={
@@ -108,9 +118,11 @@ export const ArbeidsperiodeOppsummering: React.FC<ArbeidsperiodeOppsummeringProp
                         }
                     />
                 }
-                søknadsvar={formaterDatoMedUkjent(
+                søknadsvar={formaterMånedMedUkjent(
                     tilDatoArbeidsperiode.svar,
-                    plainTekst(teksterForModal.sluttdatoFremtid.checkboxLabel)
+                    plainTekst(teksterForModal.sluttdatoFremtid.checkboxLabel),
+                    toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO],
+                    valgtLocale
                 )}
             />
             {adresse.svar && (

--- a/src/frontend/components/Felleskomponenter/MånedÅrVelger/MånedÅrVelger.tsx
+++ b/src/frontend/components/Felleskomponenter/MånedÅrVelger/MånedÅrVelger.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react';
+
+import { formatISO, lastDayOfMonth } from 'date-fns';
+
+import { MonthPicker, useMonthpicker } from '@navikt/ds-react';
+import type { Felt } from '@navikt/familie-skjema';
+
+import { useApp } from '../../../context/AppContext';
+import { useSpråkContext } from '../../../context/SpråkContext';
+import { ISODateString } from '../../../typer/common';
+import { ESanitySteg } from '../../../typer/sanity/sanity';
+
+interface MånedÅrVelgerProps {
+    tidligsteValgbareMåned?: Date;
+    senesteValgbareMåned?: Date;
+    label: React.ReactNode;
+    felt: Felt<ISODateString>;
+    visFeilmeldinger?: boolean;
+    disabled?: boolean;
+    dagIMåneden: DagIMåneden;
+    kanIkkeVæreFortid?: boolean;
+    kanIkkeVæreFremtid?: boolean;
+}
+
+/* TODO
+- vurder å lagre som Date og gjøre parsing/format mot mellomlagring og innsending - i neste runde
+*/
+
+enum Feilmelding {
+    FØR_MIN_DATO = 'FØR_MIN_DATO',
+    ETTER_MAKS_DATO = 'ETTER_MAKS_DATO',
+    UGYLDIG_DATO = 'UGYLDIG_DATO',
+    DATO_IKKE_I_FORTID = 'DATO_IKKE_I_FORTID',
+    DATO_IKKE_I_FREMTID = 'DATO_IKKE_I_FREMTID',
+}
+
+export enum DagIMåneden {
+    FØRSTE_DAG = 'FØRSTE_DAG',
+    SISTE_DAG = 'SISTE_DAG',
+}
+
+export const MånedÅrVelger: React.FC<MånedÅrVelgerProps> = ({
+    tidligsteValgbareMåned,
+    senesteValgbareMåned,
+    label,
+    felt,
+    visFeilmeldinger = false,
+    disabled = false,
+    dagIMåneden = DagIMåneden.FØRSTE_DAG,
+    kanIkkeVæreFortid,
+    kanIkkeVæreFremtid,
+}) => {
+    const { valgtLocale } = useSpråkContext();
+    const { tekster, plainTekst } = useApp();
+    const [error, setError] = useState<Feilmelding | undefined>(undefined);
+
+    const { manedformatPlaceholder } = tekster().FELLES.hjelpeteksterForInput;
+
+    const formateringsfeilmeldinger = tekster()[ESanitySteg.FELLES].formateringsfeilmeldinger;
+
+    const nullstillOgSettFeilmelding = (feilmelding: Feilmelding) => {
+        if (error !== feilmelding) {
+            setError(feilmelding);
+            felt.nullstill();
+        }
+    };
+
+    const feilmeldinger: Record<Feilmelding, string> = {
+        UGYLDIG_DATO: plainTekst(formateringsfeilmeldinger.ugyldigManed),
+        FØR_MIN_DATO: plainTekst(formateringsfeilmeldinger.datoErForForsteGyldigeTidspunkt),
+        ETTER_MAKS_DATO: plainTekst(formateringsfeilmeldinger.datoErEtterSisteGyldigeTidspunkt),
+        DATO_IKKE_I_FORTID: plainTekst(formateringsfeilmeldinger.datoKanIkkeVareIFortid),
+        DATO_IKKE_I_FREMTID: plainTekst(formateringsfeilmeldinger.datoKanIkkeVareIFremtid),
+    };
+
+    const { monthpickerProps, inputProps } = useMonthpicker({
+        fromDate: tidligsteValgbareMåned,
+        toDate: senesteValgbareMåned,
+        locale: valgtLocale,
+        onMonthChange: (dato: Date | undefined): void => {
+            if (dato === undefined) {
+                felt.nullstill();
+            } else {
+                if (dagIMåneden === DagIMåneden.FØRSTE_DAG) {
+                    felt.validerOgSettFelt(formatISO(dato, { representation: 'date' }));
+                } else {
+                    felt.validerOgSettFelt(
+                        formatISO(lastDayOfMonth(dato), { representation: 'date' })
+                    );
+                }
+            }
+        },
+        onValidate: val => {
+            if (val.isBefore && kanIkkeVæreFortid) {
+                nullstillOgSettFeilmelding(Feilmelding.DATO_IKKE_I_FORTID);
+            } else if (val.isAfter && kanIkkeVæreFremtid) {
+                nullstillOgSettFeilmelding(Feilmelding.DATO_IKKE_I_FREMTID);
+            } else if (val.isBefore) {
+                nullstillOgSettFeilmelding(Feilmelding.FØR_MIN_DATO);
+            } else if (val.isAfter) {
+                nullstillOgSettFeilmelding(Feilmelding.ETTER_MAKS_DATO);
+            } else if (val.isEmpty || val.isDisabled || !val.isValidMonth) {
+                nullstillOgSettFeilmelding(Feilmelding.UGYLDIG_DATO);
+            } else {
+                setError(undefined);
+            }
+        },
+    });
+
+    return (
+        <MonthPicker {...monthpickerProps}>
+            <MonthPicker.Input
+                {...inputProps}
+                label={label}
+                placeholder={plainTekst(manedformatPlaceholder)}
+                disabled={disabled}
+                error={
+                    error && visFeilmeldinger
+                        ? feilmeldinger[error]
+                        : felt.hentNavBaseSkjemaProps(visFeilmeldinger).error
+                }
+            />
+        </MonthPicker>
+    );
+};

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/Pensjonsmodal.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/Pensjonsmodal.tsx
@@ -178,7 +178,7 @@ export const PensjonModal: React.FC<Props> = ({
                     )}
                 </>
             )}
-            ;{visFeiloppsummering(skjema) && <SkjemaFeiloppsummering skjema={skjema} />}
+            {visFeiloppsummering(skjema) && <SkjemaFeiloppsummering skjema={skjema} />}
         </SkjemaModal>
     );
 };

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/Pensjonsmodal.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/Pensjonsmodal.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 
+import { parseISO } from 'date-fns';
+
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureTogglesContext';
+import { EFeatureToggle } from '../../../typer/feature-toggles';
 import { IPensjonsperiode } from '../../../typer/perioder';
 import { PersonType } from '../../../typer/personType';
 import { IPensjonsperiodeTekstinnhold } from '../../../typer/sanity/modaler/pensjonsperiode';
-import { dagensDato, gårsdagensDato } from '../../../utils/dato';
+import { dagensDato, gårsdagensDato, sisteDagDenneMåneden } from '../../../utils/dato';
 import { visFeiloppsummering } from '../../../utils/hjelpefunksjoner';
 import Datovelger from '../Datovelger/Datovelger';
 import { LandDropdown } from '../Dropdowns/LandDropdown';
 import JaNeiSpm from '../JaNeiSpm/JaNeiSpm';
+import { DagIMåneden, MånedÅrVelger } from '../MånedÅrVelger/MånedÅrVelger';
 import { SkjemaFeiloppsummering } from '../SkjemaFeiloppsummering/SkjemaFeiloppsummering';
 import SkjemaModal from '../SkjemaModal/SkjemaModal';
 import TekstBlock from '../TekstBlock';
@@ -36,6 +41,7 @@ export const PensjonModal: React.FC<Props> = ({
     erDød,
     forklaring = undefined,
 }) => {
+    const { toggles } = useFeatureToggles();
     const { tekster } = useApp();
     const { skjema, valideringErOk, nullstillSkjema, validerFelterOgVisFeilmelding } =
         usePensjonSkjema({
@@ -119,25 +125,60 @@ export const PensjonModal: React.FC<Props> = ({
                     ekskluderNorge
                 />
             )}
-            {pensjonFraDato.erSynlig && (
-                <Datovelger
-                    felt={pensjonFraDato}
-                    label={<TekstBlock block={teksterForModal.startdato.sporsmal} />}
-                    skjema={skjema}
-                    avgrensMaxDato={periodenErAvsluttet ? gårsdagensDato() : dagensDato()}
-                />
+            {toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO] ? (
+                <>
+                    {pensjonFraDato.erSynlig && (
+                        <MånedÅrVelger
+                            felt={pensjonFraDato}
+                            label={<TekstBlock block={teksterForModal.startdato.sporsmal} />}
+                            senesteValgbareMåned={
+                                periodenErAvsluttet ? gårsdagensDato() : dagensDato()
+                            }
+                            visFeilmeldinger={skjema.visFeilmeldinger}
+                            dagIMåneden={DagIMåneden.FØRSTE_DAG}
+                            kanIkkeVæreFremtid={true}
+                        />
+                    )}
+                    {pensjonTilDato.erSynlig && (
+                        <MånedÅrVelger
+                            felt={pensjonTilDato}
+                            label={<TekstBlock block={teksterForModal.sluttdato.sporsmal} />}
+                            tidligsteValgbareMåned={
+                                pensjonFraDato.verdi !== ''
+                                    ? parseISO(pensjonFraDato.verdi)
+                                    : undefined
+                            }
+                            senesteValgbareMåned={sisteDagDenneMåneden()}
+                            visFeilmeldinger={skjema.visFeilmeldinger}
+                            dagIMåneden={DagIMåneden.SISTE_DAG}
+                            kanIkkeVæreFremtid={periodenErAvsluttet}
+                            kanIkkeVæreFortid={!periodenErAvsluttet}
+                        />
+                    )}
+                </>
+            ) : (
+                <>
+                    {pensjonFraDato.erSynlig && (
+                        <Datovelger
+                            felt={pensjonFraDato}
+                            label={<TekstBlock block={teksterForModal.startdato.sporsmal} />}
+                            skjema={skjema}
+                            avgrensMaxDato={periodenErAvsluttet ? gårsdagensDato() : dagensDato()}
+                        />
+                    )}
+                    {pensjonTilDato.erSynlig && (
+                        <Datovelger
+                            felt={pensjonTilDato}
+                            label={<TekstBlock block={teksterForModal.sluttdato.sporsmal} />}
+                            skjema={skjema}
+                            avgrensMaxDato={dagensDato()}
+                            tilhørendeFraOgMedFelt={pensjonFraDato}
+                            dynamisk
+                        />
+                    )}
+                </>
             )}
-            {pensjonTilDato.erSynlig && (
-                <Datovelger
-                    felt={pensjonTilDato}
-                    label={<TekstBlock block={teksterForModal.sluttdato.sporsmal} />}
-                    skjema={skjema}
-                    avgrensMaxDato={dagensDato()}
-                    tilhørendeFraOgMedFelt={pensjonFraDato}
-                    dynamisk
-                />
-            )}
-            {visFeiloppsummering(skjema) && <SkjemaFeiloppsummering skjema={skjema} />}
+            ;{visFeiloppsummering(skjema) && <SkjemaFeiloppsummering skjema={skjema} />}
         </SkjemaModal>
     );
 };

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/PensjonsperiodeOppsummering.tsx
@@ -3,11 +3,14 @@ import React from 'react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureTogglesContext';
 import { useSpråkContext } from '../../../context/SpråkContext';
+import { EFeatureToggle } from '../../../typer/feature-toggles';
 import { IPensjonsperiode } from '../../../typer/perioder';
 import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
-import { formaterDato } from '../../../utils/dato';
+import { formaterDato, formaterDatostringKunMåned } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
+import { uppercaseFørsteBokstav } from '../../../utils/visning';
 import { OppsummeringFelt } from '../../SøknadsSteg/Oppsummering/OppsummeringFelt';
 import PeriodeOppsummering from '../PeriodeOppsummering/PeriodeOppsummering';
 import TekstBlock from '../TekstBlock';
@@ -30,6 +33,7 @@ export const PensjonsperiodeOppsummering: React.FC<PensjonsperiodeOppsummeringPr
     erDød = false,
     barn = undefined,
 }) => {
+    const { toggles } = useFeatureToggles();
     const { valgtLocale } = useSpråkContext();
     const { tekster } = useApp();
     const teksterForModal = tekster().FELLES.modaler.pensjonsperiode[personType];
@@ -81,13 +85,25 @@ export const PensjonsperiodeOppsummering: React.FC<PensjonsperiodeOppsummeringPr
             {pensjonFra.svar && (
                 <OppsummeringFelt
                     tittel={<TekstBlock block={teksterForModal.startdato.sporsmal} />}
-                    søknadsvar={formaterDato(pensjonFra.svar)}
+                    søknadsvar={
+                        toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO]
+                            ? uppercaseFørsteBokstav(
+                                  formaterDatostringKunMåned(pensjonFra.svar, valgtLocale)
+                              )
+                            : formaterDato(pensjonFra.svar)
+                    }
                 />
             )}
             {pensjonTil.svar && (
                 <OppsummeringFelt
                     tittel={<TekstBlock block={teksterForModal.sluttdato.sporsmal} />}
-                    søknadsvar={formaterDato(pensjonTil.svar)}
+                    søknadsvar={
+                        toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO]
+                            ? uppercaseFørsteBokstav(
+                                  formaterDatostringKunMåned(pensjonTil.svar, valgtLocale)
+                              )
+                            : formaterDato(pensjonTil.svar)
+                    }
                 />
             )}
         </PeriodeOppsummering>

--- a/src/frontend/components/Felleskomponenter/Pensjonsmodal/usePensjonSkjema.tsx
+++ b/src/frontend/components/Felleskomponenter/Pensjonsmodal/usePensjonSkjema.tsx
@@ -5,16 +5,23 @@ import { useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
 import { useEøsContext } from '../../../context/EøsContext';
+import { useFeatureToggles } from '../../../context/FeatureTogglesContext';
 import useDatovelgerFelt from '../../../hooks/useDatovelgerFelt';
 import useJaNeiSpmFelt from '../../../hooks/useJaNeiSpmFelt';
 import useLanddropdownFelt from '../../../hooks/useLanddropdownFelt';
 import { IBarnMedISøknad } from '../../../typer/barn';
+import { EFeatureToggle } from '../../../typer/feature-toggles';
 import { IUsePeriodeSkjemaVerdi } from '../../../typer/perioder';
 import { PersonType } from '../../../typer/personType';
 import { IPensjonsperiodeTekstinnhold } from '../../../typer/sanity/modaler/pensjonsperiode';
 import { ESanitySteg } from '../../../typer/sanity/sanity';
 import { IPensjonsperiodeFeltTyper } from '../../../typer/skjema';
-import { dagenEtterDato, dagensDato, gårsdagensDato, stringTilDate } from '../../../utils/dato';
+import {
+    dagenEtterDato,
+    dagensDato,
+    sisteDagDenneMåneden,
+    stringTilDate,
+} from '../../../utils/dato';
 
 import { mottarPensjonNåFeilmelding } from './språkUtils';
 import { PensjonsperiodeSpørsmålId } from './spørsmål';
@@ -32,6 +39,7 @@ export const usePensjonSkjema = ({
     erDød,
     barn,
 }: IUsePensjonSkjemaParams): IUsePeriodeSkjemaVerdi<IPensjonsperiodeFeltTyper> => {
+    const { toggles } = useFeatureToggles();
     const { tekster } = useApp();
     const { erEøsLand } = useEøsContext();
     const teksterForPersonType: IPensjonsperiodeTekstinnhold =
@@ -72,9 +80,15 @@ export const usePensjonSkjema = ({
             (mottarPensjonNå.valideringsstatus === Valideringsstatus.OK || erAndreForelderDød) &&
             (!gjelderUtland || !!erEøsLand(pensjonsland.verdi)),
         feilmelding: teksterForPersonType.startdato.feilmelding,
-        sluttdatoAvgrensning: periodenErAvsluttet ? gårsdagensDato() : dagensDato(),
+        sluttdatoAvgrensning: toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO]
+            ? sisteDagDenneMåneden()
+            : dagensDato(),
         avhengigheter: { mottarPensjonNå },
     });
+
+    const tilPensjonperiodeSluttdatoAvgrensning = toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO]
+        ? sisteDagDenneMåneden()
+        : dagensDato();
 
     const pensjonTilDato = useDatovelgerFelt({
         søknadsfelt: {
@@ -85,7 +99,7 @@ export const usePensjonSkjema = ({
             (mottarPensjonNå.verdi === ESvar.NEI || erAndreForelderDød) &&
             (!gjelderUtland || !!erEøsLand(pensjonsland.verdi)),
         feilmelding: teksterForPersonType.sluttdato.feilmelding,
-        sluttdatoAvgrensning: dagensDato(),
+        sluttdatoAvgrensning: tilPensjonperiodeSluttdatoAvgrensning,
         startdatoAvgrensning: dagenEtterDato(stringTilDate(pensjonFraDato.verdi)),
         avhengigheter: { mottarPensjonNå, pensjonFraDato },
     });

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingerModal.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingerModal.tsx
@@ -4,16 +4,19 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureTogglesContext';
+import { EFeatureToggle } from '../../../typer/feature-toggles';
 import { IUtbetalingsperiode } from '../../../typer/perioder';
 import { PersonType } from '../../../typer/personType';
 import { IAndreUtbetalingerTekstinnhold } from '../../../typer/sanity/modaler/andreUtbetalinger';
-import { dagensDato, gårsdagensDato } from '../../../utils/dato';
+import { dagensDato, gårsdagensDato, sisteDagDenneMåneden } from '../../../utils/dato';
 import { visFeiloppsummering } from '../../../utils/hjelpefunksjoner';
 import { minTilDatoForUtbetalingEllerArbeidsperiode } from '../../../utils/perioder';
 import { svarForSpørsmålMedUkjent } from '../../../utils/spørsmål';
 import Datovelger from '../Datovelger/Datovelger';
 import { LandDropdown } from '../Dropdowns/LandDropdown';
 import JaNeiSpm from '../JaNeiSpm/JaNeiSpm';
+import { DagIMåneden, MånedÅrVelger } from '../MånedÅrVelger/MånedÅrVelger';
 import { SkjemaCheckbox } from '../SkjemaCheckbox/SkjemaCheckbox';
 import { SkjemaFeiloppsummering } from '../SkjemaFeiloppsummering/SkjemaFeiloppsummering';
 import SkjemaModal from '../SkjemaModal/SkjemaModal';
@@ -38,6 +41,7 @@ export const UtbetalingerModal: React.FC<UtbetalingerModalProps> = ({
     erDød,
     forklaring = undefined,
 }) => {
+    const { toggles } = useFeatureToggles();
     const { tekster, plainTekst } = useApp();
     const { skjema, valideringErOk, nullstillSkjema, validerFelterOgVisFeilmelding } =
         useUtbetalingerSkjema(personType, barn, erDød);
@@ -118,37 +122,95 @@ export const UtbetalingerModal: React.FC<UtbetalingerModalProps> = ({
                         }
                         dynamisk
                     />
-                    <Datovelger
-                        skjema={skjema}
-                        felt={utbetalingFraDato}
-                        label={<TekstBlock block={teksterForPersonType.startdato.sporsmal} />}
-                        avgrensMaxDato={periodenErAvsluttet ? gårsdagensDato() : dagensDato()}
-                    />
-                    <div>
-                        <Datovelger
-                            skjema={skjema}
-                            felt={utbetalingTilDato}
-                            label={
-                                <TekstBlock
-                                    block={
-                                        periodenErAvsluttet
-                                            ? teksterForPersonType.sluttdatoFortid.sporsmal
-                                            : teksterForPersonType.sluttdatoFremtid.sporsmal
+                    {toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO] ? (
+                        <>
+                            <MånedÅrVelger
+                                felt={utbetalingFraDato}
+                                label={
+                                    <TekstBlock block={teksterForPersonType.startdato.sporsmal} />
+                                }
+                                senesteValgbareMåned={
+                                    periodenErAvsluttet ? gårsdagensDato() : dagensDato()
+                                }
+                                visFeilmeldinger={skjema.visFeilmeldinger}
+                                dagIMåneden={DagIMåneden.FØRSTE_DAG}
+                                kanIkkeVæreFremtid={true}
+                            />
+                            <div>
+                                <MånedÅrVelger
+                                    felt={utbetalingTilDato}
+                                    label={
+                                        <TekstBlock
+                                            block={
+                                                periodenErAvsluttet
+                                                    ? teksterForPersonType.sluttdatoFortid.sporsmal
+                                                    : teksterForPersonType.sluttdatoFremtid.sporsmal
+                                            }
+                                        />
                                     }
+                                    tidligsteValgbareMåned={minTilDatoForUtbetalingEllerArbeidsperiode(
+                                        periodenErAvsluttet,
+                                        utbetalingFraDato.verdi
+                                    )}
+                                    senesteValgbareMåned={
+                                        periodenErAvsluttet ? sisteDagDenneMåneden() : undefined
+                                    }
+                                    visFeilmeldinger={skjema.visFeilmeldinger}
+                                    dagIMåneden={DagIMåneden.SISTE_DAG}
+                                    kanIkkeVæreFremtid={periodenErAvsluttet}
+                                    kanIkkeVæreFortid={!periodenErAvsluttet}
+                                    disabled={utbetalingTilDatoUkjent.verdi === ESvar.JA}
                                 />
-                            }
-                            avgrensMaxDato={periodenErAvsluttet ? dagensDato() : undefined}
-                            avgrensMinDato={minTilDatoForUtbetalingEllerArbeidsperiode(
-                                periodenErAvsluttet,
-                                utbetalingFraDato.verdi
-                            )}
-                            disabled={utbetalingTilDatoUkjent.verdi === ESvar.JA}
-                        />
-                        <SkjemaCheckbox
-                            label={plainTekst(teksterForPersonType.sluttdatoFremtid.checkboxLabel)}
-                            felt={utbetalingTilDatoUkjent}
-                        />
-                    </div>
+                                <SkjemaCheckbox
+                                    label={plainTekst(
+                                        teksterForPersonType.sluttdatoFremtid.checkboxLabel
+                                    )}
+                                    felt={utbetalingTilDatoUkjent}
+                                />
+                            </div>
+                        </>
+                    ) : (
+                        <>
+                            <Datovelger
+                                skjema={skjema}
+                                felt={utbetalingFraDato}
+                                label={
+                                    <TekstBlock block={teksterForPersonType.startdato.sporsmal} />
+                                }
+                                avgrensMaxDato={
+                                    periodenErAvsluttet ? gårsdagensDato() : dagensDato()
+                                }
+                            />
+                            <div>
+                                <Datovelger
+                                    skjema={skjema}
+                                    felt={utbetalingTilDato}
+                                    label={
+                                        <TekstBlock
+                                            block={
+                                                periodenErAvsluttet
+                                                    ? teksterForPersonType.sluttdatoFortid.sporsmal
+                                                    : teksterForPersonType.sluttdatoFremtid.sporsmal
+                                            }
+                                        />
+                                    }
+                                    avgrensMaxDato={periodenErAvsluttet ? dagensDato() : undefined}
+                                    avgrensMinDato={minTilDatoForUtbetalingEllerArbeidsperiode(
+                                        periodenErAvsluttet,
+                                        utbetalingFraDato.verdi
+                                    )}
+                                    disabled={utbetalingTilDatoUkjent.verdi === ESvar.JA}
+                                />
+                                <SkjemaCheckbox
+                                    label={plainTekst(
+                                        teksterForPersonType.sluttdatoFremtid.checkboxLabel
+                                    )}
+                                    felt={utbetalingTilDatoUkjent}
+                                />
+                            </div>
+                        </>
+                    )}
+                    ;
                 </>
             )}
             {visFeiloppsummering(skjema) && <SkjemaFeiloppsummering skjema={skjema} />}

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/UtbetalingsperiodeOppsummering.tsx
@@ -3,12 +3,15 @@ import React from 'react';
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureTogglesContext';
 import { useSpråkContext } from '../../../context/SpråkContext';
+import { EFeatureToggle } from '../../../typer/feature-toggles';
 import { IUtbetalingsperiode } from '../../../typer/perioder';
 import { PeriodePersonTypeMedBarnProps, PersonType } from '../../../typer/personType';
 import { IAndreUtbetalingerTekstinnhold } from '../../../typer/sanity/modaler/andreUtbetalinger';
-import { formaterDato, formaterDatoMedUkjent } from '../../../utils/dato';
+import { formaterDato, formaterDatostringKunMåned } from '../../../utils/dato';
 import { landkodeTilSpråk } from '../../../utils/språk';
+import { formaterMånedMedUkjent, uppercaseFørsteBokstav } from '../../../utils/visning';
 import { OppsummeringFelt } from '../../SøknadsSteg/Oppsummering/OppsummeringFelt';
 import PeriodeOppsummering from '../PeriodeOppsummering/PeriodeOppsummering';
 import TekstBlock from '../TekstBlock';
@@ -29,6 +32,7 @@ export const UtbetalingsperiodeOppsummering: React.FC<UtbetalingsperiodeOppsumme
     erDød = false,
     barn = undefined,
 }) => {
+    const { toggles } = useFeatureToggles();
     const { tekster, plainTekst } = useApp();
     const { valgtLocale } = useSpråkContext();
     const { fårUtbetalingNå, utbetalingLand, utbetalingFraDato, utbetalingTilDato } =
@@ -79,7 +83,13 @@ export const UtbetalingsperiodeOppsummering: React.FC<UtbetalingsperiodeOppsumme
             />
             <OppsummeringFelt
                 tittel={<TekstBlock block={teksterForPersontype.startdato.sporsmal} />}
-                søknadsvar={formaterDato(utbetalingFraDato.svar)}
+                søknadsvar={
+                    toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO]
+                        ? uppercaseFørsteBokstav(
+                              formaterDatostringKunMåned(utbetalingFraDato.svar, valgtLocale)
+                          )
+                        : formaterDato(utbetalingFraDato.svar)
+                }
             />
             <OppsummeringFelt
                 tittel={
@@ -91,9 +101,11 @@ export const UtbetalingsperiodeOppsummering: React.FC<UtbetalingsperiodeOppsumme
                         }
                     />
                 }
-                søknadsvar={formaterDatoMedUkjent(
+                søknadsvar={formaterMånedMedUkjent(
                     utbetalingTilDato.svar,
-                    plainTekst(teksterForPersontype.sluttdatoFremtid.checkboxLabel)
+                    plainTekst(teksterForPersontype.sluttdatoFremtid.checkboxLabel),
+                    toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO],
+                    valgtLocale
                 )}
             />
         </PeriodeOppsummering>

--- a/src/frontend/components/Felleskomponenter/UtbetalingerModal/useUtbetalingerSkjema.tsx
+++ b/src/frontend/components/Felleskomponenter/UtbetalingerModal/useUtbetalingerSkjema.tsx
@@ -2,11 +2,13 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { useFelt, useSkjema, Valideringsstatus } from '@navikt/familie-skjema';
 
 import { useApp } from '../../../context/AppContext';
+import { useFeatureToggles } from '../../../context/FeatureTogglesContext';
 import useDatovelgerFelt from '../../../hooks/useDatovelgerFelt';
 import useDatovelgerFeltMedUkjent from '../../../hooks/useDatovelgerFeltMedUkjent';
 import useJaNeiSpmFelt from '../../../hooks/useJaNeiSpmFelt';
 import useLanddropdownFelt from '../../../hooks/useLanddropdownFelt';
 import { IBarnMedISøknad } from '../../../typer/barn';
+import { EFeatureToggle } from '../../../typer/feature-toggles';
 import { IUsePeriodeSkjemaVerdi } from '../../../typer/perioder';
 import { PersonType } from '../../../typer/personType';
 import { IAndreUtbetalingerTekstinnhold } from '../../../typer/sanity/modaler/andreUtbetalinger';
@@ -16,6 +18,7 @@ import {
     dagensDato,
     erSammeDatoSomDagensDato,
     gårsdagensDato,
+    sisteDagDenneMåneden,
     stringTilDate,
 } from '../../../utils/dato';
 import { minTilDatoForUtbetalingEllerArbeidsperiode } from '../../../utils/perioder';
@@ -33,6 +36,7 @@ export const useUtbetalingerSkjema = (
     barn,
     erDød
 ): IUsePeriodeSkjemaVerdi<IUtbetalingerFeltTyper> => {
+    const { toggles } = useFeatureToggles();
     const { tekster, plainTekst } = useApp();
     const teksterForPersontype: IAndreUtbetalingerTekstinnhold =
         tekster()[ESanitySteg.FELLES].modaler.andreUtbetalinger[personType];
@@ -75,6 +79,10 @@ export const useUtbetalingerSkjema = (
         avhengigheter: { fårUtbetalingNå },
     });
 
+    const utbetalingTilDatoSluttdatoAvgrensning = toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO]
+        ? sisteDagDenneMåneden()
+        : dagensDato();
+
     const utbetalingTilDato = useDatovelgerFeltMedUkjent({
         feltId: UtbetalingerSpørsmålId.utbetalingTilDato,
         initiellVerdi: '',
@@ -84,7 +92,9 @@ export const useUtbetalingerSkjema = (
             : teksterForPersontype.sluttdatoFremtid.feilmelding,
         skalFeltetVises:
             andreForelderErDød || fårUtbetalingNå.valideringsstatus === Valideringsstatus.OK,
-        sluttdatoAvgrensning: periodenErAvsluttet ? dagensDato() : undefined,
+        sluttdatoAvgrensning: periodenErAvsluttet
+            ? utbetalingTilDatoSluttdatoAvgrensning
+            : undefined,
         startdatoAvgrensning: minTilDatoForUtbetalingEllerArbeidsperiode(
             periodenErAvsluttet,
             utbetalingFraDato.verdi

--- a/src/frontend/hooks/useSendInnSkjema.tsx
+++ b/src/frontend/hooks/useSendInnSkjema.tsx
@@ -8,6 +8,7 @@ import { erModellMismatchResponsRessurs } from '../../shared-utils/modellversjon
 import { useApp } from '../context/AppContext';
 import { useFeatureToggles } from '../context/FeatureTogglesContext';
 import { useSpråkContext } from '../context/SpråkContext';
+import { EFeatureToggle } from '../typer/feature-toggles';
 import { ISøknadKontrakt } from '../typer/kontrakt/søknadKontrakt';
 import { IKvittering } from '../typer/kvittering';
 import { dataISøknadKontraktFormat } from '../utils/mappingTilKontrakt/søknad';
@@ -38,7 +39,8 @@ export const useSendInnSkjema = (): {
                 søknad,
                 tekster(),
                 tilRestLocaleRecord,
-                kontraktVersjon
+                kontraktVersjon,
+                toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO] === true
             );
 
             const res = await sendInn<ISøknadKontrakt>(

--- a/src/frontend/typer/feature-toggles.ts
+++ b/src/frontend/typer/feature-toggles.ts
@@ -6,6 +6,7 @@ export enum EFeatureToggle {
     // EKSEMPEL = 'EKSEMPEL',
     FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP = 'FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP',
     BRUK_NYTT_ENDEPUNKT_FOR_INNSENDING_AV_SOKNAD = 'BRUK_NYTT_ENDEPUNKT_FOR_INNSENDING_AV_SOKNAD',
+    SPOR_OM_MANED_IKKE_DATO = 'SPOR_OM_MANED_IKKE_DATO',
 }
 
 export const ToggleKeys: Record<EFeatureToggle, string> = {
@@ -14,6 +15,7 @@ export const ToggleKeys: Record<EFeatureToggle, string> = {
         'familie-ks-soknad.forklarende-tekster-over-legg-til-knapp',
     [EFeatureToggle.BRUK_NYTT_ENDEPUNKT_FOR_INNSENDING_AV_SOKNAD]:
         'familie-ks-soknad.bruk_nytt_endepunkt_for_innsending_av_soknad',
+    [EFeatureToggle.SPOR_OM_MANED_IKKE_DATO]: 'familie-ks-soknad.spor-om-maned-ikke-dato',
 };
 
 export type EAllFeatureToggles = Record<EFeatureToggle, boolean>;

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -165,6 +165,11 @@ export interface IFormateringsfeilmeldingerTekstinnhold {
     datoKanIkkeVaereDagensDatoEllerFremITid: LocaleRecordString;
     periodeAvsluttesForTidlig: LocaleRecordString;
     datoKanIkkeVaere12MndTilbake: LocaleRecordString;
+    ugyldigManed: LocaleRecordString;
+    datoErForForsteGyldigeTidspunkt: LocaleRecordString;
+    datoErEtterSisteGyldigeTidspunkt: LocaleRecordString;
+    datoKanIkkeVareIFortid: LocaleRecordString;
+    datoKanIkkeVareIFremtid: LocaleRecordString;
 }
 
 export interface IVedlikeholdsarbeidTekstinnhold {
@@ -181,6 +186,7 @@ export interface IHjelpeteksterForInputTekstInnhold {
     datoformatHjelpetekst: LocaleRecordBlock;
     datoformatPlaceholder: LocaleRecordBlock;
     velgLandPlaceholder: LocaleRecordBlock;
+    manedformatPlaceholder: LocaleRecordBlock;
 }
 
 export interface IAlternativeTeksterTekstinnhold {

--- a/src/frontend/utils/dato.tsx
+++ b/src/frontend/utils/dato.tsx
@@ -109,6 +109,9 @@ export const formaterDatostringKunMåned = (datoString: ISODateString, språk: L
 export const formaterDato = (datoString: ISODateString) =>
     format(new Date(datoString), 'dd.MM.yyyy');
 
+export const formaterDatoKunMåned = (dato: Date, språk: LocaleType) =>
+    format(dato, 'MMMM yyyy', { locale: mapSpråkvalgTilDateFnsLocale(språk) });
+
 export const formaterDatoMedUkjent = (datoMedUkjent: DatoMedUkjent, tekstForUkjent): string => {
     return datoMedUkjent === AlternativtSvarForInput.UKJENT
         ? tekstForUkjent

--- a/src/frontend/utils/dato.tsx
+++ b/src/frontend/utils/dato.tsx
@@ -1,5 +1,6 @@
 import {
     add,
+    endOfMonth,
     format,
     isAfter,
     isBefore,
@@ -48,6 +49,8 @@ export const dagenEtterDato = (dato: Date) => add(dato, { days: 1 });
 export const tidenesMorgen = () => startOfDay(new Date(1000, 0));
 
 export const tidenesEnde = () => startOfDay(new Date(3000, 0));
+
+export const sisteDagDenneMåneden = () => endOfMonth(new Date());
 
 export const stringTilDate = (dato: string) => startOfDay(new Date(dato));
 

--- a/src/frontend/utils/dato.tsx
+++ b/src/frontend/utils/dato.tsx
@@ -7,11 +7,13 @@ import {
     isFuture,
     isToday,
     isValid,
+    type Locale,
     parse,
     startOfDay,
     startOfToday,
     sub,
 } from 'date-fns';
+import { enGB, nb, nn } from 'date-fns/locale';
 
 import { feil, type FeltState, ok } from '@navikt/familie-skjema';
 
@@ -20,6 +22,7 @@ import {
     DatoMedUkjent,
     ISODateString,
     LocaleRecordBlock,
+    LocaleType,
 } from '../typer/common';
 import { PlainTekst } from '../typer/kontrakt/generelle';
 import { IFormateringsfeilmeldingerTekstinnhold } from '../typer/sanity/tekstInnhold';
@@ -100,6 +103,9 @@ export const validerDato = (
     return ok(feltState);
 };
 
+export const formaterDatostringKunMåned = (datoString: ISODateString, språk: LocaleType) =>
+    format(new Date(datoString), 'MMMM yyyy', { locale: mapSpråkvalgTilDateFnsLocale(språk) });
+
 export const formaterDato = (datoString: ISODateString) =>
     format(new Date(datoString), 'dd.MM.yyyy');
 
@@ -107,4 +113,15 @@ export const formaterDatoMedUkjent = (datoMedUkjent: DatoMedUkjent, tekstForUkje
     return datoMedUkjent === AlternativtSvarForInput.UKJENT
         ? tekstForUkjent
         : format(new Date(datoMedUkjent), 'dd.MM.yyyy');
+};
+
+const mapSpråkvalgTilDateFnsLocale = (språkvalg: LocaleType): Locale => {
+    switch (språkvalg) {
+        case LocaleType.nb:
+            return nb;
+        case LocaleType.nn:
+            return nn;
+        case LocaleType.en:
+            return enGB;
+    }
 };

--- a/src/frontend/utils/mappingTilKontrakt/andreForelder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/andreForelder.ts
@@ -25,7 +25,8 @@ export const andreForelderTilISøknadsfelt = (
     andreForelder: IAndreForelder,
     barn: IBarnMedISøknad,
     tilRestLocaleRecord: TilRestLocaleRecord,
-    tekster: ITekstinnhold
+    tekster: ITekstinnhold,
+    toggleSpørOmMånedIkkeDato: boolean
 ): IAndreForelderIKontraktFormat => {
     const {
         navn,
@@ -182,6 +183,7 @@ export const andreForelderTilISøknadsfelt = (
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.arbeidsperiode.andreForelder,
                 barn,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         utenlandsperioder: utenlandsperioder.map((periode, index) =>
@@ -201,6 +203,7 @@ export const andreForelderTilISøknadsfelt = (
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.pensjonsperiode.andreForelder,
                 barn,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         arbeidsperioderNorge: arbeidsperioderNorge.map((periode, index) =>
@@ -211,6 +214,7 @@ export const andreForelderTilISøknadsfelt = (
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.arbeidsperiode.andreForelder,
                 barn,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         pensjonsperioderNorge: pensjonsperioderNorge.map((periode, index) =>
@@ -221,6 +225,7 @@ export const andreForelderTilISøknadsfelt = (
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.pensjonsperiode.andreForelder,
                 barn,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         andreUtbetalingsperioder: andreUtbetalingsperioder.map((periode, index) =>
@@ -230,6 +235,7 @@ export const andreForelderTilISøknadsfelt = (
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.andreUtbetalinger.andreForelder,
                 barn,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         eøsKontantstøttePerioder: eøsKontantstøttePerioder.map((periode, index) =>

--- a/src/frontend/utils/mappingTilKontrakt/andreUtbetalingsperioder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/andreUtbetalingsperioder.ts
@@ -1,17 +1,17 @@
 import { ESvar } from '@navikt/familie-form-elements';
 
 import { IBarnMedISøknad } from '../../typer/barn';
+import { AlternativtSvarForInput, ISODateString } from '../../typer/common';
 import { ISøknadsfelt, TilRestLocaleRecord } from '../../typer/kontrakt/generelle';
 import { IUtbetalingsperiodeIKontraktFormat } from '../../typer/kontrakt/søknadKontrakt';
 import { IUtbetalingsperiode } from '../../typer/perioder';
 import { IAndreUtbetalingerTekstinnhold } from '../../typer/sanity/modaler/andreUtbetalinger';
+import { ISøknadSpørsmål } from '../../typer/spørsmål';
+import { formaterDatostringKunMåned } from '../dato';
 import { landkodeTilSpråk } from '../språk';
+import { uppercaseFørsteBokstav } from '../visning';
 
-import {
-    sammeVerdiAlleSpråk,
-    sammeVerdiAlleSpråkEllerUkjent,
-    verdiCallbackAlleSpråk,
-} from './hjelpefunksjoner';
+import { sammeVerdiAlleSpråk, verdiCallbackAlleSpråk } from './hjelpefunksjoner';
 
 interface UtbetalingsperiodeIKontraktFormatParams {
     periode: IUtbetalingsperiode;
@@ -19,6 +19,7 @@ interface UtbetalingsperiodeIKontraktFormatParams {
     tilRestLocaleRecord: TilRestLocaleRecord;
     tekster: IAndreUtbetalingerTekstinnhold;
     barn?: IBarnMedISøknad;
+    toggleSpørOmMånedIkkeDato: boolean;
 }
 
 export const tilIAndreUtbetalingsperioderIKontraktFormat = ({
@@ -27,6 +28,7 @@ export const tilIAndreUtbetalingsperioderIKontraktFormat = ({
     tilRestLocaleRecord,
     tekster,
     barn,
+    toggleSpørOmMånedIkkeDato,
 }: UtbetalingsperiodeIKontraktFormatParams): ISøknadsfelt<IUtbetalingsperiodeIKontraktFormat> => {
     const { fårUtbetalingNå, utbetalingLand, utbetalingFraDato, utbetalingTilDato } = periode;
 
@@ -60,7 +62,7 @@ export const tilIAndreUtbetalingsperioderIKontraktFormat = ({
             },
             utbetalingFraDato: {
                 label: tilRestLocaleRecord(tekster.startdato.sporsmal),
-                verdi: sammeVerdiAlleSpråk(utbetalingFraDato.svar),
+                verdi: datoTilVerdiForKontrakt(utbetalingFraDato),
             },
             utbetalingTilDato: {
                 label: tilRestLocaleRecord(
@@ -68,12 +70,20 @@ export const tilIAndreUtbetalingsperioderIKontraktFormat = ({
                         ? tekster.sluttdatoFortid.sporsmal
                         : tekster.sluttdatoFremtid.sporsmal
                 ),
-                verdi: sammeVerdiAlleSpråkEllerUkjent(
-                    tilRestLocaleRecord,
-                    utbetalingTilDato.svar,
+                verdi:
+                    utbetalingTilDato.svar === AlternativtSvarForInput.UKJENT &&
                     tekster.sluttdatoFremtid.checkboxLabel
-                ),
+                        ? tilRestLocaleRecord(tekster.sluttdatoFremtid.checkboxLabel)
+                        : datoTilVerdiForKontrakt(utbetalingTilDato),
             },
         }),
     };
+
+    function datoTilVerdiForKontrakt(skjemaSpørsmål: ISøknadSpørsmål<ISODateString | ''>) {
+        return toggleSpørOmMånedIkkeDato
+            ? verdiCallbackAlleSpråk(locale =>
+                  uppercaseFørsteBokstav(formaterDatostringKunMåned(skjemaSpørsmål.svar, locale))
+              )
+            : sammeVerdiAlleSpråk(skjemaSpørsmål.svar);
+    }
 };

--- a/src/frontend/utils/mappingTilKontrakt/barn.ts
+++ b/src/frontend/utils/mappingTilKontrakt/barn.ts
@@ -31,7 +31,8 @@ export const barnISøknadsFormat = (
     barn: IBarnMedISøknad,
     søknad: ISøknad,
     tekster: ITekstinnhold,
-    tilRestLocaleRecord: TilRestLocaleRecord
+    tilRestLocaleRecord: TilRestLocaleRecord,
+    toggleSpørOmMånedIkkeDato: boolean
 ): ISøknadIKontraktBarn => {
     const {
         ident,
@@ -149,11 +150,23 @@ export const barnISøknadsFormat = (
             )
         ),
         andreForelder: andreForelder
-            ? andreForelderTilISøknadsfelt(andreForelder, barn, tilRestLocaleRecord, tekster)
+            ? andreForelderTilISøknadsfelt(
+                  andreForelder,
+                  barn,
+                  tilRestLocaleRecord,
+                  tekster,
+                  toggleSpørOmMånedIkkeDato
+              )
             : null,
 
         omsorgsperson: omsorgsperson
-            ? omsorgspersonTilISøknadsfelt(omsorgsperson, barn, tilRestLocaleRecord, tekster)
+            ? omsorgspersonTilISøknadsfelt(
+                  omsorgsperson,
+                  barn,
+                  tilRestLocaleRecord,
+                  tekster,
+                  toggleSpørOmMånedIkkeDato
+              )
             : null,
         adresse: adresse.svar
             ? søknadsfelt(

--- a/src/frontend/utils/mappingTilKontrakt/omsorgsperson.ts
+++ b/src/frontend/utils/mappingTilKontrakt/omsorgsperson.ts
@@ -21,7 +21,8 @@ export const omsorgspersonTilISøknadsfelt = (
     omsorgsperson: IOmsorgsperson,
     barn: IBarnMedISøknad,
     tilRestLocaleRecord: TilRestLocaleRecord,
-    tekster: ITekstinnhold
+    tekster: ITekstinnhold,
+    toggleSpørOmMånedIkkeDato: boolean
 ): IOmsorgspersonIKontraktFormat => {
     const {
         navn,
@@ -111,6 +112,7 @@ export const omsorgspersonTilISøknadsfelt = (
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.arbeidsperiode.omsorgsperson,
                 barn,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         arbeidNorge: søknadsfeltForESvar(
@@ -126,6 +128,7 @@ export const omsorgspersonTilISøknadsfelt = (
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.arbeidsperiode.omsorgsperson,
                 barn,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         pensjonUtland: søknadsfeltForESvar(
@@ -141,6 +144,7 @@ export const omsorgspersonTilISøknadsfelt = (
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.pensjonsperiode.omsorgsperson,
                 barn: barn,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         pensjonNorge: søknadsfeltForESvar(
@@ -156,6 +160,7 @@ export const omsorgspersonTilISøknadsfelt = (
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.pensjonsperiode.omsorgsperson,
                 barn: barn,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         andreUtbetalinger: søknadsfeltForESvar(
@@ -170,6 +175,7 @@ export const omsorgspersonTilISøknadsfelt = (
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.andreUtbetalinger.omsorgsperson,
                 barn,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         pågåendeSøknadFraAnnetEøsLand: søknadsfeltForESvar(

--- a/src/frontend/utils/mappingTilKontrakt/pensjonsperioder.ts
+++ b/src/frontend/utils/mappingTilKontrakt/pensjonsperioder.ts
@@ -5,7 +5,9 @@ import { ISøknadsfelt, TilRestLocaleRecord } from '../../typer/kontrakt/generel
 import { IPensjonsperiodeIKontraktFormat } from '../../typer/kontrakt/søknadKontrakt';
 import { IPensjonsperiode } from '../../typer/perioder';
 import { IPensjonsperiodeTekstinnhold } from '../../typer/sanity/modaler/pensjonsperiode';
+import { formaterDatostringKunMåned } from '../dato';
 import { landkodeTilSpråk } from '../språk';
+import { uppercaseFørsteBokstav } from '../visning';
 
 import { sammeVerdiAlleSpråk, verdiCallbackAlleSpråk } from './hjelpefunksjoner';
 
@@ -16,6 +18,7 @@ interface PensjonsperiodeIKontraktFormatParams {
     tilRestLocaleRecord: TilRestLocaleRecord;
     tekster: IPensjonsperiodeTekstinnhold;
     barn?: IBarnMedISøknad;
+    toggleSpørOmMånedIkkeDato: boolean;
 }
 
 export const tilIPensjonsperiodeIKontraktFormat = ({
@@ -25,6 +28,7 @@ export const tilIPensjonsperiodeIKontraktFormat = ({
     tilRestLocaleRecord,
     tekster,
     barn,
+    toggleSpørOmMånedIkkeDato,
 }: PensjonsperiodeIKontraktFormatParams): ISøknadsfelt<IPensjonsperiodeIKontraktFormat> => {
     const { mottarPensjonNå, pensjonsland, pensjonFra, pensjonTil } = periode;
 
@@ -62,13 +66,25 @@ export const tilIPensjonsperiodeIKontraktFormat = ({
             pensjonFra: pensjonFra.svar
                 ? {
                       label: tilRestLocaleRecord(tekster.startdato.sporsmal),
-                      verdi: sammeVerdiAlleSpråk(pensjonFra.svar),
+                      verdi: toggleSpørOmMånedIkkeDato
+                          ? verdiCallbackAlleSpråk(locale =>
+                                uppercaseFørsteBokstav(
+                                    formaterDatostringKunMåned(pensjonFra.svar, locale)
+                                )
+                            )
+                          : sammeVerdiAlleSpråk(pensjonFra.svar),
                   }
                 : null,
             pensjonTil: pensjonTil.svar
                 ? {
                       label: tilRestLocaleRecord(tekster.sluttdato.sporsmal),
-                      verdi: sammeVerdiAlleSpråk(pensjonTil.svar),
+                      verdi: toggleSpørOmMånedIkkeDato
+                          ? verdiCallbackAlleSpråk(locale =>
+                                uppercaseFørsteBokstav(
+                                    formaterDatostringKunMåned(pensjonTil.svar, locale)
+                                )
+                            )
+                          : sammeVerdiAlleSpråk(pensjonTil.svar),
                   }
                 : null,
         }),

--- a/src/frontend/utils/mappingTilKontrakt/søker.ts
+++ b/src/frontend/utils/mappingTilKontrakt/søker.ts
@@ -21,7 +21,8 @@ import { utenlandsperiodeTilISøknadsfelt } from './utenlandsperiode';
 export const søkerIKontraktFormat = (
     søknad: ISøknad,
     tekster: ITekstinnhold,
-    tilRestLocaleRecord: TilRestLocaleRecord
+    tilRestLocaleRecord: TilRestLocaleRecord,
+    toggleSpørOmMånedIkkeDato: boolean
 ): ISøknadKontraktSøker => {
     const { søker, barnInkludertISøknaden } = søknad;
     const {
@@ -146,6 +147,7 @@ export const søkerIKontraktFormat = (
                 gjelderUtlandet: true,
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.arbeidsperiode.søker,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         arbeidsperioderNorge: arbeidsperioderNorge.map((periode, index) =>
@@ -155,6 +157,7 @@ export const søkerIKontraktFormat = (
                 gjelderUtlandet: false,
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.arbeidsperiode.søker,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         pensjonsperioderUtland: pensjonsperioderUtland.map((periode, index) =>
@@ -164,6 +167,7 @@ export const søkerIKontraktFormat = (
                 gjelderUtlandet: true,
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.pensjonsperiode.søker,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         pensjonsperioderNorge: pensjonsperioderNorge.map((periode, index) =>
@@ -173,6 +177,7 @@ export const søkerIKontraktFormat = (
                 gjelderUtlandet: false,
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.pensjonsperiode.søker,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
         andreUtbetalingsperioder: andreUtbetalingsperioder.map((periode, index) =>
@@ -181,6 +186,7 @@ export const søkerIKontraktFormat = (
                 periodeNummer: index + 1,
                 tilRestLocaleRecord,
                 tekster: tekster.FELLES.modaler.andreUtbetalinger.søker,
+                toggleSpørOmMånedIkkeDato,
             })
         ),
     };

--- a/src/frontend/utils/mappingTilKontrakt/søknad.ts
+++ b/src/frontend/utils/mappingTilKontrakt/søknad.ts
@@ -34,7 +34,8 @@ export const dataISøknadKontraktFormat = (
     søknad: ISøknad,
     tekster: ITekstinnhold,
     tilRestLocaleRecord: TilRestLocaleRecord,
-    kontraktVersjon: number
+    kontraktVersjon: number,
+    toggleSpørOmMånedIkkeDato: boolean
 ): ISøknadKontrakt => {
     const { søker } = søknad;
     // Raskeste måte å få tak i alle spørsmål minus de andre feltene på søker
@@ -47,9 +48,20 @@ export const dataISøknadKontraktFormat = (
     return {
         kontraktVersjon: kontraktVersjon,
         antallEøsSteg: antallEøsSteg(søker, barnInkludertISøknaden),
-        søker: søkerIKontraktFormat(søknad, tekster, tilRestLocaleRecord),
+        søker: søkerIKontraktFormat(
+            søknad,
+            tekster,
+            tilRestLocaleRecord,
+            toggleSpørOmMånedIkkeDato
+        ),
         barn: barnInkludertISøknaden.map(barn =>
-            barnISøknadsFormat(barn, søknad, tekster, tilRestLocaleRecord)
+            barnISøknadsFormat(
+                barn,
+                søknad,
+                tekster,
+                tilRestLocaleRecord,
+                toggleSpørOmMånedIkkeDato
+            )
         ),
         lestOgForståttBekreftelse: søknad.lestOgForståttBekreftelse,
         erNoenAvBarnaFosterbarn: søknadsfeltForESvar(

--- a/src/frontend/utils/testing.tsx
+++ b/src/frontend/utils/testing.tsx
@@ -153,6 +153,7 @@ export function mockFeatureToggle() {
                 // toggles: { [EFeatureToggle.EXAMPLE]: false },
                 toggles: {
                     [EFeatureToggle.FORKLARENDE_TEKSTER_OVER_LEGG_TIL_KNAPP]: false,
+                    [EFeatureToggle.SPOR_OM_MANED_IKKE_DATO]: false,
                 },
             })
         );

--- a/src/frontend/utils/visning.ts
+++ b/src/frontend/utils/visning.ts
@@ -1,3 +1,7 @@
+import { AlternativtSvarForInput, LocaleType } from '../typer/common';
+
+import { formaterDato, formaterDatostringKunMåned } from './dato';
+
 export const formaterFnr = (fødselsnummer: string) => {
     return fødselsnummer.substring(0, 6) + ' ' + fødselsnummer.substring(6, 11);
 };
@@ -5,6 +9,21 @@ export const formaterFnr = (fødselsnummer: string) => {
 export const uppercaseKunFørsteBokstav = text => {
     if (typeof text !== 'string') return '';
     return text.charAt(0).toUpperCase() + text.toLowerCase().slice(1);
+};
+
+export const formaterMånedMedUkjent = (
+    svar: string,
+    vetIkkeTekst,
+    toggle: boolean,
+    valgtLocale: LocaleType
+) => {
+    if (svar === AlternativtSvarForInput.UKJENT) {
+        return vetIkkeTekst;
+    } else if (toggle) {
+        return uppercaseFørsteBokstav(formaterDatostringKunMåned(svar, valgtLocale));
+    } else {
+        return formaterDato(svar);
+    }
 };
 
 export const uppercaseFørsteBokstav = text => {


### PR DESCRIPTION
Favro: [NAV-18711](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18711)
Unleash toggle: [familie-ba-soknad.spor-om-maned-ikke-dato](https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie-ba-soknad.spor-om-maned-ikke-dato)
Aksel komponent som tas i bruk for valg av måned: [MonthPicker](https://aksel.nav.no/komponenter/core/monthpicker)
Denne oppgaven er basert på arbeid som har blitt gjort tidligere: https://github.com/navikt/familie-ba-soknad/pull/1172
Samme oppgave er gjort i BA-søknad: https://github.com/navikt/familie-ba-soknad/pull/1550

### ✅ Checklist
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Ikke nødvendig mens det ligger bak toggle. Skal kanskje legge til bedre tester i fremtiden.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
#### Velg dato/måned
##### Før
![image](https://github.com/user-attachments/assets/5e4ce94f-3997-4182-9371-7c4209019611)
##### Etter
![image](https://github.com/user-attachments/assets/c5cc9ef0-7f15-4b46-a504-c95b86cdd31b)

#### Dato/måned valgt
##### Før
![image](https://github.com/user-attachments/assets/df7a370c-9a94-4723-8b2f-42974815f2c7)
##### Etter
![image](https://github.com/user-attachments/assets/1a2a90e1-3ec8-4d0f-bd25-2da064fef9c3)

#### Oppsummering av valgt dato/måned
##### Før
![image](https://github.com/user-attachments/assets/cbd9cade-c5a6-4e59-bc48-5a3f771aaed7)
##### Etter
![image](https://github.com/user-attachments/assets/cf036e28-25da-4ab8-8fd4-ac6cabf4a2ea)