### PR TITLE
Reduser antall mellomlagringer ved hurtig sletting av vedlegg

### DIFF
--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
@@ -32,7 +32,14 @@ export const erVedleggstidspunktGyldig = (vedleggTidspunkt: string): boolean => 
 };
 
 const Dokumentasjon: React.FC = () => {
-    const { søknad, settSøknad, innsendingStatus, tekster, plainTekst } = useAppContext();
+    const {
+        søknad,
+        settSøknad,
+        innsendingStatus,
+        tekster,
+        plainTekst,
+        tvingKjøringAvDebouncedMellomlagre,
+    } = useAppContext();
     const { toggles } = useFeatureToggles();
     const { sendInnSkjema } = useSendInnSkjema();
     const [slettaVedlegg, settSlettaVedlegg] = useState<IVedlegg[]>([]);
@@ -111,6 +118,7 @@ const Dokumentasjon: React.FC = () => {
                 />
             }
             gåVidereCallback={async () => {
+                tvingKjøringAvDebouncedMellomlagre();
                 const [success, _] = await sendInnSkjema();
                 return success;
             }}

--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -12,6 +12,7 @@ import {
 } from '@navikt/familie-typer';
 
 import Miljø, { basePath } from '../../shared-utils/Miljø';
+import { useDebounce } from '../hooks/useDebounce';
 import { LocaleType } from '../typer/common';
 import { IKontoinformasjon } from '../typer/kontoinformasjon';
 import { FlettefeltVerdier, PlainTekst, TilRestLocaleRecord } from '../typer/kontrakt/generelle';
@@ -55,6 +56,7 @@ export interface AppContext {
     systemetOK: () => boolean;
     systemetLaster: () => boolean;
     mellomlagre: (søknadSomSkalLagres: ISøknad, nåværendeStegIndex: number) => void;
+    tvingKjøringAvDebouncedMellomlagre: () => void;
     modellVersjonOppdatert: boolean;
     settSisteModellVersjon: React.Dispatch<React.SetStateAction<number>>;
     eøsLand: Ressurs<Map<Alpha3Code, string>>;
@@ -172,9 +174,14 @@ export function AppProvider(props: PropsWithChildren) {
         settMellomlagretVerdi(kontantstøtte);
     };
 
+    const {
+        debouncedFunksjon: debouncedMellomlagre,
+        tvingKjøringAvDebouncedFunksjon: tvingKjøringAvDebouncedMellomlagre,
+    } = useDebounce(() => mellomlagre(søknad, sisteUtfylteStegIndex), 500);
+
     useEffect(() => {
         if (sisteUtfylteStegIndex > 0) {
-            mellomlagre(søknad, sisteUtfylteStegIndex);
+            debouncedMellomlagre();
         }
     }, [nåværendeRoute, søknad.dokumentasjon]);
 
@@ -389,6 +396,7 @@ export function AppProvider(props: PropsWithChildren) {
                 systemetOK,
                 systemetLaster,
                 mellomlagre,
+                tvingKjøringAvDebouncedMellomlagre,
                 modellVersjonOppdatert,
                 settSisteModellVersjon,
                 eøsLand,

--- a/src/frontend/hooks/useDebounce.ts
+++ b/src/frontend/hooks/useDebounce.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+export function useDebounce<T extends (...args: unknown[]) => void>(
+    funksjon: T,
+    forsinkelseMs: number
+) {
+    const timeoutId = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const sistBrukteArgumenter = useRef<Parameters<T> | null>(null);
+
+    const debouncedFunksjon = useCallback(
+        (...args: Parameters<T>) => {
+            if (timeoutId.current) {
+                clearTimeout(timeoutId.current);
+            }
+
+            sistBrukteArgumenter.current = args;
+
+            timeoutId.current = setTimeout(() => {
+                funksjon(...args);
+                timeoutId.current = null;
+                sistBrukteArgumenter.current = null;
+            }, forsinkelseMs);
+        },
+        [funksjon, forsinkelseMs]
+    );
+
+    const tvingKjøringAvDebouncedFunksjon = () => {
+        if (timeoutId.current && sistBrukteArgumenter.current) {
+            clearTimeout(timeoutId.current);
+            funksjon(...sistBrukteArgumenter.current);
+            timeoutId.current = null;
+            sistBrukteArgumenter.current = null;
+        }
+    };
+
+    useEffect(() => {
+        return () => {
+            if (timeoutId.current) {
+                clearTimeout(timeoutId.current);
+            }
+        };
+    }, []);
+
+    return { debouncedFunksjon, tvingKjøringAvDebouncedFunksjon };
+}


### PR DESCRIPTION
Favro: [NAV-24801](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24801)

### 💰 Hva forsøker du å løse i denne PR'en
- Legger til en debounce hook.
- Bruker debounce for å samle opp hurtig sletting av vedlegg for å redusere antall mellomlagringer.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
- Med en vanlig debounce kan det oppstå en situasjon der brukeren sletter et vedlegg og sender inn søknaden før `debounce`-forsinkelsen er ferdig. Dette fører til at søknaden mellomlagres etter at den egentlig er sendt inn og slettet. Sannsynligheten for dette er lav ettersom det er vanskelig å både slette et vedlegg og sende inn søknaden innenfor `debounce`-forsinkelsen på 500 ms.
- For å unngå dette legger jeg til `tvingKjøringAvDebounced`, som lar `debounced`-funksjoner kjøres umiddelbart i stedet for å vente på at forsinkelsen blir ferdig av seg selv. Denne funksjonen kalles rett før innsending av søknaden, slik at vi sikrer at eventuell mellomlagring skjer før og ikke etter innsending.

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig.

### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
- Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
- Ingen visuelle endringer.
