### PR TITLE
Egen loader for iso-countries som forsvinner ved tree-shaking

### DIFF
--- a/src/webpack/rawJsonLoader.cts
+++ b/src/webpack/rawJsonLoader.cts
@@ -1,0 +1,5 @@
+function rawJsonLoader(source: string): string {
+    return `module.exports = ${source};`;
+}
+
+module.exports = rawJsonLoader;

--- a/src/webpack/webpack.common.config.ts
+++ b/src/webpack/webpack.common.config.ts
@@ -64,6 +64,15 @@ const commonConfig: webpack.Configuration = {
     module: {
         rules: [
             {
+                // Webpack 5 tree-shaker kutter JSON-arrays til [] når ingen indekser
+                // aksesseres direkte (f.eks. ved bruk av .forEach()). Dette omgår det
+                // for i18n-iso-countries/codes.json ved å bruke javascript/auto-type.
+                test: /codes\.json$/,
+                include: /node_modules[\\/]i18n-iso-countries/,
+                type: 'javascript/auto',
+                use: [path.resolve(process.cwd(), 'src/webpack/rawJsonLoader.cts')],
+            },
+            {
                 test: /\.m?js$/,
                 resolve: {
                     fullySpecified: false, // Fikser at man ikke kan gjøre import uten filextension fra moduler med type: module i package.json


### PR DESCRIPTION
### 📮 Favro: NAV-29626

### 💰 Hva skal gjøres, og hvorfor?
PR: https://github.com/navikt/familie-ks-soknad/pull/1393 innførte feil hvor det ikke var noen land å velge i landvelgeren. Dette skjedde fordi Webpack har blitt strengere med "tree-shaking", altså at den stripper vekk død kode før den bundler. På grunn av måten `i18n-iso-countries` eksporterer landkoder (for-each), så anser webpack dette som død kode og stripper det vekk.

Fiksen blir å manuelt overstyre dette og konvertere JSON-filen som inneholder landkoder til en javascript-modul. Da håndteres dette bedre.

Ikke en fryktelig elegant løsning, men siden Webpack skal erstattes av Vite så unngår jeg å gjøre større tiltak. 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [X] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har testet endringene mine i mobilstørrelse, zoom 200%, skalerer riktig med endret tekststørrelse i browser 📱
- [ ] Jeg har endret søknadskontrakten og modellversjon i miljø.ts
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Kompilert kode.