### PR TITLE
Fikser hardkodet og" tekst

### DIFF
--- a/src/frontend/components/Felleskomponenter/VedleggOppsummering/vedleggOppsummering.domene.ts
+++ b/src/frontend/components/Felleskomponenter/VedleggOppsummering/vedleggOppsummering.domene.ts
@@ -1,3 +1,5 @@
+import { PlainTekst } from '../../../typer/kontrakt/generelle';
+import { IFrittståendeOrdTekstinnhold } from '../../../typer/sanity/tekstInnhold';
 import { slåSammen } from '../../../utils/slåSammen';
 
 import { IVedleggOppsummering } from './vedleggOppsummering.types';
@@ -12,12 +14,21 @@ export const skalVedleggOppsummeringVises = (vedlegg: IVedleggOppsummering[]): b
     return vedlegg.filter(enkeltVedlegg => enkeltVedlegg.skalVises).length > 0;
 };
 
-export const hentVedleggOppsummering = (dokumentasjoner, søknad): IVedleggOppsummering[] =>
+export const hentVedleggOppsummering = (
+    dokumentasjoner,
+    søknad,
+    plainTekst: PlainTekst,
+    frittståendeOrdTekster: IFrittståendeOrdTekstinnhold
+): IVedleggOppsummering[] =>
     dokumentasjoner.map(dokumentasjon => {
         const barnDokGjelderFor = søknad.barnInkludertISøknaden.filter(barn =>
             dokumentasjon.gjelderForBarnId.find(id => id === barn.id)
         );
-        const barnasNavn = slåSammen(barnDokGjelderFor.map(barn => barn.navn));
+        const barnasNavn = slåSammen(
+            barnDokGjelderFor.map(barn => barn.navn),
+            plainTekst,
+            frittståendeOrdTekster
+        );
 
         return {
             skalVises: true,

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/Dokumentasjon.tsx
@@ -78,6 +78,9 @@ const Dokumentasjon: React.FC = () => {
         });
     });
 
+    const stegTekster = tekster()[ESanitySteg.DOKUMENTASJON];
+    const frittståendeOrdTekster = tekster()[ESanitySteg.FELLES].frittståendeOrd;
+
     const relevateDokumentasjoner = søknad.dokumentasjon.filter(dokumentasjon =>
         erDokumentasjonRelevant(dokumentasjon)
     );
@@ -94,7 +97,11 @@ const Dokumentasjon: React.FC = () => {
             const barnDokGjelderFor = søknad.barnInkludertISøknaden.filter(barn =>
                 dokumentasjon.gjelderForBarnId.find(id => id === barn.id)
             );
-            const barnasNavn = slåSammen(barnDokGjelderFor.map(barn => barn.navn));
+            const barnasNavn = slåSammen(
+                barnDokGjelderFor.map(barn => barn.navn),
+                plainTekst,
+                frittståendeOrdTekster
+            );
 
             return {
                 skalVises: true,
@@ -102,8 +109,6 @@ const Dokumentasjon: React.FC = () => {
                 flettefeltVerdier: { barnetsNavn: barnasNavn },
             };
         });
