### PR TITLE
Rydd opp i ubrukte sanity prosjekter, rename KS datasets

### DIFF
--- a/src/frontend/typer/sanity/sanity.ts
+++ b/src/frontend/typer/sanity/sanity.ts
@@ -35,7 +35,7 @@ export enum ESanitySteg {
     FELLES = 'FELLES',
 }
 
-export type SanityDataSet = 'production' | 'production-v2' | 'test';
+export type SanityDataSet = 'ks-production' |'ks-test';
 
 export const frittståendeOrdPrefix = 'FRITTSTAENDEORD';
 export const modalPrefix = 'MODAL';

--- a/src/shared-utils/Miljø.ts
+++ b/src/shared-utils/Miljø.ts
@@ -42,7 +42,7 @@ export const erLokalt = () => !erProd() && !erDev();
 const Miljø = (): MiljøProps => {
     if (erDev()) {
         return {
-            sanityDataset: 'production',
+            sanityDataset: 'ks-production',
             soknadApiProxyUrl: `https://familie-ks-soknad.${erAnsattUrl() ? 'ansatt' : 'ekstern'}.dev.nav.no${basePath}api`,
             soknadApiUrl: `http://familie-baks-soknad-api/api`,
             dokumentProxyUrl: `https://familie-ks-soknad.${erAnsattUrl() ? 'ansatt' : 'ekstern'}.dev.nav.no${basePath}dokument`,
@@ -54,7 +54,7 @@ const Miljø = (): MiljøProps => {
         };
     } else if (erProd()) {
         return {
-            sanityDataset: 'production',
+            sanityDataset: 'ks-production',
             soknadApiProxyUrl: `https://www.nav.no${basePath}api`,
             soknadApiUrl: `http://familie-baks-soknad-api/api`,
             dokumentProxyUrl: `https://www.nav.no${basePath}dokument`,
@@ -66,7 +66,7 @@ const Miljø = (): MiljøProps => {
         };
     } else {
         return {
-            sanityDataset: 'production',
+            sanityDataset: 'ks-production',
             soknadApiProxyUrl: `http://localhost:3000${basePath}api`,
             soknadApiUrl: 'http://localhost:8080/api',
             dokumentProxyUrl: `http://localhost:3000${basePath}dokument`,


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-25734

Dataset `production` som blir brukt av kontantstøtte renames til `ks-production`
Dataset `test` som blir brukt av kontantstøtte renames til `ks-test`
Dataset `production-v2` som blir brukt av ingen ting slettes.

Litt merkelig at ks-test ikke blir brukt i dev, men vi bruker kanskje ikke tests settene så mye?
Kan vurdere å slette de i framtiden i såfall.

