### PR TITLE
Hvis eslint eller prettier feiler ble det aldri catchet i PRen sine github actions

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    name: Kjør typecheck og tester
+    name: Kjør validate og tester
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
@@ -25,10 +25,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
         run: yarn --prefer-offline --frozen-lockfile
-      - name: Kjør typecheck
+      - name: Kjør validate
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
-        run: yarn typecheck
+        run: yarn validate
       - name: Kjør tester
         env:
           CI: true


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Før kjørte vi kun typescript sin typecheck og våre egne tester når vi validerte at en PR var good. Dette kunne føre til at endringer fra dependabot som hadde eslint-feil ikke ble catchet før de ble merget til main og prøvd bygget der. Endrer det til å kjøre validate, som kjører typecheck, eslint og prettier. Nå skal vi kunne catche slike feil på PR-stadiet.

Dette caset vil kun gjelde når vi approver PRer fra dependabot. På våre egne commits har vi en pre-commit hook som typechecker og sjekker eslint og prettier allerede.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Ingenting å fremheve ☺️ 

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene/skissene 🕵️
- [x] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇
- [ ] Jeg har fikset en bug, og skrevet regresjonstest for denne
- [ ] **Jeg har endret søknadskontrakten og modellversjon i Miljø.ts**

_Jeg har ikke skrevet tester fordi:_
Ikke relevant

### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei
  
### 👀 Screen shots
Ingen visuelle endringer