-
-    const stegTekster = tekster()[ESanitySteg.DOKUMENTASJON];
 
     return (
         <Steg

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg.tsx
@@ -28,7 +28,10 @@ interface Props {
 
 const LastOppVedlegg: React.FC<Props> = ({ dokumentasjon, oppdaterDokumentasjon }) => {
     const { søknad, tekster, plainTekst } = useAppContext();
+
     const dokumentasjonstekster = tekster().DOKUMENTASJON;
+    const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
+
     const settHarSendtInnTidligere = (event: React.ChangeEvent<HTMLInputElement>) => {
         const huketAv = event.target.checked;
         const vedlegg = huketAv ? [] : dokumentasjon.opplastedeVedlegg;
@@ -38,7 +41,11 @@ const LastOppVedlegg: React.FC<Props> = ({ dokumentasjon, oppdaterDokumentasjon 
     const barnDokGjelderFor = søknad.barnInkludertISøknaden.filter(barn =>
         dokumentasjon.gjelderForBarnId.find(id => id === barn.id)
     );
-    const barnasNavn = slåSammen(barnDokGjelderFor.map(barn => barn.navn));
+    const barnasNavn = slåSammen(
+        barnDokGjelderFor.map(barn => barn.navn),
+        plainTekst,
+        frittståendeOrdTekster
+    );
 
     const tittelBlock =
         dokumentasjonstekster[

--- a/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg2.tsx
+++ b/src/frontend/components/SøknadsSteg/Dokumentasjon/LastOppVedlegg2.tsx
@@ -30,6 +30,7 @@ const LastOppVedlegg2: React.FC<Props> = ({ dokumentasjon, oppdaterDokumentasjon
     const { søknad, tekster, plainTekst } = useAppContext();
 
     const dokumentasjonTekster = tekster().DOKUMENTASJON;
+    const frittståendeOrdTekster = tekster().FELLES.frittståendeOrd;
 
     const { fjernAlleAvvisteFiler } = useFilopplaster2(
         dokumentasjon,
@@ -55,7 +56,11 @@ const LastOppVedlegg2: React.FC<Props> = ({ dokumentasjon, oppdaterDokumentasjon
     const barnDokumentasjonenGjelderFor = søknad.barnInkludertISøknaden.filter(barn =>
         dokumentasjon.gjelderForBarnId.find(id => id === barn.id)
     );
-    const barnasNavn = slåSammen(barnDokumentasjonenGjelderFor.map(barn => barn.navn));
+    const barnasNavn = slåSammen(
+        barnDokumentasjonenGjelderFor.map(barn => barn.navn),
+        plainTekst,
+        frittståendeOrdTekster
+    );
 
     const dokumentasjonsbeskrivelse = dokumentasjonsbehovTilBeskrivelseSanityApiNavn(
         dokumentasjon.dokumentasjonsbehov

--- a/src/frontend/hooks/useSendInnSkjema.tsx
+++ b/src/frontend/hooks/useSendInnSkjema.tsx
@@ -24,6 +24,7 @@ export const useSendInnSkjema = (): {
         settSisteModellVersjon,
         tekster,
         tilRestLocaleRecord,
+        plainTekst,
     } = useAppContext();
     const { soknadApiProxyUrl } = Miljø();
     const { valgtLocale } = useSpråkContext();
@@ -40,7 +41,8 @@ export const useSendInnSkjema = (): {
                 tekster(),
                 tilRestLocaleRecord,
                 kontraktVersjon,
-                toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO] === true
+                toggles[EFeatureToggle.SPOR_OM_MANED_IKKE_DATO] === true,
+                plainTekst
             );
 
             const res = await sendInn<ISøknadKontrakt>(

--- a/src/frontend/typer/sanity/tekstInnhold.ts
+++ b/src/frontend/typer/sanity/tekstInnhold.ts
@@ -141,6 +141,7 @@ export interface IFrittståendeOrdTekstinnhold {
     barnehageplassperioder: LocaleRecordString;
     slipp: LocaleRecordString;
     eller: LocaleRecordString;
+    og: LocaleRecordString;
 }
 
 export interface INavigasjonTekstinnhold {

--- a/src/frontend/utils/mappingTilKontrakt/dokumentasjon.ts
+++ b/src/frontend/utils/mappingTilKontrakt/dokumentasjon.ts
@@ -8,9 +8,9 @@ import {
     ISøknadKontraktDokumentasjon,
     ISøknadKontraktVedlegg,
 } from '../../typer/kontrakt/dokumentasjon';
-import { FlettefeltVerdier, TilRestLocaleRecord } from '../../typer/kontrakt/generelle';
+import { FlettefeltVerdier, PlainTekst, TilRestLocaleRecord } from '../../typer/kontrakt/generelle';
 import { ESanitySteg } from '../../typer/sanity/sanity';
-import { ITekstinnhold } from '../../typer/sanity/tekstInnhold';
+import { IFrittståendeOrdTekstinnhold, ITekstinnhold } from '../../typer/sanity/tekstInnhold';
 import { ISøknad } from '../../typer/søknad';
 import { slåSammen } from '../slåSammen';
 
@@ -18,7 +18,8 @@ export const dokumentasjonISøknadFormat = (
     dokumentasjon: IDokumentasjon,
     tekster: ITekstinnhold,
     tilRestLocaleRecord: TilRestLocaleRecord,
-    søknad: ISøknad
+    søknad: ISøknad,
+    plainTekst: PlainTekst
 ): ISøknadKontraktDokumentasjon => {
     const dokumentsjonstekster = tekster[ESanitySteg.DOKUMENTASJON];
 
@@ -32,14 +33,21 @@ export const dokumentasjonISøknadFormat = (
             dokumentsjonstekster[
                 dokumentasjonsbehovTilTittelSanityApiNavn(dokumentasjon.dokumentasjonsbehov)
             ],
-            flettefelterForDokumentasjonTittel(dokumentasjon, søknad)
+            flettefelterForDokumentasjonTittel(
+                dokumentasjon,
+                søknad,
+                plainTekst,
+                tekster.FELLES.frittståendeOrd
+            )
         ),
     };
 };
 
 const flettefelterForDokumentasjonTittel = (
     dokumentasjon: IDokumentasjon,
-    søknad: ISøknad
+    søknad: ISøknad,
+    plainTekst: PlainTekst,
+    frittståendeOrdTekster: IFrittståendeOrdTekstinnhold
 ): FlettefeltVerdier => {
     switch (dokumentasjon.dokumentasjonsbehov) {
         case Dokumentasjonsbehov.BOR_FAST_MED_SØKER:
@@ -47,7 +55,11 @@ const flettefelterForDokumentasjonTittel = (
                 .filter(barn => dokumentasjon.gjelderForBarnId.find(id => barn.id === id))
                 .map(barn => barn.navn);
             return {
-                barnetsNavn: slåSammen(barnDokumentasjonsbehovGjelderFor),
+                barnetsNavn: slåSammen(
+                    barnDokumentasjonsbehovGjelderFor,
+                    plainTekst,
+                    frittståendeOrdTekster
+                ),
             };
         default:
             return {};

--- a/src/frontend/utils/mappingTilKontrakt/søknad.ts
+++ b/src/frontend/utils/mappingTilKontrakt/søknad.ts
@@ -3,7 +3,7 @@ import { ESvar } from '@navikt/familie-form-elements';
 import { OmBarnaDineSpørsmålId } from '../../components/SøknadsSteg/OmBarnaDine/spørsmål';
 import { IBarnMedISøknad } from '../../typer/barn';
 import { LocaleRecordBlock, LocaleRecordString, LocaleType } from '../../typer/common';
-import { ESivilstand, TilRestLocaleRecord } from '../../typer/kontrakt/generelle';
+import { ESivilstand, PlainTekst, TilRestLocaleRecord } from '../../typer/kontrakt/generelle';
 import { ISøknadKontrakt } from '../../typer/kontrakt/søknadKontrakt';
 import { ISøker } from '../../typer/person';
 import { ESanitySivilstandApiKey } from '../../typer/sanity/sanity';
@@ -35,7 +35,8 @@ export const dataISøknadKontraktFormat = (
     tekster: ITekstinnhold,
     tilRestLocaleRecord: TilRestLocaleRecord,
     kontraktVersjon: number,
-    toggleSpørOmMånedIkkeDato: boolean
+    toggleSpørOmMånedIkkeDato: boolean,
+    plainTekst: PlainTekst
 ): ISøknadKontrakt => {
     const { søker } = søknad;
     // Raskeste måte å få tak i alle spørsmål minus de andre feltene på søker
@@ -101,7 +102,9 @@ export const dataISøknadKontraktFormat = (
         ),
         dokumentasjon: søknad.dokumentasjon
             .filter(dok => erDokumentasjonRelevant(dok))
-            .map(dok => dokumentasjonISøknadFormat(dok, tekster, tilRestLocaleRecord, søknad)),
+            .map(dok =>
+                dokumentasjonISøknadFormat(dok, tekster, tilRestLocaleRecord, søknad, plainTekst)
+            ),
         teksterTilPdf: {
             ...Object.values(ESivilstand).reduce(
                 (map, sivilstand) => ({

--- a/src/frontend/utils/slåSammen.test.ts
+++ b/src/frontend/utils/slåSammen.test.ts
@@ -1,21 +1,36 @@
+import { IFrittståendeOrdTekstinnhold } from '../typer/sanity/tekstInnhold';
+
 import { slåSammen } from './slåSammen';
 
 describe('slåSammen', () => {
+    const PlainTekstMock = () => 'og';
+    const frittståendeOrdTekstinnholdMock = {} as IFrittståendeOrdTekstinnhold;
+
     test('Returnerer tom streng ved tom liste ', () => {
-        expect(slåSammen([])).toEqual('');
+        expect(slåSammen([], PlainTekstMock, frittståendeOrdTekstinnholdMock)).toEqual('');
     });
 
     test('Returnerer første element om det kun er ett element i listen', () => {
-        expect(slåSammen(['test'])).toEqual('test');
+        expect(slåSammen(['test'], PlainTekstMock, frittståendeOrdTekstinnholdMock)).toEqual(
+            'test'
+        );
     });
 
     test('Returnerer "element1 og element2" ved to elementer ', () => {
-        const sammenslåttTekst1 = slåSammen(['test1', 'test2']);
+        const sammenslåttTekst1 = slåSammen(
+            ['test1', 'test2'],
+            PlainTekstMock,
+            frittståendeOrdTekstinnholdMock
+        );
         expect(sammenslåttTekst1).toEqual('test1 og test2');
     });
 
     test('Returnerer kommaseparert streng med "og" på slutten ved flere elementer', () => {
-        const sammenslåttTekst2 = slåSammen(['test1', 'test2', 'test3', 'test4', 'test5', 'test6']);
+        const sammenslåttTekst2 = slåSammen(
+            ['test1', 'test2', 'test3', 'test4', 'test5', 'test6'],
+            PlainTekstMock,
+            frittståendeOrdTekstinnholdMock
+        );
         expect(sammenslåttTekst2).toEqual('test1, test2, test3, test4, test5 og test6');
     });
 });

--- a/src/frontend/utils/slåSammen.ts
+++ b/src/frontend/utils/slåSammen.ts
@@ -1,4 +1,11 @@
-export const slåSammen = (tekstListe: string[]) => {
+import { PlainTekst } from '../typer/kontrakt/generelle';
+import { IFrittståendeOrdTekstinnhold } from '../typer/sanity/tekstInnhold';
+
+export const slåSammen = (
+    tekstListe: string[],
+    plainTekst: PlainTekst,
+    frittståendeOrdTekster: IFrittståendeOrdTekstinnhold
+) => {
     if (tekstListe.length === 0) {
         return '';
     }
@@ -7,5 +14,7 @@ export const slåSammen = (tekstListe: string[]) => {
         return tekstListe[0];
     }
 
-    return tekstListe.join(', ').replace(/,(?=[^,]+$)/, ' og');
+    return tekstListe
+        .join(', ')
+        .replace(/,(?=[^,]+$)/, ` ${plainTekst(frittståendeOrdTekster.og)}`);
 };


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24814
Samme oppgave er også gjort i BA: https://github.com/navikt/familie-ba-soknad/pull/1632

### 💰 Hva forsøker du å løse i denne PR'en
- Fikser hardkodet "og" tekst i slåSammen funksjonen ved å bytte til Sanity tekst

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
- Ikke nødvendig.

### 🤷‍♀ ️Hvor er det lurt å starte?
- Alt i ett.

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Nå viser dette "and" istedenfor "og" på engelsk
![image](https://github.com/user-attachments/assets/1a3d60e9-dedf-4ae1-8747-75a5ed87d74c)
