### PR TITLE
Bump workflow for å kun scanne kildekode

### DIFF
--- a/.github/workflows/scan-vulnerabilities.yaml
+++ b/.github/workflows/scan-vulnerabilities.yaml
@@ -19,5 +19,5 @@ jobs:
     permissions:
       contents: write # to write sarif
       security-events: write # push sarif to github security
-    uses: navikt/familie-baks-gha-workflows/.github/workflows/scan-vulnerabilities-yarn.yaml@95b1f0f855f8c73015db7b815d249ee11f035906 # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/scan-vulnerabilities-yarn.yaml@main
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/scan-vulnerabilities-yarn.yaml@82a1b51d070fc79d18271521118786f545269c25 # ratchet:navikt/familie-baks-gha-workflows/.github/workflows/scan-vulnerabilities-yarn.yaml@main
     secrets: inherit


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Bumper scan-vulnerabilities template med forbedringer på hva som scannes. Ble mye varsler på kompilert kode som ikke sa noe nyttig, skal heller scanne kildekode.

Ref: https://github.com/navikt/familie-baks-gha-workflows/pull/16