### PR TITLE
Legger på håndtering av kansellerte requests og clearing av timeouts

### DIFF
--- a/src/frontend/hooks/useUnmountCleanup.ts
+++ b/src/frontend/hooks/useUnmountCleanup.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+
+export function useUnmountCleanup() {
+    const timerRefs = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+    const abortRequestRefs = useRef<Set<AbortController>>(new Set());
+
+    function registerTimeoutUnmountHandler(timeout: ReturnType<typeof setTimeout>) {
+        timerRefs.current.add(timeout);
+    }
+
+    function registerRequestUnmountHandler(controller: AbortController) {
+        abortRequestRefs.current.add(controller);
+    }
+
+    function removeRequestUnmountHandler(controller: AbortController) {
+        abortRequestRefs.current.delete(controller);
+    }
+
+    useEffect(() => {
+        // Når komponenten unmountes bør vi cleare alle timeouts og requests
+        return () => {
+            for (const id of timerRefs.current) {
+                clearTimeout(id);
+            }
+
+            for (const controller of abortRequestRefs.current) {
+                controller.abort();
+            }
+        };
+    }, []);
+
+    return {
+        registerTimeoutUnmountHandler,
+        registerRequestUnmountHandler,
+        removeRequestUnmountHandler,
+    };
+}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Jeg ser at vitest-testene feiler på github randomly, noe jeg trodde vi hadde unngått her. Gjør samme endring som vi gjorde i ba-soknad, som clearer timeouts og håndterer kansellerte requests når vi unmounter React-applikasjonen.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingen bekymringer. Jeg skal teste dette i dev før jeg merger. :)

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer